### PR TITLE
Implement query select clause for column selection

### DIFF
--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -15,6 +15,7 @@ pub fn apply_operations(value: Value, operations: &[Operation]) -> Result<Value,
 fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitError> {
     match operation {
         Operation::Where(condition) => apply_where(value, condition),
+        Operation::Select(fields) => apply_select(value, fields),
     }
 }
 
@@ -31,6 +32,39 @@ fn apply_where(value: Value, condition: &Condition) -> Result<Value, DkitError> 
         _ => Err(DkitError::QueryError(
             "where clause requires an array input".to_string(),
         )),
+    }
+}
+
+/// select 절: 배열의 각 요소에서 지정된 필드만 추출
+fn apply_select(value: Value, fields: &[String]) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let projected: Vec<Value> = arr
+                .into_iter()
+                .map(|item| select_fields(item, fields))
+                .collect();
+            Ok(Value::Array(projected))
+        }
+        Value::Object(_) => Ok(select_fields(value, fields)),
+        _ => Err(DkitError::QueryError(
+            "select clause requires an array or object input".to_string(),
+        )),
+    }
+}
+
+/// 오브젝트에서 지정된 필드만 추출
+fn select_fields(value: Value, fields: &[String]) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut new_map = indexmap::IndexMap::new();
+            for field in fields {
+                if let Some(v) = map.get(field) {
+                    new_map.insert(field.clone(), v.clone());
+                }
+            }
+            Value::Object(new_map)
+        }
+        _ => value,
     }
 }
 
