### PR TITLE
feat: implement where clause with comparison operators

### DIFF
--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -10,6 +10,7 @@ use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
 use crate::format::{detect_format, Format, FormatOptions, FormatReader, FormatWriter};
 use crate::query::evaluator::evaluate_path;
+use crate::query::filter::apply_operations;
 use crate::query::parser::parse_query;
 use crate::value::Value;
 
@@ -50,7 +51,8 @@ pub fn run(args: &QueryArgs) -> Result<()> {
 
     // 쿼리 파싱 및 실행
     let query = parse_query(args.query)?;
-    let result = evaluate_path(&value, &query.path)?;
+    let path_result = evaluate_path(&value, &query.path)?;
+    let result = apply_operations(path_result, &query.operations)?;
 
     // 출력 포맷 결정: -o 파일 확장자 → --to → 기본 JSON
     let output_format = match args.to {

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -1,1 +1,402 @@
-// Query filter (where/sort/limit) — to be implemented
+use crate::error::DkitError;
+use crate::query::parser::{CompareOp, Comparison, Condition, LiteralValue, Operation};
+use crate::value::Value;
+
+/// 연산 목록을 순차적으로 적용
+pub fn apply_operations(value: Value, operations: &[Operation]) -> Result<Value, DkitError> {
+    let mut current = value;
+    for op in operations {
+        current = apply_operation(current, op)?;
+    }
+    Ok(current)
+}
+
+/// 단일 연산 적용
+fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitError> {
+    match operation {
+        Operation::Where(condition) => apply_where(value, condition),
+    }
+}
+
+/// where 절: 배열의 각 요소에 대해 조건을 평가하고 필터링
+fn apply_where(value: Value, condition: &Condition) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let filtered: Vec<Value> = arr
+                .into_iter()
+                .filter(|item| evaluate_condition(item, condition).unwrap_or(false))
+                .collect();
+            Ok(Value::Array(filtered))
+        }
+        _ => Err(DkitError::QueryError(
+            "where clause requires an array input".to_string(),
+        )),
+    }
+}
+
+/// 조건식 평가
+fn evaluate_condition(value: &Value, condition: &Condition) -> Result<bool, DkitError> {
+    match condition {
+        Condition::Comparison(cmp) => evaluate_comparison(value, cmp),
+    }
+}
+
+/// 비교식 평가: value의 필드를 리터럴과 비교
+fn evaluate_comparison(value: &Value, cmp: &Comparison) -> Result<bool, DkitError> {
+    let field_value = match value {
+        Value::Object(map) => match map.get(&cmp.field) {
+            Some(v) => v,
+            None => return Ok(false),
+        },
+        _ => return Ok(false),
+    };
+
+    compare_values(field_value, &cmp.op, &cmp.value)
+}
+
+/// Value와 LiteralValue를 비교
+fn compare_values(
+    field: &Value,
+    op: &CompareOp,
+    literal: &LiteralValue,
+) -> Result<bool, DkitError> {
+    match (field, literal) {
+        // 정수 비교
+        (Value::Integer(a), LiteralValue::Integer(b)) => Ok(apply_compare_op(*a, op, *b)),
+        // 정수 필드 vs 부동소수점 리터럴
+        (Value::Integer(a), LiteralValue::Float(b)) => Ok(apply_compare_op(*a as f64, op, *b)),
+        // 부동소수점 비교
+        (Value::Float(a), LiteralValue::Float(b)) => Ok(apply_compare_op(*a, op, *b)),
+        // 부동소수점 필드 vs 정수 리터럴
+        (Value::Float(a), LiteralValue::Integer(b)) => Ok(apply_compare_op(*a, op, *b as f64)),
+        // 문자열 비교
+        (Value::String(a), LiteralValue::String(b)) => {
+            Ok(apply_compare_op(a.as_str(), op, b.as_str()))
+        }
+        // 불리언: == 와 != 만 지원
+        (Value::Bool(a), LiteralValue::Bool(b)) => match op {
+            CompareOp::Eq => Ok(a == b),
+            CompareOp::Ne => Ok(a != b),
+            _ => Err(DkitError::QueryError(
+                "boolean values only support == and != operators".to_string(),
+            )),
+        },
+        // null 비교: == 와 != 만 지원
+        (Value::Null, LiteralValue::Null) => match op {
+            CompareOp::Eq => Ok(true),
+            CompareOp::Ne => Ok(false),
+            _ => Err(DkitError::QueryError(
+                "null values only support == and != operators".to_string(),
+            )),
+        },
+        // null vs non-null
+        (Value::Null, _) => match op {
+            CompareOp::Eq => Ok(false),
+            CompareOp::Ne => Ok(true),
+            _ => Ok(false),
+        },
+        // 타입 불일치: false 반환 (== 에서는 false, != 에서는 true)
+        (_, _) => match op {
+            CompareOp::Eq => Ok(false),
+            CompareOp::Ne => Ok(true),
+            _ => Ok(false),
+        },
+    }
+}
+
+/// 비교 연산자 적용 (PartialOrd를 구현하는 타입에 대해)
+fn apply_compare_op<T: PartialOrd>(a: T, op: &CompareOp, b: T) -> bool {
+    match op {
+        CompareOp::Eq => a == b,
+        CompareOp::Ne => a != b,
+        CompareOp::Gt => a > b,
+        CompareOp::Lt => a < b,
+        CompareOp::Ge => a >= b,
+        CompareOp::Le => a <= b,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::parser::parse_query;
+    use indexmap::IndexMap;
+
+    fn sample_users() -> Value {
+        let users = vec![
+            {
+                let mut u = IndexMap::new();
+                u.insert("name".to_string(), Value::String("Alice".to_string()));
+                u.insert("age".to_string(), Value::Integer(30));
+                u.insert("city".to_string(), Value::String("Seoul".to_string()));
+                Value::Object(u)
+            },
+            {
+                let mut u = IndexMap::new();
+                u.insert("name".to_string(), Value::String("Bob".to_string()));
+                u.insert("age".to_string(), Value::Integer(25));
+                u.insert("city".to_string(), Value::String("Busan".to_string()));
+                Value::Object(u)
+            },
+            {
+                let mut u = IndexMap::new();
+                u.insert("name".to_string(), Value::String("Charlie".to_string()));
+                u.insert("age".to_string(), Value::Integer(35));
+                u.insert("city".to_string(), Value::String("Seoul".to_string()));
+                Value::Object(u)
+            },
+        ];
+        Value::Array(users)
+    }
+
+    fn run_where(data: &Value, condition: &Condition) -> Result<Value, DkitError> {
+        apply_where(data.clone(), condition)
+    }
+
+    fn make_condition(field: &str, op: CompareOp, value: LiteralValue) -> Condition {
+        Condition::Comparison(Comparison {
+            field: field.to_string(),
+            op,
+            value,
+        })
+    }
+
+    // --- where 기본 동작 ---
+
+    #[test]
+    fn test_where_eq_integer() {
+        let data = sample_users();
+        let cond = make_condition("age", CompareOp::Eq, LiteralValue::Integer(30));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_where_ne_integer() {
+        let data = sample_users();
+        let cond = make_condition("age", CompareOp::Ne, LiteralValue::Integer(30));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_where_gt_integer() {
+        let data = sample_users();
+        let cond = make_condition("age", CompareOp::Gt, LiteralValue::Integer(28));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // Alice(30), Charlie(35)
+    }
+
+    #[test]
+    fn test_where_lt_integer() {
+        let data = sample_users();
+        let cond = make_condition("age", CompareOp::Lt, LiteralValue::Integer(30));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1); // Bob(25)
+    }
+
+    #[test]
+    fn test_where_ge_integer() {
+        let data = sample_users();
+        let cond = make_condition("age", CompareOp::Ge, LiteralValue::Integer(30));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // Alice(30), Charlie(35)
+    }
+
+    #[test]
+    fn test_where_le_integer() {
+        let data = sample_users();
+        let cond = make_condition("age", CompareOp::Le, LiteralValue::Integer(30));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // Alice(30), Bob(25)
+    }
+
+    // --- 문자열 비교 ---
+
+    #[test]
+    fn test_where_eq_string() {
+        let data = sample_users();
+        let cond = make_condition(
+            "city",
+            CompareOp::Eq,
+            LiteralValue::String("Seoul".to_string()),
+        );
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // Alice, Charlie
+    }
+
+    #[test]
+    fn test_where_ne_string() {
+        let data = sample_users();
+        let cond = make_condition(
+            "city",
+            CompareOp::Ne,
+            LiteralValue::String("Seoul".to_string()),
+        );
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1); // Bob
+    }
+
+    // --- 필드 없는 경우 ---
+
+    #[test]
+    fn test_where_missing_field() {
+        let data = sample_users();
+        let cond = make_condition("nonexistent", CompareOp::Eq, LiteralValue::Integer(1));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // --- 빈 배열 ---
+
+    #[test]
+    fn test_where_empty_array() {
+        let data = Value::Array(vec![]);
+        let cond = make_condition("age", CompareOp::Gt, LiteralValue::Integer(0));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // --- 비배열에 대한 where 에러 ---
+
+    #[test]
+    fn test_where_on_non_array() {
+        let data = Value::Integer(42);
+        let cond = make_condition("age", CompareOp::Gt, LiteralValue::Integer(0));
+        let result = run_where(&data, &cond);
+        assert!(result.is_err());
+    }
+
+    // --- 불리언 비교 ---
+
+    #[test]
+    fn test_where_eq_bool() {
+        let data = Value::Array(vec![
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("active".to_string(), Value::Bool(true));
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("active".to_string(), Value::Bool(false));
+                m
+            }),
+        ]);
+        let cond = make_condition("active", CompareOp::Eq, LiteralValue::Bool(true));
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 1);
+    }
+
+    // --- null 비교 ---
+
+    #[test]
+    fn test_where_eq_null() {
+        let data = Value::Array(vec![
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("value".to_string(), Value::Null);
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("value".to_string(), Value::Integer(1));
+                m
+            }),
+        ]);
+        let cond = make_condition("value", CompareOp::Eq, LiteralValue::Null);
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 1);
+    }
+
+    // --- 부동소수점 비교 ---
+
+    #[test]
+    fn test_where_gt_float() {
+        let data = Value::Array(vec![
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("score".to_string(), Value::Float(3.14));
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("score".to_string(), Value::Float(2.71));
+                m
+            }),
+        ]);
+        let cond = make_condition("score", CompareOp::Gt, LiteralValue::Float(3.0));
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 1);
+    }
+
+    // --- 정수 필드 vs 부동소수점 리터럴 ---
+
+    #[test]
+    fn test_where_integer_field_float_literal() {
+        let data = sample_users();
+        let cond = make_condition("age", CompareOp::Gt, LiteralValue::Float(29.5));
+        let result = run_where(&data, &cond).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // Alice(30), Charlie(35)
+    }
+
+    // --- apply_operations 통합 테스트 ---
+
+    #[test]
+    fn test_apply_operations_where() {
+        let data = sample_users();
+        let query = parse_query(".[] | where age > 30").unwrap();
+
+        // 먼저 path 평가
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        // 그 다음 operations 적용
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Charlie".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_apply_operations_no_ops() {
+        let data = Value::Integer(42);
+        let result = apply_operations(data.clone(), &[]).unwrap();
+        assert_eq!(result, data);
+    }
+
+    // --- 타입 불일치 ---
+
+    #[test]
+    fn test_where_type_mismatch_returns_false() {
+        let data = sample_users();
+        // age는 Integer인데 String과 비교
+        let cond = make_condition("age", CompareOp::Eq, LiteralValue::String("30".to_string()));
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_where_type_mismatch_ne_returns_true() {
+        let data = sample_users();
+        let cond = make_condition("age", CompareOp::Ne, LiteralValue::String("30".to_string()));
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 3);
+    }
+}

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -5,6 +5,8 @@ use crate::error::DkitError;
 pub struct Query {
     /// 경로 접근 (`.users[0].name`)
     pub path: Path,
+    /// 파이프라인 연산 (`| where ...`)
+    pub operations: Vec<Operation>,
 }
 
 /// 경로: `.` + 세그먼트들
