### PR TITLE
feat: implement merge subcommand for combining data files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,44 @@ pub enum Commands {
         no_header: bool,
     },
 
+    /// Merge multiple data files into one
+    #[command(
+        after_help = "Examples:\n  dkit merge a.json b.json --to json\n  dkit merge users1.csv users2.csv --to json -o merged.json\n  dkit merge config1.yaml config2.yaml --to yaml"
+    )]
+    Merge {
+        /// Input file paths (at least 2 required)
+        #[arg(value_name = "INPUT", required = true)]
+        input: Vec<PathBuf>,
+
+        /// Output format (json, csv, yaml, toml). Defaults to first input's format
+        #[arg(long, value_name = "FORMAT")]
+        to: Option<String>,
+
+        /// Output file path (default: stdout)
+        #[arg(short, long, value_name = "FILE")]
+        output: Option<PathBuf>,
+
+        /// CSV delimiter character (default: ',')
+        #[arg(long, value_name = "CHAR")]
+        delimiter: Option<char>,
+
+        /// Pretty-print output
+        #[arg(long)]
+        pretty: bool,
+
+        /// Compact single-line output (JSON)
+        #[arg(long, conflicts_with = "pretty")]
+        compact: bool,
+
+        /// Treat CSV as having no header row
+        #[arg(long)]
+        no_header: bool,
+
+        /// Use YAML inline/flow style
+        #[arg(long)]
+        flow: bool,
+    },
+
     /// Show schema/structure of data
     #[command(
         after_help = "Examples:\n  dkit schema config.yaml\n  dkit schema data.json\n  cat data.json | dkit schema - --from json"

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1,0 +1,216 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+use super::read_file;
+use crate::format::csv::{CsvReader, CsvWriter};
+use crate::format::json::{JsonReader, JsonWriter};
+use crate::format::toml::{TomlReader, TomlWriter};
+use crate::format::yaml::{YamlReader, YamlWriter};
+use crate::format::{detect_format, Format, FormatOptions, FormatReader, FormatWriter};
+use crate::value::Value;
+
+pub struct MergeArgs<'a> {
+    pub input: &'a [PathBuf],
+    pub to: Option<&'a str>,
+    pub output: Option<&'a Path>,
+    pub delimiter: Option<char>,
+    pub no_header: bool,
+    pub pretty: bool,
+    pub compact: bool,
+    pub flow: bool,
+}
+
+/// merge 서브커맨드 실행
+pub fn run(args: &MergeArgs) -> Result<()> {
+    if args.input.len() < 2 {
+        bail!("merge requires at least 2 input files\n  Hint: dkit merge file1.json file2.json --to json");
+    }
+
+    // 각 파일을 Value로 읽기
+    let read_options = FormatOptions {
+        delimiter: args.delimiter,
+        no_header: args.no_header,
+        ..Default::default()
+    };
+
+    let mut values = Vec::with_capacity(args.input.len());
+    for path in args.input {
+        let format = detect_format(path)?;
+        let content = read_file(path)?;
+        let value = read_value(&content, format, &read_options)?;
+        values.push(value);
+    }
+
+    // 값 합치기
+    let merged = merge_values(values)?;
+
+    // 출력 포맷 결정: --to > 출력 파일 확장자 > 첫 번째 입력 파일 확장자
+    let target_format = match args.to {
+        Some(f) => Format::from_str(f)?,
+        None => match args.output {
+            Some(p) => detect_format(p).unwrap_or_else(|_| detect_format(&args.input[0]).unwrap()),
+            None => detect_format(&args.input[0])?,
+        },
+    };
+
+    let write_options = FormatOptions {
+        delimiter: args.delimiter,
+        no_header: args.no_header,
+        pretty: if args.compact {
+            false
+        } else {
+            args.pretty || !args.compact
+        },
+        compact: args.compact,
+        flow_style: args.flow,
+    };
+
+    let result = write_value(&merged, target_format, &write_options)?;
+
+    if let Some(out_path) = args.output {
+        if let Some(parent) = out_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+            }
+        }
+        fs::write(out_path, &result)
+            .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+    } else {
+        print!("{result}");
+    }
+
+    Ok(())
+}
+
+/// 여러 Value를 하나로 합치기
+/// - 모두 배열: 배열을 concat
+/// - 모두 오브젝트: 키를 merge (뒤 파일이 우선)
+/// - 혼합: 모든 값을 하나의 배열로 합치기
+fn merge_values(values: Vec<Value>) -> Result<Value> {
+    if values.is_empty() {
+        return Ok(Value::Array(vec![]));
+    }
+
+    let all_arrays = values.iter().all(|v| matches!(v, Value::Array(_)));
+    let all_objects = values.iter().all(|v| matches!(v, Value::Object(_)));
+
+    if all_arrays {
+        // 배열 concat
+        let mut merged = Vec::new();
+        for v in values {
+            if let Value::Array(arr) = v {
+                merged.extend(arr);
+            }
+        }
+        Ok(Value::Array(merged))
+    } else if all_objects {
+        // 오브젝트 merge (뒤 파일이 우선)
+        let mut merged = indexmap::IndexMap::new();
+        for v in values {
+            if let Value::Object(map) = v {
+                for (k, val) in map {
+                    merged.insert(k, val);
+                }
+            }
+        }
+        Ok(Value::Object(merged))
+    } else {
+        // 혼합: 배열은 펼치고 나머지는 그대로 추가
+        let mut merged = Vec::new();
+        for v in values {
+            match v {
+                Value::Array(arr) => merged.extend(arr),
+                other => merged.push(other),
+            }
+        }
+        Ok(Value::Array(merged))
+    }
+}
+
+fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
+    match format {
+        Format::Json => JsonReader.read(content),
+        Format::Csv => CsvReader::new(options.clone()).read(content),
+        Format::Yaml => YamlReader.read(content),
+        Format::Toml => TomlReader.read(content),
+    }
+}
+
+fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result<String> {
+    match format {
+        Format::Json => JsonWriter::new(options.clone()).write(value),
+        Format::Csv => CsvWriter::new(options.clone()).write(value),
+        Format::Yaml => YamlWriter::new(options.clone()).write(value),
+        Format::Toml => TomlWriter::new(options.clone()).write(value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_arrays() {
+        let values = vec![
+            Value::Array(vec![Value::Integer(1), Value::Integer(2)]),
+            Value::Array(vec![Value::Integer(3), Value::Integer(4)]),
+        ];
+        let result = merge_values(values).unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::Integer(1),
+                Value::Integer(2),
+                Value::Integer(3),
+                Value::Integer(4),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_merge_objects() {
+        let mut map1 = indexmap::IndexMap::new();
+        map1.insert("a".to_string(), Value::Integer(1));
+        map1.insert("b".to_string(), Value::Integer(2));
+
+        let mut map2 = indexmap::IndexMap::new();
+        map2.insert("b".to_string(), Value::Integer(99));
+        map2.insert("c".to_string(), Value::Integer(3));
+
+        let values = vec![Value::Object(map1), Value::Object(map2)];
+        let result = merge_values(values).unwrap();
+
+        if let Value::Object(map) = result {
+            assert_eq!(map.get("a"), Some(&Value::Integer(1)));
+            assert_eq!(map.get("b"), Some(&Value::Integer(99))); // 뒤 파일 우선
+            assert_eq!(map.get("c"), Some(&Value::Integer(3)));
+        } else {
+            panic!("Expected Object");
+        }
+    }
+
+    #[test]
+    fn test_merge_mixed() {
+        let mut map = indexmap::IndexMap::new();
+        map.insert("key".to_string(), Value::String("val".to_string()));
+
+        let values = vec![
+            Value::Array(vec![Value::Integer(1)]),
+            Value::Object(map.clone()),
+        ];
+        let result = merge_values(values).unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![Value::Integer(1), Value::Object(map)])
+        );
+    }
+
+    #[test]
+    fn test_merge_empty() {
+        let result = merge_values(vec![]).unwrap();
+        assert_eq!(result, Value::Array(vec![]));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod convert;
+pub mod merge;
 pub mod query;
 pub mod schema;
 pub mod stats;

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,27 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                 no_header,
             })?;
         }
