### PR TITLE
Implement Display trait for Value type

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
@@ -10,6 +12,50 @@ pub enum Value {
     String(String),
     Array(Vec<Value>),
     Object(IndexMap<String, Value>),
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::Null => write!(f, "null"),
+            Value::Bool(b) => write!(f, "{b}"),
+            Value::Integer(n) => write!(f, "{n}"),
+            Value::Float(n) => {
+                if n.fract() == 0.0 && n.is_finite() {
+                    write!(f, "{n:.1}")
+                } else {
+                    write!(f, "{n}")
+                }
+            }
+            Value::String(s) => write!(f, "{s}"),
+            Value::Array(arr) => {
+                write!(f, "[")?;
+                for (i, v) in arr.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    match v {
+                        Value::String(s) => write!(f, "\"{s}\"")?,
+                        _ => write!(f, "{v}")?,
+                    }
+                }
+                write!(f, "]")
+            }
+            Value::Object(map) => {
+                write!(f, "{{")?;
+                for (i, (k, v)) in map.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    match v {
+                        Value::String(s) => write!(f, "\"{k}\": \"{s}\"")?,
+                        _ => write!(f, "\"{k}\": {v}")?,
+                    }
+                }
+                write!(f, "}}")
+            }
+        }
+    }
 }
 
 impl Value {
@@ -91,5 +137,54 @@ mod tests {
             obj.as_object().unwrap().get("key"),
             Some(&Value::String("value".into()))
         );
+    }
+
+    #[test]
+    fn test_display_primitives() {
+        assert_eq!(Value::Null.to_string(), "null");
+        assert_eq!(Value::Bool(true).to_string(), "true");
+        assert_eq!(Value::Bool(false).to_string(), "false");
+        assert_eq!(Value::Integer(42).to_string(), "42");
+        assert_eq!(Value::Float(3.14).to_string(), "3.14");
+        assert_eq!(Value::Float(1.0).to_string(), "1.0");
+        assert_eq!(Value::String("hello".into()).to_string(), "hello");
+    }
+
+    #[test]
+    fn test_display_array() {
+        let arr = Value::Array(vec![
+            Value::Integer(1),
+            Value::String("two".into()),
+            Value::Bool(true),
+        ]);
+        assert_eq!(arr.to_string(), r#"[1, "two", true]"#);
+    }
+
+    #[test]
+    fn test_display_empty_array() {
+        assert_eq!(Value::Array(vec![]).to_string(), "[]");
+    }
+
+    #[test]
+    fn test_display_object() {
+        let mut map = IndexMap::new();
+        map.insert("name".to_string(), Value::String("dkit".into()));
+        map.insert("version".to_string(), Value::Integer(1));
+        let obj = Value::Object(map);
+        assert_eq!(obj.to_string(), r#"{"name": "dkit", "version": 1}"#);
+    }
+
+    #[test]
+    fn test_display_empty_object() {
+        assert_eq!(Value::Object(IndexMap::new()).to_string(), "{}");
+    }
+
+    #[test]
+    fn test_accessor_returns_none_for_wrong_type() {
+        let v = Value::Integer(42);
+        assert_eq!(v.as_bool(), None);
+        assert_eq!(v.as_str(), None);
+        assert_eq!(v.as_array(), None);
+        assert_eq!(v.as_object(), None);
     }
 }


### PR DESCRIPTION
## Summary
- `Value` enum의 `Display` 트레이트 구현 (JSON-like 포맷)
- 모든 variant에 대한 포맷팅: Null→"null", Bool→"true"/"false", Integer, Float(소수점 보존), String, Array(대괄호), Object(중괄호)
- 포괄적인 단위 테스트 추가 (Display, 빈 컬렉션, 잘못된 타입 접근자)

## Test plan
- [x] `cargo test value::` — 9개 테스트 모두 통과
- [x] `cargo fmt -- --check` — 포맷 OK

Closes #2

https://claude.ai/code/session_019UPfygjdRdEn3tDWmd2av6