### PR TITLE
feat: improve error messages and UX

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,9 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "dkit",
     version,
-    about = "Swiss army knife for data format conversion and querying"
+    about = "Swiss army knife for data format conversion and querying",
+    long_about = "dkit (Data Kit) — Convert and query data across JSON, CSV, YAML, and TOML.\n\nExamples:\n  dkit convert data.json --to csv\n  dkit convert data.csv --to yaml -o output.yaml\n  dkit query data.json '.users[0].name'\n  dkit view data.csv --limit 10\n  cat data.json | dkit convert --from json --to toml",
+    after_help = "Supported formats: json, csv, yaml (yml), toml\nUse 'dkit <command> --help' for more information about a command."
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -16,104 +18,118 @@ pub struct Cli {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Convert between data formats (JSON, CSV, YAML, TOML)
+    #[command(
+        after_help = "Examples:\n  dkit convert data.json --to csv\n  dkit convert data.csv --to yaml --pretty\n  dkit convert a.json b.json --to csv --outdir ./output\n  cat data.json | dkit convert --from json --to toml"
+    )]
     Convert {
         /// Input file path(s). Use stdin if not provided (requires --from)
         #[arg(value_name = "INPUT")]
         input: Vec<PathBuf>,
 
         /// Output format (json, csv, yaml, toml)
-        #[arg(long)]
+        #[arg(long, value_name = "FORMAT")]
         to: String,
 
-        /// Input format (required when reading from stdin)
-        #[arg(long)]
+        /// Input format override (auto-detected from file extension)
+        #[arg(long, value_name = "FORMAT")]
         from: Option<String>,
 
         /// Output file path (default: stdout)
-        #[arg(short, long)]
+        #[arg(short, long, value_name = "FILE")]
         output: Option<PathBuf>,
 
-        /// Output directory for multiple file conversion
-        #[arg(long)]
+        /// Output directory for batch conversion
+        #[arg(long, value_name = "DIR")]
         outdir: Option<PathBuf>,
 
-        /// CSV delimiter character
-        #[arg(long)]
+        /// CSV delimiter character (default: ',')
+        #[arg(long, value_name = "CHAR")]
         delimiter: Option<char>,
 
-        /// Pretty-print output (default for JSON)
+        /// Pretty-print output
         #[arg(long)]
         pretty: bool,
 
-        /// Compact output (single-line JSON)
+        /// Compact single-line output (JSON)
         #[arg(long, conflicts_with = "pretty")]
         compact: bool,
 
-        /// CSV without header row
+        /// Treat CSV as having no header row
         #[arg(long)]
         no_header: bool,
 
-        /// YAML inline/flow style
+        /// Use YAML inline/flow style
         #[arg(long)]
         flow: bool,
     },
 
-    /// Query data using dkit query syntax
+    /// Query data using path expressions
+    #[command(
+        after_help = "Examples:\n  dkit query data.json '.users[0].name'\n  dkit query data.yaml '.config.database.host'\n  cat data.json | dkit query - '.items[]' --from json"
+    )]
     Query {
-        /// Input file path (use - for stdin)
+        /// Input file path (use '-' for stdin)
+        #[arg(value_name = "INPUT")]
         input: String,
 
         /// Query expression (e.g. '.users[0].name')
+        #[arg(value_name = "EXPR")]
         query: String,
 
-        /// Input format (required when reading from stdin)
-        #[arg(long)]
+        /// Input format (required for stdin)
+        #[arg(long, value_name = "FORMAT")]
         from: Option<String>,
 
-        /// Output format (default: same as input)
-        #[arg(long)]
+        /// Output format (default: json)
+        #[arg(long, value_name = "FORMAT")]
         to: Option<String>,
     },
 
     /// View data in a formatted table