+        Commands::Merge {
+            input,
+            to,
+            output,
+            delimiter,
+            pretty,
+            compact,
+            no_header,
+            flow,
+        } => {
+            commands::merge::run(&commands::merge::MergeArgs {
+                input: &input,
+                to: to.as_deref(),
+                output: output.as_deref(),
+                delimiter,
+                no_header,
+                pretty,
+                compact,
+                flow,
+            })?;
+        }
         Commands::Schema { input, from } => {
             commands::schema::run(&commands::schema::SchemaArgs {
                 input: &input,

--- a/tests/fixtures/config2.yaml
+++ b/tests/fixtures/config2.yaml
@@ -1,0 +1,6 @@
+logging:
+  level: info
+  file: app.log
+server:
+  port: 9090
+  debug: false

--- a/tests/fixtures/users2.csv
+++ b/tests/fixtures/users2.csv
@@ -1,0 +1,3 @@
+name,age,email
+Charlie,35,charlie@example.com
+Diana,28,diana@example.com

--- a/tests/fixtures/users2.json
+++ b/tests/fixtures/users2.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Charlie", "age": 35, "email": "charlie@example.com"},
+  {"name": "Diana", "age": 28, "email": "diana@example.com"}
+]

--- a/tests/merge_test.rs
+++ b/tests/merge_test.rs
@@ -1,0 +1,168 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// --- 배열 합치기 (concat) ---
+
+#[test]
+fn merge_json_arrays() {
+    dkit()
+        .args(&[
+            "merge",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users2.json",
+            "--to",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"))
+        .stdout(predicate::str::contains("Charlie"))
+        .stdout(predicate::str::contains("Diana"));
+}
+
+#[test]
+fn merge_csv_files() {
+    dkit()
+        .args(&[
+            "merge",
+            "tests/fixtures/users.csv",
+            "tests/fixtures/users2.csv",
+            "--to",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Charlie"));
+}
+
+// --- 오브젝트 합치기 (merge) ---
+
+#[test]
+fn merge_yaml_objects() {
+    dkit()
+        .args(&[
+            "merge",
+            "tests/fixtures/config.yaml",
+            "tests/fixtures/config2.yaml",
+            "--to",
+            "yaml",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("database"))
+        .stdout(predicate::str::contains("logging"))
+        // server.port는 config2의 9090으로 덮어쓰기
+        .stdout(predicate::str::contains("9090"));
+}
+
+// --- 다른 포맷 간 합치기 ---
+
+#[test]
+fn merge_different_formats() {
+    dkit()
+        .args(&[
+            "merge",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users2.csv",
+            "--to",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Charlie"));
+}
+
+// --- 출력 파일 지정 ---
+
+#[test]
+fn merge_to_output_file() {
+    let tmp = TempDir::new().unwrap();
+    let out_path = tmp.path().join("merged.json");
+
+    dkit()
+        .args(&[
+            "merge",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users2.json",
+            "--to",
+            "json",
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out_path).unwrap();
+    assert!(content.contains("Alice"));
+    assert!(content.contains("Diana"));
+}
+
+// --- 에러 케이스 ---
+
+#[test]
+fn merge_single_file_error() {
+    dkit()
+        .args(&["merge", "tests/fixtures/users.json", "--to", "json"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("at least 2"));
+}
+
+#[test]
+fn merge_nonexistent_file_error() {
+    dkit()
+        .args(&[
+            "merge",
+            "tests/fixtures/users.json",
+            "tests/fixtures/nonexistent.json",
+            "--to",
+            "json",
+        ])
+        .assert()
+        .failure();
+}
+
+// --- 포맷 자동 감지 ---
+
+#[test]
+fn merge_auto_detect_output_format() {
+    // --to 없이 첫 번째 입력 파일의 포맷을 사용
+    dkit()
+        .args(&[
+            "merge",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users2.json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Charlie"));
+}
+
+// --- 출력 포맷 변환 ---
+
+#[test]
+fn merge_json_to_csv() {
+    dkit()
+        .args(&[
+            "merge",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users2.json",
+            "--to",
+            "csv",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Diana"));
+}


### PR DESCRIPTION
## Summary

- Implement `dkit merge` subcommand that combines multiple data files into one
- Support array concatenation, object key merging, and mixed-type flattening
- Support cross-format merging (e.g., JSON + CSV)
- Add unit tests and 9 integration tests covering all merge scenarios

Closes #21

## Test plan

- [x] Unit tests for merge logic (arrays, objects, mixed, empty)
- [x] Integration tests: same-format array merge (JSON, CSV)
- [x] Integration tests: object merge with key override (YAML)
- [x] Integration tests: cross-format merge
- [x] Integration tests: output file writing
- [x] Integration tests: error cases (single file, nonexistent file)
- [x] Integration tests: auto-detect output format
- [x] Integration tests: format conversion on merge output
- [x] All 336 tests pass, clippy clean, fmt check pass

https://claude.ai/code/session_017gnWLZBCT2PbDiFq3cFm4H