@@ -22,6 +24,49 @@ pub enum Segment {
     Index(i64),
     /// 배열 이터레이션 (`[]`)
     Iterate,
+}
+
+/// 파이프라인 연산
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operation {
+    /// `where` 필터링
+    Where(Condition),
+}
+
+/// 조건식 (where 절)
+#[derive(Debug, Clone, PartialEq)]
+pub enum Condition {
+    /// 단일 비교: `field op value`
+    Comparison(Comparison),
+}
+
+/// 비교식: `IDENTIFIER compare_op value`
+#[derive(Debug, Clone, PartialEq)]
+pub struct Comparison {
+    pub field: String,
+    pub op: CompareOp,
+    pub value: LiteralValue,
+}
+
+/// 비교 연산자
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompareOp {
+    Eq, // ==
+    Ne, // !=
+    Gt, // >
+    Lt, // <
+    Ge, // >=
+    Le, // <=
+}
+
+/// 리터럴 값 (비교 대상)
+#[derive(Debug, Clone, PartialEq)]
+pub enum LiteralValue {
+    String(String),
+    Integer(i64),
+    Float(f64),
+    Bool(bool),
+    Null,
 }
 
 /// 쿼리 문자열을 파싱하는 파서
@@ -44,6 +89,15 @@ impl Parser {
         let path = self.parse_path()?;
         self.skip_whitespace();
 
+        // 파이프라인 연산 파싱: `| where ...`
+        let mut operations = Vec::new();
+        while self.peek() == Some('|') {
+            self.advance(); // consume '|'
+            self.skip_whitespace();
+            operations.push(self.parse_operation()?);
+            self.skip_whitespace();
+        }
+
         if self.pos != self.input.len() {
             return Err(DkitError::QueryError(format!(
                 "unexpected character '{}' at position {}",
@@ -51,7 +105,7 @@ impl Parser {
             )));
         }
 
-        Ok(Query { path })
+        Ok(Query { path, operations })
     }
 
     /// 경로를 파싱: `.` 으로 시작
@@ -163,6 +217,237 @@ impl Parser {
         }
 
         Ok(Segment::Index(if negative { -index } else { index }))
+    }
+
+    // --- 파이프라인 연산 파싱 ---
+
+    /// 연산 파싱: `where ...`
+    fn parse_operation(&mut self) -> Result<Operation, DkitError> {
+        let keyword = self.parse_keyword()?;
+        match keyword.as_str() {
+            "where" => {
+                self.skip_whitespace();
+                let condition = self.parse_condition()?;
+                Ok(Operation::Where(condition))
+            }
+            _ => Err(DkitError::QueryError(format!(
+                "unknown operation '{}' at position {}",
+                keyword,
+                self.pos - keyword.len()
+            ))),
+        }
+    }
+
+    /// 키워드 파싱 (알파벳 + 언더스코어)
+    fn parse_keyword(&mut self) -> Result<String, DkitError> {
+        let start = self.pos;
+        while !self.is_at_end() {
+            let c = self.input[self.pos];
+            if c.is_alphabetic() || c == '_' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.pos == start {
+            return Err(DkitError::QueryError(format!(
+                "expected operation keyword at position {}",
+                self.pos
+            )));
+        }
+        Ok(self.input[start..self.pos].iter().collect())
+    }
+
+    /// 조건식 파싱: `field op value`
+    fn parse_condition(&mut self) -> Result<Condition, DkitError> {
+        let comparison = self.parse_comparison()?;
+        Ok(Condition::Comparison(comparison))
+    }
+
+    /// 비교식 파싱: `IDENTIFIER compare_op literal_value`
+    fn parse_comparison(&mut self) -> Result<Comparison, DkitError> {
+        // 필드 이름
+        let field = self.parse_identifier()?;
+        self.skip_whitespace();
+
+        // 비교 연산자
+        let op = self.parse_compare_op()?;
+        self.skip_whitespace();
+
+        // 리터럴 값
+        let value = self.parse_literal_value()?;
+
+        Ok(Comparison { field, op, value })
+    }
+
+    /// 식별자 파싱 (필드 이름)
+    fn parse_identifier(&mut self) -> Result<String, DkitError> {
+        let start = self.pos;
+        while !self.is_at_end() {
+            let c = self.input[self.pos];
+            if c.is_alphanumeric() || c == '_' || c == '-' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.pos == start {
+            return Err(DkitError::QueryError(format!(
+                "expected field name at position {}",
+                self.pos
+            )));
+        }
+        Ok(self.input[start..self.pos].iter().collect())
+    }
+
+    /// 비교 연산자 파싱: ==, !=, >=, <=, >, <
+    fn parse_compare_op(&mut self) -> Result<CompareOp, DkitError> {
+        let c1 = self.peek().ok_or_else(|| {
+            DkitError::QueryError(format!(
+                "expected comparison operator at position {}",
+                self.pos
+            ))
+        })?;
+
+        match c1 {
+            '=' => {
+                self.advance();
+                if self.consume_char('=') {
+                    Ok(CompareOp::Eq)
+                } else {
+                    Err(DkitError::QueryError(format!(
+                        "expected '==' at position {}",
+                        self.pos - 1
+                    )))
+                }
+            }
+            '!' => {
+                self.advance();
+                if self.consume_char('=') {
+                    Ok(CompareOp::Ne)
+                } else {
+                    Err(DkitError::QueryError(format!(
+                        "expected '!=' at position {}",
+                        self.pos - 1
+                    )))
+                }
+            }
+            '>' => {
+                self.advance();
+                if self.consume_char('=') {
+                    Ok(CompareOp::Ge)
+                } else {
+                    Ok(CompareOp::Gt)
+                }
+            }
+            '<' => {
+                self.advance();
+                if self.consume_char('=') {
+                    Ok(CompareOp::Le)
+                } else {
+                    Ok(CompareOp::Lt)
+                }
+            }
+            _ => Err(DkitError::QueryError(format!(
+                "expected comparison operator at position {}, found '{}'",
+                self.pos, c1
+            ))),
+        }
+    }
+
+    /// 리터럴 값 파싱: 문자열, 숫자, bool, null
+    fn parse_literal_value(&mut self) -> Result<LiteralValue, DkitError> {
+        match self.peek() {
+            Some('"') => self.parse_string_literal(),
+            Some(c) if c.is_ascii_digit() || c == '-' => self.parse_number_literal(),
+            Some(c) if c.is_alphabetic() => {
+                let word = self.parse_keyword()?;
+                match word.as_str() {
+                    "true" => Ok(LiteralValue::Bool(true)),
+                    "false" => Ok(LiteralValue::Bool(false)),
+                    "null" => Ok(LiteralValue::Null),
+                    _ => Err(DkitError::QueryError(format!(
+                        "unexpected value '{}' at position {}",
+                        word,
+                        self.pos - word.len()
+                    ))),
+                }
+            }
+            Some(c) => Err(DkitError::QueryError(format!(
+                "unexpected character '{}' at position {}",
+                c, self.pos
+            ))),
+            None => Err(DkitError::QueryError(format!(
+                "expected value at position {}",
+                self.pos
+            ))),
+        }
+    }
+
+    /// 문자열 리터럴 파싱: `"..."`
+    fn parse_string_literal(&mut self) -> Result<LiteralValue, DkitError> {
+        if !self.consume_char('"') {
+            return Err(DkitError::QueryError(format!(
+                "expected '\"' at position {}",
+                self.pos
+            )));
+        }
+        let start = self.pos;
+        while !self.is_at_end() && self.input[self.pos] != '"' {
+            self.pos += 1;
+        }
+        if self.is_at_end() {
+            return Err(DkitError::QueryError(format!(
+                "unterminated string starting at position {}",
+                start - 1
+            )));
+        }
+        let s: String = self.input[start..self.pos].iter().collect();
+        self.advance(); // consume closing '"'
+        Ok(LiteralValue::String(s))
+    }
+
+    /// 숫자 리터럴 파싱: 정수 또는 부동소수점
+    fn parse_number_literal(&mut self) -> Result<LiteralValue, DkitError> {
+        let start = self.pos;
+        if self.peek() == Some('-') {
+            self.advance();
+        }
+        while !self.is_at_end() && self.input[self.pos].is_ascii_digit() {
+            self.pos += 1;
+        }
+        let mut is_float = false;
+        if self.peek() == Some('.') {
+            is_float = true;
+            self.advance();
+            while !self.is_at_end() && self.input[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+        if self.pos == start || (self.pos == start + 1 && self.input[start] == '-') {
+            return Err(DkitError::QueryError(format!(
+                "expected number at position {}",
+                start
+            )));
+        }
+        let num_str: String = self.input[start..self.pos].iter().collect();
+        if is_float {
+            let f: f64 = num_str.parse().map_err(|_| {
+                DkitError::QueryError(format!(
+                    "invalid number '{}' at position {}",
+                    num_str, start
+                ))
+            })?;
+            Ok(LiteralValue::Float(f))
+        } else {
+            let n: i64 = num_str.parse().map_err(|_| {
+                DkitError::QueryError(format!(
+                    "invalid number '{}' at position {}",
+                    num_str, start
+                ))
+            })?;
+            Ok(LiteralValue::Integer(n))
+        }
     }
 
     // --- 유틸리티 ---
@@ -426,5 +711,173 @@ mod tests {
             q.path.segments,
             vec![Segment::Iterate, Segment::Field("name".to_string()),]
         );
+    }
+
+    // --- where 절 파싱 ---
+
+    #[test]
+    fn test_where_eq_integer() {
+        let q = parse_query(".users[] | where age == 30").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::Field("users".to_string()), Segment::Iterate]
+        );
+        assert_eq!(q.operations.len(), 1);
+        assert_eq!(
+            q.operations[0],
+            Operation::Where(Condition::Comparison(Comparison {
+                field: "age".to_string(),
+                op: CompareOp::Eq,
+                value: LiteralValue::Integer(30),
+            }))
+        );
+    }
+
+    #[test]
+    fn test_where_ne_string() {
+        let q = parse_query(".items[] | where status != \"inactive\"").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Where(Condition::Comparison(Comparison {
+                field: "status".to_string(),
+                op: CompareOp::Ne,
+                value: LiteralValue::String("inactive".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn test_where_gt() {
+        let q = parse_query(".[] | where age > 25").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.field, "age");
+                assert_eq!(cmp.op, CompareOp::Gt);
+                assert_eq!(cmp.value, LiteralValue::Integer(25));
+            }
+        }
+    }
+
+    #[test]
+    fn test_where_lt() {
+        let q = parse_query(".[] | where price < 100").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.op, CompareOp::Lt);
+                assert_eq!(cmp.value, LiteralValue::Integer(100));
+            }
+        }
+    }
+
+    #[test]
+    fn test_where_ge() {
+        let q = parse_query(".[] | where score >= 80").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.op, CompareOp::Ge);
+                assert_eq!(cmp.value, LiteralValue::Integer(80));
+            }
+        }
+    }
+
+    #[test]
+    fn test_where_le() {
+        let q = parse_query(".[] | where price <= 1000").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.op, CompareOp::Le);
+                assert_eq!(cmp.value, LiteralValue::Integer(1000));
+            }
+        }
+    }
+
+    #[test]
+    fn test_where_float_literal() {
+        let q = parse_query(".[] | where score > 3.14").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.value, LiteralValue::Float(3.14));
+            }
+        }
+    }
+
+    #[test]
+    fn test_where_negative_number() {
+        let q = parse_query(".[] | where temp > -10").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.value, LiteralValue::Integer(-10));
+            }
+        }
+    }
+
+    #[test]
+    fn test_where_bool_literal() {
+        let q = parse_query(".[] | where active == true").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.value, LiteralValue::Bool(true));
+            }
+        }
+    }
+
+    #[test]
+    fn test_where_null_literal() {
+        let q = parse_query(".[] | where value == null").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.value, LiteralValue::Null);
+            }
+        }
+    }
+
+    #[test]
+    fn test_where_no_operations_for_path_only() {
+        let q = parse_query(".users[0].name").unwrap();
+        assert!(q.operations.is_empty());
+    }
+
+    #[test]
+    fn test_where_with_extra_whitespace() {
+        let q = parse_query(".[]  |  where  age  >  30  ").unwrap();
+        match &q.operations[0] {
+            Operation::Where(Condition::Comparison(cmp)) => {
+                assert_eq!(cmp.field, "age");
+                assert_eq!(cmp.op, CompareOp::Gt);
+                assert_eq!(cmp.value, LiteralValue::Integer(30));
+            }
+        }
+    }
+
+    // --- where 파싱 에러 ---
+
+    #[test]
+    fn test_error_where_missing_field() {
+        let err = parse_query(".[] | where == 30").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    #[test]
+    fn test_error_where_missing_operator() {
+        let err = parse_query(".[] | where age 30").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    #[test]
+    fn test_error_where_missing_value() {
+        let err = parse_query(".[] | where age >").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    #[test]
+    fn test_error_where_unterminated_string() {
+        let err = parse_query(".[] | where name == \"hello").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    #[test]
+    fn test_error_unknown_operation() {
+        let err = parse_query(".[] | foobar age > 30").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
     }
 }


### PR DESCRIPTION
## Summary
- 쿼리 엔진에 `where` 절 파싱 및 실행 기능 추가
- 파이프라인(`|`) 파싱 지원으로 `path | where condition` 구조 가능
- 비교 연산자 6종 지원: `==`, `!=`, `>`, `<`, `>=`, `<=`
- 리터럴 값: 문자열, 정수, 부동소수점, boolean, null

## Test plan
- [x] 파서 단위 테스트 17개 (where 절 파싱, 각 연산자, 리터럴 타입, 에러 케이스)
- [x] 필터 단위 테스트 19개 (각 연산자 실행, 타입 비교, 에지 케이스)
- [x] 기존 테스트 272개 전체 통과
- [x] clippy, fmt 통과

Closes #45

https://claude.ai/code/session_019vCo7cWHGFfwE1NqWEs2os