+    #[command(
+        after_help = "Examples:\n  dkit view data.csv\n  dkit view data.json --path .users --limit 5\n  dkit view data.json --columns name,email"
+    )]
     View {
-        /// Input file path (use - for stdin)
+        /// Input file path (use '-' for stdin)
+        #[arg(value_name = "INPUT")]
         input: String,
 
-        /// Input format (required when reading from stdin)
-        #[arg(long)]
+        /// Input format (required for stdin)
+        #[arg(long, value_name = "FORMAT")]
         from: Option<String>,
 
         /// Path to nested data (e.g. '.users' or '.config.db')
-        #[arg(long)]
+        #[arg(long, value_name = "PATH")]
         path: Option<String>,
 
         /// Maximum number of rows to display
-        #[arg(short = 'n', long)]
+        #[arg(short = 'n', long, value_name = "N")]
         limit: Option<usize>,
 
         /// Columns to display (comma-separated)
-        #[arg(long, value_delimiter = ',')]
+        #[arg(long, value_delimiter = ',', value_name = "COLS")]
         columns: Option<Vec<String>>,
 
-        /// CSV delimiter character
-        #[arg(long)]
+        /// CSV delimiter character (default: ',')
+        #[arg(long, value_name = "CHAR")]
         delimiter: Option<char>,
 
-        /// CSV without header row
+        /// Treat CSV as having no header row
         #[arg(long)]
         no_header: bool,
     },
 
     /// Show statistics about data
     Stats {
-        /// Input file path (use - for stdin)
+        /// Input file path (use '-' for stdin)
+        #[arg(value_name = "INPUT")]
         input: String,
     },
 
     /// Show schema/structure of data
     Schema {
-        /// Input file path (use - for stdin)
+        /// Input file path (use '-' for stdin)
+        #[arg(value_name = "INPUT")]
         input: String,
     },
 }

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 
+use super::read_file;
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
@@ -44,7 +45,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
     if args.input.is_empty() {
         let source_format = match args.from {
             Some(f) => Format::from_str(f)?,
-            None => bail!("--from is required when reading from stdin"),
+            None => bail!("--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"),
         };
         let mut buf = String::new();
         io::stdin()
@@ -72,7 +73,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
     if args.input.len() > 1 {
         let outdir = match args.outdir {
             Some(d) => d,
-            None => bail!("--outdir is required when converting multiple files"),
+            None => bail!("--outdir is required when converting multiple files\n  Hint: specify an output directory, e.g. --outdir ./output"),
         };
         fs::create_dir_all(outdir)
             .with_context(|| format!("Failed to create directory {}", outdir.display()))?;
@@ -89,8 +90,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
                 ..Default::default()
             };
 
-            let content = fs::read_to_string(path)
-                .with_context(|| format!("Failed to read {}", path.display()))?;
+            let content = read_file(path)?;
             let value = read_value(&content, source_format, &read_options)?;
             let result = write_value(&value, target_format, &write_options)?;
 
@@ -121,8 +121,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         ..Default::default()
     };
 
-    let content =
-        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let content = read_file(path)?;
     let value = read_value(&content, source_format, &read_options)?;
     let result = write_value(&value, target_format, &write_options)?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,3 +3,25 @@ pub mod query;
 pub mod schema;
 pub mod stats;
 pub mod view;
