### PR TITLE
feat: add -o output file option to query subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,10 @@ pub enum Commands {
         /// Output format (default: json)
         #[arg(long, value_name = "FORMAT")]
         to: Option<String>,
+
+        /// Output file path (default: stdout)
+        #[arg(short, long, value_name = "FILE")]
+        output: Option<PathBuf>,
     },
 
     /// View data in a formatted table

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -1,5 +1,6 @@
+use std::fs;
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 
@@ -17,6 +18,7 @@ pub struct QueryArgs<'a> {
     pub query: &'a str,
     pub from: Option<&'a str>,
     pub to: Option<&'a str>,
+    pub output: Option<&'a Path>,
 }
 
 /// query 서브커맨드 실행
@@ -50,10 +52,13 @@ pub fn run(args: &QueryArgs) -> Result<()> {
     let query = parse_query(args.query)?;
     let result = evaluate_path(&value, &query.path)?;
 
-    // 출력 포맷 결정 (--to 지정 시 해당 포맷, 아니면 JSON 기본)
+    // 출력 포맷 결정: -o 파일 확장자 → --to → 기본 JSON
     let output_format = match args.to {
         Some(f) => Format::from_str(f)?,
-        None => Format::Json,
+        None => match args.output {
+            Some(p) => detect_format(p).unwrap_or(Format::Json),
+            None => Format::Json,
+        },
     };
 
     let write_options = FormatOptions {
@@ -61,11 +66,25 @@ pub fn run(args: &QueryArgs) -> Result<()> {
         ..Default::default()
     };
     let output = write_value(&result, output_format, &write_options)?;
-    // 출력 끝에 줄바꿈이 없으면 추가
-    if output.ends_with('\n') {
-        print!("{output}");
-    } else {
-        println!("{output}");
+
+    // 출력: -o 지정 시 파일에 쓰기, 아니면 stdout
+    match args.output {
+        Some(path) => {
+            let content = if output.ends_with('\n') {
+                output
+            } else {
+                format!("{output}\n")
+            };
+            fs::write(path, &content)
+                .with_context(|| format!("Failed to write to {}", path.display()))?;
+        }
+        None => {
+            if output.ends_with('\n') {
+                print!("{output}");
+            } else {
+                println!("{output}");
+            }
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,12 +75,14 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             query,
             from,
             to,
+            output,
         } => {
             commands::query::run(&commands::query::QueryArgs {
                 input: &input,
                 query: &query,
                 from: from.as_deref(),
                 to: to.as_deref(),
+                output: output.as_deref(),
             })?;
         }
         Commands::View {

--- a/tests/query_test.rs
+++ b/tests/query_test.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use tempfile::TempDir;
 
 fn dkit() -> Command {
     Command::cargo_bin("dkit").unwrap()
@@ -153,4 +154,136 @@ fn query_index_out_of_bounds() {
         .args(["query", "tests/fixtures/users.json", ".[99]"])
         .assert()
         .failure();
+}
+
+// --- -o 출력 파일 옵션 ---
+
+#[test]
+fn query_output_to_json_file() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("result.json");
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/users.json",
+            ".[0].name",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout("");
+    let content = std::fs::read_to_string(&out).unwrap();
+    assert_eq!(content.trim(), "\"Alice\"");
+}
+
+#[test]
+fn query_output_to_yaml_file() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("result.yaml");
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/users.json",
+            ".[0]",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = std::fs::read_to_string(&out).unwrap();
+    assert!(content.contains("name: Alice"));
+}
+
+#[test]
+fn query_output_to_csv_file() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("result.csv");
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/users.json",
+            ".",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = std::fs::read_to_string(&out).unwrap();
+    assert!(content.contains("Alice"));
+    assert!(content.contains("Bob"));
+}
+
+#[test]
+fn query_output_to_toml_file() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("result.toml");
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/config.yaml",
+            ".database",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = std::fs::read_to_string(&out).unwrap();
+    assert!(content.contains("host"));
+    assert!(content.contains("localhost"));
+}
+
+#[test]
+fn query_to_flag_overrides_file_extension() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("result.yaml");
+    // --to json should override .yaml extension
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/users.json",
+            ".[0]",
+            "--to",
+            "json",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = std::fs::read_to_string(&out).unwrap();
+    // JSON output should have braces, not YAML
+    assert!(content.contains("{"));
+    assert!(content.contains("\"name\""));
+}
+
+// --- --to 포맷 변환 ---
+
+#[test]
+fn query_with_to_toml() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/config.yaml",
+            ".database",
+            "--to",
+            "toml",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("host"));
+    assert!(stdout.contains("localhost"));
+}
+
+#[test]
+fn query_with_to_csv() {
+    let output = dkit()
+        .args(["query", "tests/fixtures/users.json", ".", "--to", "csv"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("name"));
+    assert!(stdout.contains("Alice"));
 }


### PR DESCRIPTION
## Summary
- query 서브커맨드에 `-o`/`--output` 옵션을 추가하여 쿼리 결과를 파일로 저장할 수 있도록 함
- `-o` 파일 확장자로 출력 포맷 자동 감지 (--to 미지정 시)
- `--to` 옵션이 `-o` 파일 확장자보다 우선함
- JSON, CSV, YAML, TOML 모든 포맷 Writer 연동 완료

## Test plan
- [x] 기존 query 테스트 14개 전부 통과
- [x] 신규 테스트 7개 추가 (파일 출력, 포맷 자동감지, --to 우선순위 등)
- [x] cargo clippy, cargo fmt 통과

Closes #18

https://claude.ai/code/session_01CtJVJjpFWDMZiWvF8squFp