@@ -584,5 +618,129 @@ mod tests {
         let result = apply_operations(path_result, &query.operations).unwrap();
         let arr = result.as_array().unwrap();
         assert_eq!(arr.len(), 2); // Bob(25), Charlie(35)
+    }
+
+    // --- select 절 ---
+
+    #[test]
+    fn test_select_single_field() {
+        let data = sample_users();
+        let result = apply_select(data, &["name".to_string()]).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // 각 요소에 name만 있어야 함
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.len(), 1);
+            assert!(obj.contains_key("name"));
+        }
+    }
+
+    #[test]
+    fn test_select_multiple_fields() {
+        let data = sample_users();
+        let result = apply_select(data, &["name".to_string(), "age".to_string()]).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.len(), 2);
+            assert!(obj.contains_key("name"));
+            assert!(obj.contains_key("age"));
+        }
+    }
+
+    #[test]
+    fn test_select_preserves_order() {
+        let data = sample_users();
+        let result = apply_select(data, &["city".to_string(), "name".to_string()]).unwrap();
+        let arr = result.as_array().unwrap();
+        let obj = arr[0].as_object().unwrap();
+        let keys: Vec<&String> = obj.keys().collect();
+        assert_eq!(keys, vec!["city", "name"]);
+    }
+
+    #[test]
+    fn test_select_missing_field_skipped() {
+        let data = sample_users();
+        let result = apply_select(data, &["name".to_string(), "nonexistent".to_string()]).unwrap();
+        let arr = result.as_array().unwrap();
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.len(), 1);
+            assert!(obj.contains_key("name"));
+        }
+    }
+
+    #[test]
+    fn test_select_on_single_object() {
+        let mut m = IndexMap::new();
+        m.insert("name".to_string(), Value::String("Alice".to_string()));
+        m.insert("age".to_string(), Value::Integer(30));
+        m.insert("city".to_string(), Value::String("Seoul".to_string()));
+        let data = Value::Object(m);
+
+        let result = apply_select(data, &["name".to_string(), "city".to_string()]).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("name"));
+        assert!(obj.contains_key("city"));
+    }
+
+    #[test]
+    fn test_select_on_non_object_array() {
+        // 배열 안에 비-오브젝트 요소는 그대로 반환
+        let data = Value::Array(vec![Value::Integer(1), Value::Integer(2)]);
+        let result = apply_select(data, &["name".to_string()]).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0], Value::Integer(1));
+    }
+
+    #[test]
+    fn test_select_on_non_array_non_object_error() {
+        let data = Value::Integer(42);
+        let result = apply_select(data, &["name".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_select_empty_array() {
+        let data = Value::Array(vec![]);
+        let result = apply_select(data, &["name".to_string()]).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    // --- 통합: where + select ---
+
+    #[test]
+    fn test_integration_where_then_select() {
+        let data = sample_users();
+        let query = parse_query(".[] | where age > 25 | select name, city").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // Alice(30), Charlie(35)
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.len(), 2);
+            assert!(obj.contains_key("name"));
+            assert!(obj.contains_key("city"));
+            assert!(!obj.contains_key("age"));
+        }
+    }
+
+    #[test]
+    fn test_integration_select_only() {
+        let data = sample_users();
+        let query = parse_query(".[] | select name").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.len(), 1);
+            assert!(obj.contains_key("name"));
+        }
     }
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -31,6 +31,8 @@ pub enum Segment {
 pub enum Operation {
     /// `where` 필터링
     Where(Condition),
+    /// `select` 컬럼 선택: `select name, email`
+    Select(Vec<String>),
 }
 
 /// 조건식 (where 절)
@@ -228,7 +230,7 @@ impl Parser {
 
     // --- 파이프라인 연산 파싱 ---
 
-    /// 연산 파싱: `where ...`
+    /// 연산 파싱: `where ...`, `select ...`
     fn parse_operation(&mut self) -> Result<Operation, DkitError> {
         let keyword = self.parse_keyword()?;
         match keyword.as_str() {
@@ -237,12 +239,32 @@ impl Parser {
                 let condition = self.parse_condition()?;
                 Ok(Operation::Where(condition))
             }
+            "select" => {
+                self.skip_whitespace();
+                let fields = self.parse_identifier_list()?;
+                Ok(Operation::Select(fields))
+            }
             _ => Err(DkitError::QueryError(format!(
                 "unknown operation '{}' at position {}",
                 keyword,
                 self.pos - keyword.len()
             ))),
         }
+    }
+
+    /// 쉼표로 구분된 식별자 목록 파싱: `IDENTIFIER ( "," IDENTIFIER )*`
+    fn parse_identifier_list(&mut self) -> Result<Vec<String>, DkitError> {
+        let mut fields = vec![self.parse_identifier()?];
+        loop {
+            self.skip_whitespace();
+            if self.consume_char(',') {
+                self.skip_whitespace();
+                fields.push(self.parse_identifier()?);
+            } else {
+                break;
+            }
+        }
+        Ok(fields)
     }
 
     /// 키워드 파싱 (알파벳 + 언더스코어)
@@ -962,7 +984,9 @@ mod tests {
     #[test]
     fn test_where_and() {
         let q = parse_query(".[] | where age > 25 and city == \"Seoul\"").unwrap();
-        let Operation::Where(cond) = &q.operations[0];
+        let Operation::Where(cond) = &q.operations[0] else {
+            panic!("expected Where operation");
+        };
         match cond {
             Condition::And(left, right) => {
                 let Condition::Comparison(l) = left.as_ref() else {
@@ -985,7 +1009,9 @@ mod tests {
     #[test]
     fn test_where_or() {
         let q = parse_query(".[] | where role == \"admin\" or role == \"manager\"").unwrap();
-        let Operation::Where(cond) = &q.operations[0];
+        let Operation::Where(cond) = &q.operations[0] else {
+            panic!("expected Where operation");
+        };
         match cond {
             Condition::Or(left, right) => {
                 let Condition::Comparison(l) = left.as_ref() else {
@@ -1006,14 +1032,18 @@ mod tests {
     #[test]
     fn test_where_and_with_string_op() {
         let q = parse_query(".[] | where name starts_with \"A\" and age > 20").unwrap();
-        let Operation::Where(cond) = &q.operations[0];
+        let Operation::Where(cond) = &q.operations[0] else {
+            panic!("expected Where operation");
+        };
         assert!(matches!(cond, Condition::And(_, _)));
     }
 
     #[test]
     fn test_where_chained_and() {
         let q = parse_query(".[] | where a == 1 and b == 2 and c == 3").unwrap();
-        let Operation::Where(cond) = &q.operations[0];
+        let Operation::Where(cond) = &q.operations[0] else {
+            panic!("expected Where operation");
+        };
         // Left-associative: ((a==1 and b==2) and c==3)
         match cond {
             Condition::And(left, right) => {
@@ -1022,5 +1052,80 @@ mod tests {
             }
             _ => panic!("expected And condition"),
         }
+    }
+
+    // --- select 절 파싱 ---
+
+    #[test]
+    fn test_select_single_field() {
+        let q = parse_query(".users[] | select name").unwrap();
+        assert_eq!(q.operations.len(), 1);
+        assert_eq!(q.operations[0], Operation::Select(vec!["name".to_string()]));
+    }
+
+    #[test]
+    fn test_select_multiple_fields() {
+        let q = parse_query(".users[] | select name, email").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec!["name".to_string(), "email".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_select_three_fields() {
+        let q = parse_query(".users[] | select name, age, email").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec![
+                "name".to_string(),
+                "age".to_string(),
+                "email".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_select_with_extra_whitespace() {
+        let q = parse_query(".[]  |  select  name ,  email  ").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec!["name".to_string(), "email".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_select_field_with_underscore() {
+        let q = parse_query(".[] | select user_name, created_at").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec!["user_name".to_string(), "created_at".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_select_field_with_hyphen() {
+        let q = parse_query(".[] | select content-type").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec!["content-type".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_where_then_select() {
+        let q = parse_query(".users[] | where age > 30 | select name, email").unwrap();
+        assert_eq!(q.operations.len(), 2);
+        assert!(matches!(&q.operations[0], Operation::Where(_)));
+        assert_eq!(
+            q.operations[1],
+            Operation::Select(vec!["name".to_string(), "email".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_error_select_missing_fields() {
+        let err = parse_query(".[] | select").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
     }
 }


### PR DESCRIPTION
## Summary
- Add `Select` variant to `Operation` enum in the query parser
- Implement `select` keyword parsing with comma-separated field list
- Implement `apply_select` executor that projects specified fields from objects
- Add comprehensive unit tests for parser and executor

## Test plan
- [x] Parser tests: single/multiple fields, whitespace handling, special characters, error cases
- [x] Executor tests: single/multiple fields, field ordering, missing fields, single objects, non-object arrays
- [x] Integration tests: where+select pipeline, select-only pipeline
- [x] All 307 tests pass, clippy clean, fmt clean

Closes #47

https://claude.ai/code/session_01L5Th5zQA5RxA8vMBQWoc7r