+
+use std::path::Path;
+
+/// 파일 읽기 실패 시 도움말 힌트가 포함된 에러 메시지 생성
+pub fn read_file(path: &Path) -> anyhow::Result<String> {
+    std::fs::read_to_string(path).map_err(|e| {
+        let hint = if e.kind() == std::io::ErrorKind::NotFound {
+            format!(
+                "\n  Hint: check that the file path '{}' is correct",
+                path.display()
+            )
+        } else if e.kind() == std::io::ErrorKind::PermissionDenied {
+            format!(
+                "\n  Hint: permission denied for '{}' — check file permissions",
+                path.display()
+            )
+        } else {
+            String::new()
+        };
+        anyhow::anyhow!("Failed to read '{}': {e}{hint}", path.display())
+    })
+}

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
@@ -26,7 +25,7 @@ pub fn run(args: &QueryArgs) -> Result<()> {
     let (content, source_format) = if args.input == "-" {
         let format = match args.from {
             Some(f) => Format::from_str(f)?,
-            None => bail!("--from is required when reading from stdin"),
+            None => bail!("--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"),
         };
         let mut buf = String::new();
         io::stdin()
@@ -39,8 +38,7 @@ pub fn run(args: &QueryArgs) -> Result<()> {
             Some(f) => Format::from_str(f)?,
             None => detect_format(&path)?,
         };
-        let content = fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read {}", path.display()))?;
+        let content = super::read_file(&path)?;
         (content, format)
     };
 

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::io::{self, Read};
 use std::path::Path;
 
@@ -51,7 +50,7 @@ fn read_input(args: &ViewArgs) -> Result<(String, Format)> {
     if args.input == "-" {
         let format = match args.from {
             Some(f) => Format::from_str(f)?,
-            None => bail!("--from is required when reading from stdin"),
+            None => bail!("--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"),
         };
         let mut buf = String::new();
         io::stdin()
@@ -64,8 +63,7 @@ fn read_input(args: &ViewArgs) -> Result<(String, Format)> {
             Some(f) => Format::from_str(f)?,
             None => detect_format(path)?,
         };
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("Failed to read {}", path.display()))?;
+        let content = super::read_file(path)?;
         Ok((content, format))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,16 @@
+/// 지원하는 포맷 목록 (에러 메시지용)
+pub const SUPPORTED_FORMATS: &[&str] = &["json", "csv", "yaml", "yml", "toml"];
+
 /// dkit 에러 타입 정의
 ///
 /// 포맷 파싱, 쓰기, IO, 쿼리 등 카테고리별 에러를 구분하며,
 /// `thiserror`로 `Display`와 `Error`를 자동 구현한다.
 #[derive(Debug, thiserror::Error)]
 pub enum DkitError {
-    #[error("Unknown format: {0}")]
+    #[error("Unknown format: '{0}'\n  Supported formats: {}", SUPPORTED_FORMATS.join(", "))]
     UnknownFormat(String),
 
-    #[error("Failed to parse {format}: {source}")]
+    #[error("Failed to parse {format}: {source}\n  Hint: check that the input is valid {format}")]
     ParseError {
         format: String,
         #[source]
@@ -22,7 +25,7 @@ pub enum DkitError {
     },
 
     #[allow(dead_code)]
-    #[error("Invalid query: {0}")]
+    #[error("Invalid query: {0}\n  Hint: use 'dkit query --help' for query syntax")]
     QueryError(String),
 
     #[error("IO error: {0}")]
@@ -46,7 +49,12 @@ mod tests {
     #[test]
     fn test_unknown_format_display() {
         let err = DkitError::UnknownFormat("xml".to_string());
-        assert_eq!(err.to_string(), "Unknown format: xml");
+        let msg = err.to_string();
+        assert!(msg.contains("Unknown format: 'xml'"));
+        assert!(msg.contains("Supported formats:"));
+        assert!(msg.contains("json"));
+        assert!(msg.contains("csv"));
+        assert!(msg.contains("toml"));
     }
 
     #[test]
@@ -57,7 +65,9 @@ mod tests {
             format: "JSON".to_string(),
             source,
         };
-        assert_eq!(err.to_string(), "Failed to parse JSON: unexpected token");
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to parse JSON: unexpected token"));
+        assert!(msg.contains("Hint:"));
     }
 
     #[test]
@@ -77,10 +87,9 @@ mod tests {
     #[test]
     fn test_query_error_display() {
         let err = DkitError::QueryError("invalid syntax at position 5".to_string());
-        assert_eq!(
-            err.to_string(),
-            "Invalid query: invalid syntax at position 5"
-        );
+        let msg = err.to_string();
+        assert!(msg.contains("Invalid query: invalid syntax at position 5"));
+        assert!(msg.contains("Hint:"));
     }
 
     #[test]
@@ -102,7 +111,7 @@ mod tests {
         // DkitError는 anyhow::Error로 변환 가능해야 한다
         let err = DkitError::UnknownFormat("bin".to_string());
         let anyhow_err: anyhow::Error = err.into();
-        assert_eq!(anyhow_err.to_string(), "Unknown format: bin");
+        assert!(anyhow_err.to_string().contains("Unknown format: 'bin'"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,13 +6,44 @@ mod output;
 mod query;
 mod value;
 
+use std::process;
+
 use clap::Parser;
+use colored::Colorize;
 
 use cli::{Cli, Commands};
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     let cli = Cli::parse();
 
+    if let Err(err) = run_command(cli) {
+        print_error(&err);
+        process::exit(1);
+    }
+}
+
+/// 에러를 색상 강조와 함께 stderr에 출력
+fn print_error(err: &anyhow::Error) {
+    let msg = format!("{err:#}");
+    let mut lines = msg.lines();
+
+    // 첫 줄은 "error:" 접두사와 빨간색
+    if let Some(first) = lines.next() {
+        eprintln!("{} {}", "error:".red().bold(), first);
+    }
+
+    // 나머지 줄 (힌트 등)은 노란색
+    for line in lines {
+        let line = line.trim();
+        if line.starts_with("Hint:") || line.starts_with("Supported formats:") {
+            eprintln!("  {}", line.yellow());
+        } else if !line.is_empty() {
+            eprintln!("  {line}");
+        }
+    }
+}
+
+fn run_command(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Commands::Convert {
             input,


### PR DESCRIPTION
## Summary
- 모든 에러 메시지에 도움말 힌트 추가 (지원 포맷 목록, 경로 확인 안내 등)
- `colored` 크레이트로 에러 출력 색상 강조 (빨간색: 에러, 노란색: 힌트)
- 파일 없음/권한 에러 시 구체적인 안내 메시지 제공
- `--help` 출력에 사용 예제와 값 이름(value_name) 추가
- 파일 읽기 공통 헬퍼 함수 추출 (`commands::read_file`)

Closes #13

## Test plan
- [x] `cargo test` — 전체 276개 테스트 통과
- [x] `cargo clippy -- -D warnings` — 경고 없음
- [x] `cargo fmt -- --check` — 포맷 검사 통과
- [ ] 잘못된 포맷 지정 시 지원 포맷 목록 표시 확인: `dkit convert data.json --to xml`
- [ ] 존재하지 않는 파일 에러 메시지 확인: `dkit view nonexistent.json`
- [ ] `--help` 출력 확인: `dkit --help`, `dkit convert --help`

https://claude.ai/code/session_01GZvtTprGYf3NQK4fVhdJ1n