### PR TITLE
Remove Project Board reference from task management docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,9 @@ JSON, CSV, YAML, TOML 간 양방향 변환 + 통합 쿼리 + 테이블 출력.
 
 ### Task Management
 
-모든 기획, 계획, 진행, 상태 관리는 **GitHub Issues와 Project 보드**에서 관리한다.
+모든 기획, 계획, 진행, 상태 관리는 **GitHub Issues**에서 관리한다.
 저장소 내부 문서로 태스크를 관리하지 않는다.
 
-- **Project Board**: https://github.com/users/syangkkim/projects/2
 - **Issues**: https://github.com/syangkkim/dkit/issues
 
 ### How to Work on Issues


### PR DESCRIPTION
## Summary
Updated the task management documentation to reflect that all planning and status tracking is managed exclusively through GitHub Issues, removing the reference to the Project Board.

## Changes
- Removed mention of "Project Board" from the task management section
- Removed the Project Board URL link (https://github.com/users/syangkkim/projects/2)
- Clarified that GitHub Issues is the single source of truth for task management

## Details
This change simplifies the task management workflow documentation by consolidating all task tracking to GitHub Issues only, eliminating the need to maintain parallel tracking across multiple tools.

https://claude.ai/code/session_01BQ1QuQ7sHR9V2zsKpG8vQL