### PR TITLE
feat: implement view subcommand with table output (#10)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,9 +77,29 @@ pub enum Commands {
         /// Input file path (use - for stdin)
         input: String,
 
+        /// Input format (required when reading from stdin)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Path to nested data (e.g. '.users' or '.config.db')
+        #[arg(long)]
+        path: Option<String>,
+
         /// Maximum number of rows to display
         #[arg(short = 'n', long)]
-        max_rows: Option<usize>,
+        limit: Option<usize>,
+
+        /// Columns to display (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        columns: Option<Vec<String>>,
+
+        /// CSV delimiter character
+        #[arg(long)]
+        delimiter: Option<char>,
+
+        /// CSV without header row
+        #[arg(long)]
+        no_header: bool,
     },
 
     /// Show statistics about data

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -1,1 +1,253 @@
-// View command — to be implemented
+use std::fs;
+use std::io::{self, Read};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+
+use crate::format::csv::CsvReader;
+use crate::format::json::JsonReader;
+use crate::format::toml::TomlReader;
+use crate::format::yaml::YamlReader;
+use crate::format::{detect_format, Format, FormatOptions, FormatReader};
+use crate::output::table::render_table;
+use crate::value::Value;
+
+pub struct ViewArgs<'a> {
+    pub input: &'a str,
+    pub from: Option<&'a str>,
+    pub path: Option<&'a str>,
+    pub limit: Option<usize>,
+    pub columns: Option<Vec<String>>,
+    pub delimiter: Option<char>,
+    pub no_header: bool,
+}
+
+/// view 서브커맨드 실행
+pub fn run(args: &ViewArgs) -> Result<()> {
+    let (content, source_format) = read_input(args)?;
+
+    let read_options = FormatOptions {
+        delimiter: args.delimiter,
+        no_header: args.no_header,
+        ..Default::default()
+    };
+
+    let value = read_value(&content, source_format, &read_options)?;
+
+    // --path 옵션으로 중첩 데이터 접근
+    let target = match args.path {
+        Some(path_expr) => resolve_path(&value, path_expr)?,
+        None => value,
+    };
+
+    let output = render_table(&target, args.limit, args.columns.as_deref());
+
+    println!("{output}");
+    Ok(())
+}
+
+/// 입력 소스에서 콘텐츠와 포맷을 읽어온다
+fn read_input(args: &ViewArgs) -> Result<(String, Format)> {
+    if args.input == "-" {
+        let format = match args.from {
+            Some(f) => Format::from_str(f)?,
+            None => bail!("--from is required when reading from stdin"),
+        };
+        let mut buf = String::new();
+        io::stdin()
+            .read_to_string(&mut buf)
+            .context("Failed to read from stdin")?;
+        Ok((buf, format))
+    } else {
+        let path = Path::new(args.input);
+        let format = match args.from {
+            Some(f) => Format::from_str(f)?,
+            None => detect_format(path)?,
+        };
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        Ok((content, format))
+    }
+}
+
+fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
+    match format {
+        Format::Json => JsonReader.read(content),
+        Format::Csv => CsvReader::new(options.clone()).read(content),
+        Format::Yaml => YamlReader.read(content),
+        Format::Toml => TomlReader.read(content),
+    }
+}
+
+/// 간단한 경로 접근: ".field.subfield" 또는 ".array[0]" 형태
+fn resolve_path(value: &Value, path_expr: &str) -> Result<Value> {
+    let path_expr = path_expr.trim();
+    if path_expr.is_empty() || path_expr == "." {
+        return Ok(value.clone());
+    }
+
+    // 선행 dot 제거
+    let path_expr = path_expr.strip_prefix('.').unwrap_or(path_expr);
+
+    let mut current = value.clone();
+
+    for segment in split_path_segments(path_expr) {
+        // 배열 인덱싱 확인: "field[0]" 또는 "[0]"
+        if let Some((field, idx)) = parse_index_segment(&segment) {
+            if !field.is_empty() {
+                current = access_field(&current, &field)?;
+            }
+            current = access_index(&current, idx)?;
+        } else {
+            current = access_field(&current, &segment)?;
+        }
+    }
+
+    Ok(current)
+}
+
+/// 경로를 dot으로 분할 (대괄호 내부의 dot은 무시)
+fn split_path_segments(path: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut in_bracket = false;
+
+    for ch in path.chars() {
+        match ch {
+            '[' => {
+                in_bracket = true;
+                current.push(ch);
+            }
+            ']' => {
+                in_bracket = false;
+                current.push(ch);
+            }
+            '.' if !in_bracket => {
+                if !current.is_empty() {
+                    segments.push(current.clone());
+                    current.clear();
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        segments.push(current);
+    }
+
+    segments
+}
+
+/// "field[N]" → (field, N) 파싱. 음수 인덱스 지원.
+fn parse_index_segment(segment: &str) -> Option<(String, i64)> {
+    let bracket_start = segment.find('[')?;
+    let bracket_end = segment.find(']')?;
+    let field = segment[..bracket_start].to_string();
+    let idx_str = &segment[bracket_start + 1..bracket_end];
+    let idx: i64 = idx_str.parse().ok()?;
+    Some((field, idx))
+}
+
+fn access_field(value: &Value, field: &str) -> Result<Value> {
+    match value {
+        Value::Object(obj) => obj
+            .get(field)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Field '{}' not found", field)),
+        _ => bail!("Cannot access field '{}' on non-object value", field),
+    }
+}
+
+fn access_index(value: &Value, idx: i64) -> Result<Value> {
+    match value {
+        Value::Array(arr) => {
+            let actual_idx = if idx < 0 {
+                (arr.len() as i64 + idx) as usize
+            } else {
+                idx as usize
+            };
+            arr.get(actual_idx).cloned().ok_or_else(|| {
+                anyhow::anyhow!("Index {} out of bounds (length {})", idx, arr.len())
+            })
+        }
+        _ => bail!("Cannot index into non-array value"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    #[test]
+    fn test_resolve_path_root() {
+        let v = Value::Integer(42);
+        assert_eq!(resolve_path(&v, ".").unwrap(), Value::Integer(42));
+        assert_eq!(resolve_path(&v, "").unwrap(), Value::Integer(42));
+    }
+
+    #[test]
+    fn test_resolve_path_field() {
+        let mut m = IndexMap::new();
+        m.insert("name".to_string(), Value::String("Alice".to_string()));
+        let v = Value::Object(m);
+        assert_eq!(
+            resolve_path(&v, ".name").unwrap(),
+            Value::String("Alice".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_nested() {
+        let mut inner = IndexMap::new();
+        inner.insert("host".to_string(), Value::String("localhost".to_string()));
+        let mut outer = IndexMap::new();
+        outer.insert("db".to_string(), Value::Object(inner));
+        let v = Value::Object(outer);
+        assert_eq!(
+            resolve_path(&v, ".db.host").unwrap(),
+            Value::String("localhost".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_array_index() {
+        let mut m = IndexMap::new();
+        m.insert(
+            "items".to_string(),
+            Value::Array(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+            ]),
+        );
+        let v = Value::Object(m);
+        assert_eq!(
+            resolve_path(&v, ".items[0]").unwrap(),
+            Value::String("a".to_string())
+        );
+        assert_eq!(
+            resolve_path(&v, ".items[-1]").unwrap(),
+            Value::String("b".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_not_found() {
+        let mut m = IndexMap::new();
+        m.insert("x".to_string(), Value::Integer(1));
+        let v = Value::Object(m);
+        assert!(resolve_path(&v, ".y").is_err());
+    }
+
+    #[test]
+    fn test_split_path_segments() {
+        let segs = split_path_segments("users[0].name");
+        assert_eq!(segs, vec!["users[0]", "name"]);
+    }
+
+    #[test]
+    fn test_split_path_segments_nested_brackets() {
+        let segs = split_path_segments("a.b[1].c");
+        assert_eq!(segs, vec!["a", "b[1]", "c"]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,24 @@ fn main() -> anyhow::Result<()> {
         Commands::Query { .. } => {
             eprintln!("query command is not yet implemented");
         }
-        Commands::View { .. } => {
-            eprintln!("view command is not yet implemented");
+        Commands::View {
+            input,
+            from,
+            path,
+            limit,
+            columns,
+            delimiter,
+            no_header,
+        } => {
+            commands::view::run(&commands::view::ViewArgs {
+                input: &input,
+                from: from.as_deref(),
+                path: path.as_deref(),
+                limit,
+                columns,
+                delimiter,
+                no_header,
+            })?;
         }
         Commands::Stats { .. } => {
             eprintln!("stats command is not yet implemented");

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -1,1 +1,288 @@
-// Table output formatter — to be implemented
+use comfy_table::{Cell, ContentArrangement, Table};
+
+use crate::value::Value;
+
+/// Value 데이터를 테이블 문자열로 렌더링한다.
+///
+/// - Array of Objects → 각 object가 하나의 행, 키가 컬럼 헤더
+/// - Array of primitives → 단일 "value" 컬럼
+/// - Single Object → key/value 2-컬럼 테이블
+/// - Primitive → 단일 값 출력
+pub fn render_table(value: &Value, limit: Option<usize>, columns: Option<&[String]>) -> String {
+    match value {
+        Value::Array(arr) if !arr.is_empty() && arr[0].as_object().is_some() => {
+            render_array_of_objects(arr, limit, columns)
+        }
+        Value::Array(arr) => render_array_of_primitives(arr, limit),
+        Value::Object(_) => render_single_object(value, columns),
+        _ => format!("{value}"),
+    }
+}
+
+/// Array<Object> → 테이블 (각 object = 1행)
+fn render_array_of_objects(
+    arr: &[Value],
+    limit: Option<usize>,
+    columns: Option<&[String]>,
+) -> String {
+    // 모든 object에서 키를 수집하여 컬럼 헤더 결정 (순서 보존)
+    let all_keys = collect_keys(arr);
+    let headers: Vec<&String> = match columns {
+        Some(cols) => all_keys.iter().filter(|k| cols.contains(k)).collect(),
+        None => all_keys.iter().collect(),
+    };
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(headers.iter().copied().map(Cell::new));
+
+    let row_count = match limit {
+        Some(n) => n.min(arr.len()),
+        None => arr.len(),
+    };
+
+    for item in arr.iter().take(row_count) {
+        if let Value::Object(obj) = item {
+            let row: Vec<Cell> = headers
+                .iter()
+                .map(|key| {
+                    let cell_text = match obj.get(*key) {
+                        Some(Value::Null) => "null".to_string(),
+                        Some(v) => format_cell_value(v),
+                        None => "".to_string(),
+                    };
+                    Cell::new(cell_text)
+                })
+                .collect();
+            table.add_row(row);
+        }
+    }
+
+    if let Some(n) = limit {
+        if n < arr.len() {
+            table.add_row(vec![Cell::new(format!(
+                "... ({} more rows)",
+                arr.len() - n
+            ))]);
+        }
+    }
+
+    table.to_string()
+}
+
+/// Array<Primitive> → 단일 컬럼 테이블
+fn render_array_of_primitives(arr: &[Value], limit: Option<usize>) -> String {
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec![Cell::new("value")]);
+
+    let row_count = match limit {
+        Some(n) => n.min(arr.len()),
+        None => arr.len(),
+    };
+
+    for item in arr.iter().take(row_count) {
+        table.add_row(vec![Cell::new(format_cell_value(item))]);
+    }
+
+    if let Some(n) = limit {
+        if n < arr.len() {
+            table.add_row(vec![Cell::new(format!(
+                "... ({} more rows)",
+                arr.len() - n
+            ))]);
+        }
+    }
+
+    table.to_string()
+}
+
+/// 단일 Object → key | value 테이블
+fn render_single_object(value: &Value, columns: Option<&[String]>) -> String {
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec![Cell::new("key"), Cell::new("value")]);
+
+    if let Value::Object(obj) = value {
+        for (k, v) in obj {
+            if let Some(cols) = columns {
+                if !cols.contains(k) {
+                    continue;
+                }
+            }
+            table.add_row(vec![Cell::new(k), Cell::new(format_cell_value(v))]);
+        }
+    }
+
+    table.to_string()
+}
+
+/// 모든 object에서 키를 순서 보존하며 수집
+fn collect_keys(arr: &[Value]) -> Vec<String> {
+    let mut keys: Vec<String> = Vec::new();
+    for item in arr {
+        if let Value::Object(obj) = item {
+            for k in obj.keys() {
+                if !keys.contains(k) {
+                    keys.push(k.clone());
+                }
+            }
+        }
+    }
+    keys
+}
+
+/// Value를 셀 표시용 문자열로 변환
+fn format_cell_value(v: &Value) -> String {
+    match v {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Integer(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => s.clone(),
+        Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(format_cell_value).collect();
+            format!("[{}]", items.join(", "))
+        }
+        Value::Object(_) => "{...}".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn make_user(name: &str, age: i64) -> Value {
+        let mut m = IndexMap::new();
+        m.insert("name".to_string(), Value::String(name.to_string()));
+        m.insert("age".to_string(), Value::Integer(age));
+        Value::Object(m)
+    }
+
+    #[test]
+    fn test_render_array_of_objects() {
+        let data = Value::Array(vec![make_user("Alice", 30), make_user("Bob", 25)]);
+        let output = render_table(&data, None, None);
+        assert!(output.contains("name"));
+        assert!(output.contains("age"));
+        assert!(output.contains("Alice"));
+        assert!(output.contains("Bob"));
+        assert!(output.contains("30"));
+        assert!(output.contains("25"));
+    }
+
+    #[test]
+    fn test_render_with_limit() {
+        let data = Value::Array(vec![
+            make_user("Alice", 30),
+            make_user("Bob", 25),
+            make_user("Charlie", 35),
+        ]);
+        let output = render_table(&data, Some(2), None);
+        assert!(output.contains("Alice"));
+        assert!(output.contains("Bob"));
+        assert!(!output.contains("Charlie"));
+        assert!(output.contains("1 more rows"));
+    }
+
+    #[test]
+    fn test_render_with_columns() {
+        let data = Value::Array(vec![make_user("Alice", 30), make_user("Bob", 25)]);
+        let cols = vec!["name".to_string()];
+        let output = render_table(&data, None, Some(&cols));
+        assert!(output.contains("name"));
+        assert!(output.contains("Alice"));
+        // age column should not appear in header
+        // (the values 30/25 won't appear since the age column is filtered)
+    }
+
+    #[test]
+    fn test_render_array_of_primitives() {
+        let data = Value::Array(vec![
+            Value::Integer(1),
+            Value::Integer(2),
+            Value::Integer(3),
+        ]);
+        let output = render_table(&data, None, None);
+        assert!(output.contains("value"));
+        assert!(output.contains('1'));
+        assert!(output.contains('2'));
+        assert!(output.contains('3'));
+    }
+
+    #[test]
+    fn test_render_single_object() {
+        let mut m = IndexMap::new();
+        m.insert("host".to_string(), Value::String("localhost".to_string()));
+        m.insert("port".to_string(), Value::Integer(8080));
+        let data = Value::Object(m);
+        let output = render_table(&data, None, None);
+        assert!(output.contains("key"));
+        assert!(output.contains("value"));
+        assert!(output.contains("host"));
+        assert!(output.contains("localhost"));
+        assert!(output.contains("port"));
+        assert!(output.contains("8080"));
+    }
+
+    #[test]
+    fn test_render_single_object_with_columns() {
+        let mut m = IndexMap::new();
+        m.insert("host".to_string(), Value::String("localhost".to_string()));
+        m.insert("port".to_string(), Value::Integer(8080));
+        let data = Value::Object(m);
+        let cols = vec!["host".to_string()];
+        let output = render_table(&data, None, Some(&cols));
+        assert!(output.contains("host"));
+        assert!(!output.contains("8080"));
+    }
+
+    #[test]
+    fn test_render_primitive() {
+        let data = Value::String("hello".to_string());
+        let output = render_table(&data, None, None);
+        assert_eq!(output, "hello");
+    }
+
+    #[test]
+    fn test_render_null_values() {
+        let mut m = IndexMap::new();
+        m.insert("name".to_string(), Value::String("Alice".to_string()));
+        m.insert("email".to_string(), Value::Null);
+        let data = Value::Array(vec![Value::Object(m)]);
+        let output = render_table(&data, None, None);
+        assert!(output.contains("null"));
+    }
+
+    #[test]
+    fn test_render_nested_value_in_cell() {
+        let mut m = IndexMap::new();
+        m.insert(
+            "tags".to_string(),
+            Value::Array(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+            ]),
+        );
+        let data = Value::Array(vec![Value::Object(m)]);
+        let output = render_table(&data, None, None);
+        assert!(output.contains("[a, b]"));
+    }
+
+    #[test]
+    fn test_render_empty_array() {
+        let data = Value::Array(vec![]);
+        let output = render_table(&data, None, None);
+        // Empty array of primitives path
+        assert!(output.contains("value"));
+    }
+
+    #[test]
+    fn test_limit_larger_than_data() {
+        let data = Value::Array(vec![make_user("Alice", 30)]);
+        let output = render_table(&data, Some(100), None);
+        assert!(output.contains("Alice"));
+        assert!(!output.contains("more rows"));
+    }
+}

--- a/tests/view_test.rs
+++ b/tests/view_test.rs
@@ -1,0 +1,148 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// --- 기본 view ---
+
+#[test]
+fn view_json_array() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("age"))
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+#[test]
+fn view_csv() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.csv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("Alice"));
+}
+
+#[test]
+fn view_yaml() {
+    dkit()
+        .args(&["view", "tests/fixtures/config.yaml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("key"))
+        .stdout(predicate::str::contains("value"))
+        .stdout(predicate::str::contains("database"));
+}
+
+#[test]
+fn view_toml() {
+    dkit()
+        .args(&["view", "tests/fixtures/config.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("database"));
+}
+
+// --- --path 옵션 ---
+
+#[test]
+fn view_with_path() {
+    dkit()
+        .args(&["view", "tests/fixtures/config.yaml", "--path", ".database"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("host"))
+        .stdout(predicate::str::contains("localhost"))
+        .stdout(predicate::str::contains("port"))
+        .stdout(predicate::str::contains("5432"));
+}
+
+#[test]
+fn view_with_path_array_index() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json", "--path", ".[0]"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("Alice"));
+}
+
+// --- --limit 옵션 ---
+
+#[test]
+fn view_with_limit() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json", "-n", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("1 more rows"));
+}
+
+// --- --columns 옵션 ---
+
+#[test]
+fn view_with_columns() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/users.json",
+            "--columns",
+            "name,email",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("email"))
+        .stdout(predicate::str::contains("Alice"));
+}
+
+// --- 에러 케이스 ---
+
+#[test]
+fn view_nonexistent_file() {
+    dkit()
+        .args(&["view", "nonexistent.json"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn view_invalid_path() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/users.json",
+            "--path",
+            ".nonexistent",
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn view_stdin_without_from() {
+    dkit()
+        .args(&["view", "-"])
+        .write_stdin("[{\"a\": 1}]")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--from"));
+}
+
+#[test]
+fn view_stdin_with_from() {
+    dkit()
+        .args(&["view", "-", "--from", "json"])
+        .write_stdin("[{\"name\": \"Test\", \"value\": 42}]")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("Test"));
+}


### PR DESCRIPTION
## Summary
- Implement `dkit view` subcommand for previewing data as formatted tables using comfy-table
- Support `--path` option for navigating nested data (e.g. `.database`, `.[0]`)
- Support `--limit` / `-n` option for limiting displayed rows
- Support `--columns` option for selecting specific columns (comma-separated)
- Support all input formats (JSON, CSV, YAML, TOML) and stdin with `--from`

## Test plan
- [x] Unit tests for table rendering (array of objects, primitives, single object, limits, columns, edge cases)
- [x] Unit tests for path resolution (field access, nested paths, array indexing, negative indices)
- [x] Integration tests for all formats (JSON, CSV, YAML, TOML)
- [x] Integration tests for --path, --limit, --columns options
- [x] Integration tests for error cases (nonexistent file, invalid path, stdin without --from)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

Closes #10

https://claude.ai/code/session_014nMpE7scF5frCKX63EkUbA