### PR TITLE
feat: add v0.1.0 release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (unix)
+        if: matrix.archive == 'tar.gz'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../dkit-${{ github.ref_name }}-${{ matrix.target }}.tar.gz dkit
+          cd ../../..
+
+      - name: Package (windows)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path target/${{ matrix.target }}/release/dkit.exe -DestinationPath dkit-${{ github.ref_name }}-${{ matrix.target }}.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dkit-${{ matrix.target }}
+          path: dkit-${{ github.ref_name }}-${{ matrix.target }}.*
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*
+
+  publish:
+    name: Publish to crates.io
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-03-20
+
+### Added
+
+- **Core data model**: `Value` enum for unified representation of JSON, CSV, YAML, and TOML data, backed by `IndexMap` for key-order preservation.
+- **Error handling**: `DkitError` type using `thiserror` with structured error variants for parse, format, IO, query, and CLI errors.
+- **Format support**: `FormatReader` and `FormatWriter` traits with implementations for:
+  - JSON (via `serde_json`)
+  - CSV (via `csv` crate, with `--delimiter` and `--no-header` options)
+  - YAML (via `serde_yaml`)
+  - TOML (via `toml` crate)
+- **`convert` subcommand**: Convert between any combination of JSON, CSV, YAML, and TOML (12 conversion paths). Supports stdin/stdout piping, output file (`-o`), batch mode (`--outdir`), `--compact`, and `--pretty` options.
+- **`query` subcommand**: Query data using path expressions with field access (`.field`), nested paths (`.a.b.c`), array indexing (`.[0]`, `.[-1]`), and array iteration (`.[].field`). Supports `--to` for output format conversion.
+- **`view` subcommand**: Display data as a formatted table in the terminal using `comfy-table`.
+- **Automatic format detection**: Detect input format from file extension; require `--from` flag for stdin.
+- **User-friendly error messages**: Colored output with contextual hints using `colored`.
+- **CI pipeline**: GitHub Actions workflow with test (Linux/macOS/Windows), clippy, and rustfmt checks.
+- **Test suite**: Integration tests covering all conversion paths, query operations, table view, fixture data, edge cases (unicode, empty input, quoted CSV fields).
+
+[0.1.0]: https://github.com/syangkkim/dkit/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 description = "Swiss army knife for data format conversion and querying"
 license = "MIT"
+repository = "https://github.com/syangkkim/dkit"
+homepage = "https://github.com/syangkkim/dkit"
+keywords = ["cli", "json", "csv", "yaml", "toml"]
+categories = ["command-line-utilities", "encoding"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` documenting all features included in v0.1.0
- Add GitHub Actions release workflow (`release.yml`) that builds release binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64), creates a GitHub Release, and publishes to crates.io on tag push
- Add crates.io metadata to `Cargo.toml` (repository, homepage, keywords, categories)

## Release Instructions
After merging this PR:
1. Create and push the version tag: `git tag v0.1.0 && git push origin v0.1.0`
2. The release workflow will automatically:
   - Build release binaries for all platforms
   - Create a GitHub Release with the binaries
   - Publish the crate to crates.io (requires `CARGO_REGISTRY_TOKEN` secret)

## Test plan
- [x] All 276 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo publish --dry-run` validates crates.io metadata

Closes #16

https://claude.ai/code/session_01LsyvqpPjcpuXkyuVSxVe4E