### PR TITLE
프로젝트 설정: GitHub Project 보드, 이슈, 개발 문서 구성

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md - dkit Development Guide
+
+## Project Overview
+
+dkit (Data Kit) — 모든 데이터 포맷을 하나의 CLI로 변환하고 쿼리하는 스위스 아미 나이프.
+JSON, CSV, YAML, TOML 간 양방향 변환 + 통합 쿼리 + 테이블 출력.
+
+- Language: Rust
+- License: MIT
+
+## Development Workflow
+
+### Task Management
+
+모든 기획, 계획, 진행, 상태 관리는 **GitHub Issues와 Project 보드**에서 관리한다.
+저장소 내부 문서로 태스크를 관리하지 않는다.
+
+- **Project Board**: https://github.com/users/syangkkim/projects/2
+- **Issues**: https://github.com/syangkkim/dkit/issues
+
+### How to Work on Issues
+
+개발자가 "N번 이슈를 개발해줘"라고 요청하면:
+
+1. `gh issue view N`으로 이슈 내용 확인
+2. 이슈의 "의존 이슈"가 있으면 해당 이슈들이 완료되었는지 확인
+3. `docs/` 폴더의 관련 문서를 참조하여 구현 세부사항 파악
+4. 구현 완료 후 PR을 생성하고 이슈를 참조
+
+### Reference Documents (docs/)
+
+버전 관리가 필요한 기술 문서만 `docs/`에서 관리한다:
+
+- `docs/architecture.md` — 프로젝트 구조, 모듈 구조, 의존성
+- `docs/technical-spec.md` — Value 타입, 트레이트, 에러 타입, 쿼리 엔진 설계
+- `docs/cli-spec.md` — 서브커맨드별 CLI 인터페이스 명세 (옵션, 사용법)
+- `docs/query-syntax.md` — 쿼리 문법 명세 (EBNF, 연산자, 예제)
+
+### Labels
+
+- `v0.1.0` ~ `v0.4.0`: 버전 마일스톤
+- `core`: 핵심 기능 (Value, 트레이트, 에러)
+- `format`: 데이터 포맷 관련 (JSON, CSV, YAML, TOML)
+- `cli`: CLI 인터페이스 및 서브커맨드
+- `query`: 쿼리 엔진
+- `testing`: 테스트 관련
+- `infra`: 인프라 및 CI/CD
+- `release`: 릴리스 관련
+
+## Build & Test Commands
+
+```bash
+cargo build                    # 빌드
+cargo test                     # 전체 테스트
+cargo clippy -- -D warnings    # 린트
+cargo fmt -- --check           # 포맷 검사
+cargo run -- <subcommand>      # 실행
+```
+
+## Code Style
+
+- `cargo fmt`으로 포맷팅
+- `cargo clippy`으로 린트
+- 에러 처리: `thiserror` (라이브러리 에러) + `anyhow` (애플리케이션 에러)
+- 테스트: 각 모듈에 `#[cfg(test)]` 단위 테스트 + `tests/` 통합 테스트

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,115 @@
+# dkit Architecture
+
+## Overview
+
+dkit은 모든 데이터 포맷을 하나의 CLI로 변환하고 쿼리하는 도구이다.
+
+```
+입력 파일 → Reader(포맷별) → Value → Writer(포맷별) → 출력
+                                ↑
+                          Query 엔진이 여기서 처리
+```
+
+## Internal Data Model
+
+모든 포맷은 내부적으로 통합 `Value` 타입으로 변환된 뒤 처리된다.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Value {
+    Null,
+    Bool(bool),
+    Integer(i64),
+    Float(f64),
+    String(String),
+    Array(Vec<Value>),
+    Object(IndexMap<String, Value>),  // 키 순서 보존
+}
+```
+
+## Module Structure
+
+```
+src/
+├── main.rs                 # CLI 엔트리포인트
+├── cli.rs                  # clap 서브커맨드 정의
+├── value.rs                # 통합 Value 타입
+├── error.rs                # 에러 타입 정의
+│
+├── format/                 # 포맷별 Reader/Writer
+│   ├── mod.rs              # FormatReader/Writer 트레이트
+│   ├── json.rs
+│   ├── csv.rs
+│   ├── yaml.rs
+│   └── toml.rs
+│
+├── query/                  # 쿼리 엔진
+│   ├── mod.rs
+│   ├── parser.rs           # 쿼리 문법 파서
+│   ├── evaluator.rs        # 쿼리 실행기
+│   └── filter.rs           # where/sort/limit 처리
+│
+├── commands/               # 서브커맨드 구현
+│   ├── mod.rs
+│   ├── convert.rs
+│   ├── query.rs
+│   ├── view.rs
+│   ├── stats.rs
+│   └── schema.rs
+│
+└── output/                 # 출력 포맷터
+    ├── mod.rs
+    ├── table.rs            # 테이블 출력
+    └── pretty.rs           # 색상 하이라이팅
+```
+
+## Core Traits
+
+```rust
+pub trait FormatReader {
+    fn read(&self, input: &str) -> Result<Value>;
+    fn read_from_reader(&self, reader: impl Read) -> Result<Value>;
+}
+
+pub trait FormatWriter {
+    fn write(&self, value: &Value) -> Result<String>;
+    fn write_to_writer(&self, value: &Value, writer: impl Write) -> Result<()>;
+}
+```
+
+## Format Detection
+
+```rust
+pub fn detect_format(path: &Path) -> Result<Format> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("json") => Ok(Format::Json),
+        Some("csv" | "tsv") => Ok(Format::Csv),
+        Some("yaml" | "yml") => Ok(Format::Yaml),
+        Some("toml") => Ok(Format::Toml),
+        _ => Err(Error::UnknownFormat),
+    }
+}
+```
+
+## Dependencies
+
+| 용도 | 크레이트 | 버전 | 이유 |
+|------|---------|------|------|
+| CLI 파싱 | clap (derive) | 4.x | Rust CLI 표준, 서브커맨드 지원 |
+| JSON | serde_json | 1.x | serde 생태계 표준 |
+| YAML | serde_yaml | 0.9.x | serde 통합 |
+| CSV | csv | 1.x | BurntSushi 제작, 최고 성능 |
+| TOML | toml | 0.8.x | serde 통합 |
+| 순서 보존 Map | indexmap | 2.x | JSON/YAML 키 순서 유지 |
+| 테이블 출력 | comfy-table | 7.x | 예쁜 터미널 테이블 |
+| 색상 출력 | colored | 2.x | 터미널 하이라이팅 |
+| 에러 처리 | thiserror + anyhow | 1.x / 1.x | 라이브러리 + 애플리케이션 에러 |
+
+## Conversion Matrix (v0.1)
+
+| FROM \ TO | JSON | CSV | YAML | TOML |
+|-----------|------|-----|------|------|
+| JSON | - | O | O | O |
+| CSV | O | - | O | O |
+| YAML | O | O | - | O |
+| TOML | O | O | O | - |

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -1,0 +1,234 @@
+# dkit CLI Specification
+
+## Command Structure
+
+```
+dkit <command> [options] [arguments]
+
+Commands:
+  convert   포맷 간 변환
+  query     데이터 쿼리/필터
+  view      데이터 미리보기 (테이블 출력)
+  stats     기본 통계
+  merge     여러 파일 합치기
+  schema    데이터 구조(스키마) 출력
+```
+
+## convert
+
+포맷 간 데이터 변환.
+
+### Usage
+
+```bash
+dkit convert <INPUT> --to <FORMAT> [OPTIONS]
+dkit convert --from <FORMAT> --to <FORMAT>  # stdin 사용 시
+```
+
+### Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--to <FORMAT>` | | 출력 포맷 (json, csv, yaml, toml) | 필수 |
+| `--from <FORMAT>` | | 입력 포맷 (stdin 사용 시 필수) | 확장자 자동 감지 |
+| `--output <FILE>` | `-o` | 출력 파일 경로 | stdout |
+| `--outdir <DIR>` | | 여러 파일 변환 시 출력 디렉토리 | |
+| `--delimiter <CHAR>` | | CSV 구분자 | `,` |
+| `--pretty` | | 포맷팅된 출력 | 기본 활성 |
+| `--compact` | | 한 줄 출력 (JSON) | |
+| `--no-header` | | CSV 헤더 없음 | |
+| `--flow` | | YAML 인라인 스타일 | |
+
+### Examples
+
+```bash
+# 기본 변환
+dkit convert data.json --to yaml
+dkit convert users.csv --to json
+dkit convert config.yaml --to toml
+
+# 출력 파일 지정
+dkit convert data.json --to csv -o output.csv
+
+# 여러 파일
+dkit convert *.csv --to json --outdir ./converted/
+
+# stdin/stdout 파이프
+cat data.json | dkit convert --from json --to csv
+curl https://api.example.com/data | dkit convert --from json --to yaml
+
+# 옵션
+dkit convert data.tsv --to json --delimiter '\t'
+dkit convert data.csv --to json --compact
+dkit convert data.csv --to json --pretty
+```
+
+## query
+
+데이터 쿼리/필터링.
+
+### Usage
+
+```bash
+dkit query <INPUT> '<QUERY>' [OPTIONS]
+```
+
+### Query Syntax
+
+```
+# 필드 접근
+.field
+.field.subfield
+
+# 배열 접근
+.array[0]
+.array[-1]
+.array[]          # 모든 요소 이터레이션
+
+# 필터링
+.items[] | where <condition>
+.items[] | where field > value
+.items[] | where field == "string"
+.items[] | where field contains "substr"
+
+# 선택
+.items[] | select field1, field2
+
+# 정렬/제한
+.items[] | sort field [desc]
+.items[] | limit N
+
+# 조합
+.items[] | where age > 25 and city == "Seoul" | select name, email | sort name | limit 10
+```
+
+### Operators
+
+| Type | Operators |
+|------|-----------|
+| 비교 | `==`, `!=`, `>`, `<`, `>=`, `<=` |
+| 문자열 | `contains`, `starts_with`, `ends_with` |
+| 논리 | `and`, `or` |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--to <FORMAT>` | 결과를 다른 포맷으로 출력 |
+| `-o <FILE>` | 출력 파일 |
+
+### Examples
+
+```bash
+dkit query config.yaml '.database.host'
+dkit query data.json '.users[0].name'
+dkit query data.json '.users[] | where age > 30'
+dkit query data.json '.users[] | where age > 30 | select name, email'
+dkit query users.csv '.rows[] | where age > 30' --to json -o filtered.json
+```
+
+## view
+
+데이터를 테이블 형태로 미리보기.
+
+### Usage
+
+```bash
+dkit view <INPUT> [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--path <QUERY>` | 중첩 데이터 경로 | root |
+| `--limit <N>` | 표시할 행 수 | 전체 |
+| `--columns <COLS>` | 표시할 컬럼 (쉼표 구분) | 전체 |
+
+### Examples
+
+```bash
+dkit view users.csv
+dkit view data.json --path '.users'
+dkit view large_data.csv --limit 20
+dkit view users.csv --columns name,email
+```
+
+## stats
+
+데이터 기본 통계.
+
+### Usage
+
+```bash
+dkit stats <INPUT> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--path <QUERY>` | 중첩 데이터 경로 |
+| `--column <NAME>` | 특정 컬럼 통계 |
+
+### Output
+
+전체 통계:
+```
+rows: 1,234
+columns: 5 (date, product, region, quantity, revenue)
+```
+
+컬럼 통계:
+```
+type: numeric
+count: 1,234
+sum: 45,678,900
+avg: 37,017.34
+min: 1,200
+max: 892,000
+median: 28,500
+```
+
+## schema
+
+데이터 구조(스키마)를 트리 형태로 출력.
+
+### Usage
+
+```bash
+dkit schema <INPUT>
+```
+
+### Output
+
+```
+root: object
+├─ database: object
+│  ├─ host: string
+│  ├─ port: integer
+│  └─ name: string
+├─ server: object
+│  ├─ port: integer
+│  └─ debug: boolean
+└─ users: array[object]
+   ├─ name: string
+   └─ email: string
+```
+
+## merge
+
+여러 파일을 하나로 합치기.
+
+### Usage
+
+```bash
+dkit merge <INPUT...> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--to <FORMAT>` | 출력 포맷 |
+| `-o <FILE>` | 출력 파일 |

--- a/docs/query-syntax.md
+++ b/docs/query-syntax.md
@@ -1,0 +1,135 @@
+# dkit Query Syntax
+
+dkit의 쿼리 문법은 jq에서 영감을 받았지만, 더 직관적이고 배우기 쉽게 설계되었다.
+
+## Path Access
+
+데이터의 특정 위치에 접근한다.
+
+```bash
+# 필드 접근
+dkit query data.json '.name'
+dkit query data.json '.database.host'
+
+# 배열 인덱스
+dkit query data.json '.users[0]'
+dkit query data.json '.users[-1]'        # 마지막 요소
+dkit query data.json '.users[0].name'    # 배열 요소의 필드
+
+# 배열 이터레이션 (모든 요소)
+dkit query data.json '.users[]'
+dkit query data.json '.users[].name'     # 모든 요소의 name 필드
+```
+
+## Pipeline
+
+`|` 로 여러 연산을 체이닝한다. 앞 연산의 결과가 다음 연산의 입력이 된다.
+
+```bash
+dkit query data.json '.users[] | where age > 30 | select name, email | sort name'
+```
+
+## where — Filtering
+
+조건에 맞는 요소만 필터링한다.
+
+### Comparison Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `==` | 같음 | `where name == "Alice"` |
+| `!=` | 다름 | `where status != "inactive"` |
+| `>` | 초과 | `where age > 30` |
+| `<` | 미만 | `where age < 25` |
+| `>=` | 이상 | `where score >= 80` |
+| `<=` | 이하 | `where price <= 1000` |
+
+### String Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `contains` | 포함 | `where email contains "@gmail"` |
+| `starts_with` | ~로 시작 | `where name starts_with "A"` |
+| `ends_with` | ~로 끝남 | `where file ends_with ".json"` |
+
+### Logical Operators
+
+```bash
+# AND
+dkit query data.json '.users[] | where age > 25 and city == "Seoul"'
+
+# OR
+dkit query data.json '.users[] | where role == "admin" or role == "manager"'
+```
+
+## select — Column Selection
+
+특정 필드만 추출한다.
+
+```bash
+dkit query data.json '.users[] | select name, email'
+dkit query data.json '.users[] | select name, age, email'
+```
+
+## sort — Sorting
+
+결과를 정렬한다.
+
+```bash
+# 오름차순 (기본)
+dkit query data.json '.users[] | sort age'
+
+# 내림차순
+dkit query data.json '.users[] | sort age desc'
+```
+
+## limit — Result Limiting
+
+결과 개수를 제한한다.
+
+```bash
+dkit query data.json '.users[] | limit 10'
+dkit query data.json '.users[] | sort age desc | limit 5'
+```
+
+## Combined Examples
+
+```bash
+# 30세 이상 사용자의 이름과 이메일을 이름순으로 정렬
+dkit query users.json '.users[] | where age > 30 | select name, email | sort name'
+
+# 서울 거주자 중 상위 5명
+dkit query users.json '.users[] | where city == "Seoul" | sort score desc | limit 5'
+
+# CSV에서도 동일 문법 (CSV의 경우 .rows[] 사용)
+dkit query sales.csv '.rows[] | where region == "KR" | select product, revenue | sort revenue desc'
+
+# 쿼리 결과를 다른 포맷으로 저장
+dkit query sales.csv '.rows[] | where region == "KR"' --to json -o korea.json
+```
+
+## Grammar (EBNF)
+
+```
+query       = path ( "|" operation )*
+path        = "." segment*
+segment     = field_access | index_access | iterate
+field_access = IDENTIFIER ( "." IDENTIFIER )*
+index_access = "[" INTEGER "]"
+iterate     = "[" "]"
+
+operation   = where_op | select_op | sort_op | limit_op
+where_op    = "where" condition
+select_op   = "select" IDENTIFIER ( "," IDENTIFIER )*
+sort_op     = "sort" IDENTIFIER [ "desc" ]
+limit_op    = "limit" INTEGER
+
+condition   = comparison ( logic_op comparison )*
+comparison  = IDENTIFIER compare_op value
+            | IDENTIFIER string_op STRING
+compare_op  = "==" | "!=" | ">" | "<" | ">=" | "<="
+string_op   = "contains" | "starts_with" | "ends_with"
+logic_op    = "and" | "or"
+
+value       = STRING | NUMBER | "true" | "false" | "null"
+```

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -1,0 +1,194 @@
+# dkit Technical Specification
+
+## Value Type
+
+모든 데이터 포맷의 통합 내부 표현.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Value {
+    Null,
+    Bool(bool),
+    Integer(i64),
+    Float(f64),
+    String(String),
+    Array(Vec<Value>),
+    Object(IndexMap<String, Value>),
+}
+```
+
+### Accessor Methods
+
+```rust
+impl Value {
+    pub fn as_bool(&self) -> Option<bool>;
+    pub fn as_i64(&self) -> Option<i64>;
+    pub fn as_f64(&self) -> Option<f64>;
+    pub fn as_str(&self) -> Option<&str>;
+    pub fn as_array(&self) -> Option<&Vec<Value>>;
+    pub fn as_object(&self) -> Option<&IndexMap<String, Value>>;
+    pub fn is_null(&self) -> bool;
+}
+```
+
+### Key Design Decisions
+
+- `IndexMap` 사용: JSON/YAML 키 순서 보존을 위해 `HashMap` 대신 `IndexMap` 사용
+- `Integer` vs `Float` 분리: TOML은 정수/실수를 구분하므로 별도 variant 필요
+- `Null` variant: JSON의 null, YAML의 ~, 빈 값 표현
+
+## FormatReader / FormatWriter Traits
+
+```rust
+pub trait FormatReader {
+    fn read(&self, input: &str) -> Result<Value>;
+    fn read_from_reader(&self, reader: impl Read) -> Result<Value>;
+}
+
+pub trait FormatWriter {
+    fn write(&self, value: &Value) -> Result<String>;
+    fn write_to_writer(&self, value: &Value, writer: impl Write) -> Result<()>;
+}
+```
+
+### Format Options
+
+```rust
+pub struct FormatOptions {
+    pub delimiter: Option<char>,      // CSV delimiter (default: ',')
+    pub no_header: bool,              // CSV without header
+    pub pretty: bool,                 // Pretty-print output
+    pub compact: bool,                // Compact output (JSON)
+    pub flow_style: bool,             // YAML inline style
+}
+```
+
+## Error Types
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum DkitError {
+    #[error("Unknown format: {0}")]
+    UnknownFormat(String),
+
+    #[error("Failed to parse {format}: {source}")]
+    ParseError {
+        format: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Failed to write {format}: {source}")]
+    WriteError {
+        format: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Invalid query: {0}")]
+    QueryError(String),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Path not found: {0}")]
+    PathNotFound(String),
+}
+```
+
+## Format-specific Notes
+
+### JSON ↔ Value
+
+- `serde_json::Value` → `Value` 직접 매핑
+- `Number`가 정수이면 `Integer`, 아니면 `Float`
+
+### CSV ↔ Value
+
+- CSV는 항상 `Array(Vec<Object>)` 형태로 변환
+- 모든 CSV 값은 기본적으로 `String`
+- 숫자 자동 추론: 정수/실수 패턴이면 `Integer`/`Float`로 변환 시도
+- `--no-header` 시 컬럼명은 `col0`, `col1`, ... 자동 생성
+- **주의**: CSV → JSON → CSV 왕복 시 타입 정보 차이 발생 가능
+
+### YAML ↔ Value
+
+- `serde_yaml::Value` → `Value` 직접 매핑
+- YAML의 `~`는 `Null`
+- YAML의 `true`/`false`는 `Bool`
+
+### TOML ↔ Value
+
+- TOML은 top-level이 반드시 table(object)
+- 배열 데이터를 TOML로 변환 시 `data` 키로 감싸기
+- TOML의 `Datetime`은 `String`으로 변환
+
+## Query Engine
+
+### Query Grammar (EBNF)
+
+```
+query       = path ("|" operation)*
+path        = "." segment*
+segment     = field | index | iterate
+field       = identifier
+index       = "[" integer "]"
+iterate     = "[]"
+operation   = where | select | sort | limit
+where       = "where" condition
+condition   = expr compare_op expr (logic_op expr compare_op expr)*
+select      = "select" field ("," field)*
+sort        = "sort" field ["desc"]
+limit       = "limit" integer
+compare_op  = "==" | "!=" | ">" | "<" | ">=" | "<="
+logic_op    = "and" | "or"
+expr        = path | string_literal | number_literal
+```
+
+### Parser Implementation
+
+재귀 하강 파서(recursive descent parser) 방식으로 구현.
+
+```rust
+pub struct QueryParser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+pub enum QueryNode {
+    Path(Vec<PathSegment>),
+    Where(Condition),
+    Select(Vec<String>),
+    Sort(String, SortOrder),
+    Limit(usize),
+    Pipeline(Vec<QueryNode>),
+}
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+각 모듈별 단위 테스트. `#[cfg(test)]` 모듈 내부에 작성.
+
+### Integration Tests
+
+`tests/` 디렉토리에 CLI 레벨 통합 테스트.
+
+```rust
+use assert_cmd::Command;
+
+#[test]
+fn convert_json_to_csv() {
+    Command::cargo_bin("dkit")
+        .unwrap()
+        .args(&["convert", "tests/fixtures/users.json", "--to", "csv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name,age,email"));
+}
+```
+
+### Test Fixtures
+
+`tests/fixtures/` 에 다양한 테스트 데이터 파일 배치. 자세한 목록은 Issue #12 참조.


### PR DESCRIPTION
## Summary
- GitHub Project 보드 생성 및 24개 이슈 등록 (v0.1.0~v0.4.0)
- `docs/` 폴더에 기술 문서 4종 작성 (architecture, technical-spec, cli-spec, query-syntax)
- `CLAUDE.md` 작성: Issue-driven 개발 워크플로우 가이드

## Test plan
- [ ] GitHub Project 보드 확인: https://github.com/users/syangkkim/projects/2
- [ ] 이슈 24개 생성 및 라벨/필드 확인
- [ ] docs/ 문서 내용 검토

https://claude.ai/code/session_01NF8GXfFrPk8HbUXYfGXPry