### PR TITLE
feat: GitHub Actions CI 설정 (테스트 + clippy + rustfmt)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --verbose
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt -- --check


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` 추가: push to main 및 PR 시 자동 CI 실행
- `cargo test` — Linux, macOS, Windows 매트릭스 빌드
- `cargo clippy -- -D warnings` — 린트 검사
- `cargo fmt -- --check` — 포맷 검사
- `rust-cache` 를 활용한 빌드 캐싱

Closes #14

## Test plan
- [ ] PR 생성 후 GitHub Actions에서 워크플로우가 정상 실행되는지 확인
- [ ] 각 OS(ubuntu, macos, windows)에서 테스트 통과 확인
- [ ] clippy, fmt 체크 통과 확인

https://claude.ai/code/session_01WyGYo8vqe64pUNsLE1pgnp