### PR TITLE
feat: implement sort/limit query operations

### DIFF
--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -16,6 +16,8 @@ fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitErr
     match operation {
         Operation::Where(condition) => apply_where(value, condition),
         Operation::Select(fields) => apply_select(value, fields),
+        Operation::Sort { field, descending } => apply_sort(value, field, *descending),
+        Operation::Limit(n) => apply_limit(value, *n),
     }
 }
 
@@ -48,6 +50,91 @@ fn apply_select(value: Value, fields: &[String]) -> Result<Value, DkitError> {
         Value::Object(_) => Ok(select_fields(value, fields)),
         _ => Err(DkitError::QueryError(
             "select clause requires an array or object input".to_string(),
+        )),
+    }
+}
+
+/// sort 절: 배열의 요소를 지정된 필드 기준으로 정렬
+fn apply_sort(value: Value, field: &str, descending: bool) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(mut arr) => {
+            arr.sort_by(|a, b| {
+                let va = extract_sort_key(a, field);
+                let vb = extract_sort_key(b, field);
+                let ord = compare_sort_keys(&va, &vb);
+                if descending {
+                    ord.reverse()
+                } else {
+                    ord
+                }
+            });
+            Ok(Value::Array(arr))
+        }
+        _ => Err(DkitError::QueryError(
+            "sort clause requires an array input".to_string(),
+        )),
+    }
+}
+
+/// 정렬용 키 값 추출
+fn extract_sort_key(value: &Value, field: &str) -> Option<Value> {
+    match value {
+        Value::Object(map) => map.get(field).cloned(),
+        _ => None,
+    }
+}
+
+/// 정렬 키 비교 (None은 항상 뒤로)
+fn compare_sort_keys(a: &Option<Value>, b: &Option<Value>) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(va), Some(vb)) => compare_value_ordering(va, vb),
+    }
+}
+
+/// Value 간 순서 비교
+fn compare_value_ordering(a: &Value, b: &Value) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (Value::Integer(x), Value::Integer(y)) => x.cmp(y),
+        (Value::Integer(x), Value::Float(y)) => {
+            (*x as f64).partial_cmp(y).unwrap_or(Ordering::Equal)
+        }
+        (Value::Float(x), Value::Integer(y)) => {
+            x.partial_cmp(&(*y as f64)).unwrap_or(Ordering::Equal)
+        }
+        (Value::Float(x), Value::Float(y)) => x.partial_cmp(y).unwrap_or(Ordering::Equal),
+        (Value::String(x), Value::String(y)) => x.cmp(y),
+        (Value::Bool(x), Value::Bool(y)) => x.cmp(y),
+        // 타입이 다른 경우 타입 순서로 정렬: Null < Bool < Integer/Float < String
+        _ => type_order(a).cmp(&type_order(b)),
+    }
+}
+
+/// 타입별 정렬 우선순위
+fn type_order(v: &Value) -> u8 {
+    match v {
+        Value::Null => 0,
+        Value::Bool(_) => 1,
+        Value::Integer(_) | Value::Float(_) => 2,
+        Value::String(_) => 3,
+        Value::Array(_) => 4,
+        Value::Object(_) => 5,
+    }
+}
+
+/// limit 절: 배열의 처음 N개 요소만 반환
+fn apply_limit(value: Value, n: usize) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let limited: Vec<Value> = arr.into_iter().take(n).collect();
+            Ok(Value::Array(limited))
+        }
+        _ => Err(DkitError::QueryError(
+            "limit clause requires an array input".to_string(),
         )),
     }
 }
@@ -742,5 +829,275 @@ mod tests {
             assert_eq!(obj.len(), 1);
             assert!(obj.contains_key("name"));
         }
+    }
+
+    // --- sort 절 ---
+
+    #[test]
+    fn test_sort_asc_integer() {
+        let data = sample_users();
+        let result = apply_sort(data, "age", false).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Bob".to_string()))
+        ); // 25
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        ); // 30
+        assert_eq!(
+            arr[2].as_object().unwrap().get("name"),
+            Some(&Value::String("Charlie".to_string()))
+        ); // 35
+    }
+
+    #[test]
+    fn test_sort_desc_integer() {
+        let data = sample_users();
+        let result = apply_sort(data, "age", true).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Charlie".to_string()))
+        ); // 35
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        ); // 30
+        assert_eq!(
+            arr[2].as_object().unwrap().get("name"),
+            Some(&Value::String("Bob".to_string()))
+        ); // 25
+    }
+
+    #[test]
+    fn test_sort_asc_string() {
+        let data = sample_users();
+        let result = apply_sort(data, "name", false).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Bob".to_string()))
+        );
+        assert_eq!(
+            arr[2].as_object().unwrap().get("name"),
+            Some(&Value::String("Charlie".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_sort_desc_string() {
+        let data = sample_users();
+        let result = apply_sort(data, "name", true).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Charlie".to_string()))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Bob".to_string()))
+        );
+        assert_eq!(
+            arr[2].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_sort_missing_field() {
+        // 일부 요소에 필드가 없으면 뒤로 정렬
+        let data = Value::Array(vec![
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Alice".to_string()));
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("age".to_string(), Value::Integer(25));
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Bob".to_string()));
+                m.insert("age".to_string(), Value::Integer(30));
+                m
+            }),
+        ]);
+        let result = apply_sort(data, "age", false).unwrap();
+        let arr = result.as_array().unwrap();
+        // Alice has no age → goes to end
+        assert_eq!(
+            arr[0].as_object().unwrap().get("age"),
+            Some(&Value::Integer(25))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("age"),
+            Some(&Value::Integer(30))
+        );
+        assert_eq!(arr[2].as_object().unwrap().get("age"), None);
+    }
+
+    #[test]
+    fn test_sort_empty_array() {
+        let data = Value::Array(vec![]);
+        let result = apply_sort(data, "age", false).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_sort_on_non_array() {
+        let data = Value::Integer(42);
+        let result = apply_sort(data, "age", false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sort_float() {
+        let data = Value::Array(vec![
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("score".to_string(), Value::Float(3.14));
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("score".to_string(), Value::Float(1.41));
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("score".to_string(), Value::Float(2.71));
+                m
+            }),
+        ]);
+        let result = apply_sort(data, "score", false).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0].as_object().unwrap().get("score"),
+            Some(&Value::Float(1.41))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("score"),
+            Some(&Value::Float(2.71))
+        );
+        assert_eq!(
+            arr[2].as_object().unwrap().get("score"),
+            Some(&Value::Float(3.14))
+        );
+    }
+
+    // --- limit 절 ---
+
+    #[test]
+    fn test_limit_basic() {
+        let data = sample_users();
+        let result = apply_limit(data, 2).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Bob".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_limit_larger_than_array() {
+        let data = sample_users();
+        let result = apply_limit(data, 100).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_limit_zero() {
+        let data = sample_users();
+        let result = apply_limit(data, 0).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_limit_one() {
+        let data = sample_users();
+        let result = apply_limit(data, 1).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn test_limit_empty_array() {
+        let data = Value::Array(vec![]);
+        let result = apply_limit(data, 5).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_limit_on_non_array() {
+        let data = Value::Integer(42);
+        let result = apply_limit(data, 5);
+        assert!(result.is_err());
+    }
+
+    // --- 통합: sort + limit ---
+
+    #[test]
+    fn test_integration_sort_then_limit() {
+        let data = sample_users();
+        let query = parse_query(".[] | sort age desc | limit 2").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Charlie".to_string()))
+        ); // 35
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        ); // 30
+    }
+
+    #[test]
+    fn test_integration_where_sort_limit() {
+        let data = sample_users();
+        let query = parse_query(".[] | where city == \"Seoul\" | sort age | limit 1").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        ); // Alice(30, Seoul) is younger than Charlie(35, Seoul)
+    }
+
+    #[test]
+    fn test_integration_where_select_sort() {
+        let data = sample_users();
+        let query = parse_query(".[] | where age > 25 | select name, age | sort name").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Charlie".to_string()))
+        );
     }
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -33,6 +33,10 @@ pub enum Operation {
     Where(Condition),
     /// `select` 컬럼 선택: `select name, email`
     Select(Vec<String>),
+    /// `sort` 정렬: `sort age` (오름차순) / `sort age desc` (내림차순)
+    Sort { field: String, descending: bool },
+    /// `limit` 결과 제한: `limit 10`
+    Limit(usize),
 }
 
 /// 조건식 (where 절)
@@ -243,6 +247,18 @@ impl Parser {
                 self.skip_whitespace();
                 let fields = self.parse_identifier_list()?;
                 Ok(Operation::Select(fields))
+            }
+            "sort" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                self.skip_whitespace();
+                let descending = self.try_consume_keyword("desc");
+                Ok(Operation::Sort { field, descending })
+            }
+            "limit" => {
+                self.skip_whitespace();
+                let n = self.parse_positive_integer()?;
+                Ok(Operation::Limit(n))
             }
             _ => Err(DkitError::QueryError(format!(
                 "unknown operation '{}' at position {}",
@@ -553,6 +569,39 @@ impl Parser {
 
     fn is_at_end(&self) -> bool {
         self.pos >= self.input.len()
+    }
+
+    /// 키워드를 시도적으로 소비: 매치하면 true, 아니면 위치를 복원하고 false
+    fn try_consume_keyword(&mut self, keyword: &str) -> bool {
+        let saved_pos = self.pos;
+        if let Ok(word) = self.parse_keyword() {
+            if word == keyword {
+                return true;
+            }
+        }
+        self.pos = saved_pos;
+        false
+    }
+
+    /// 양의 정수 파싱 (limit 절용)
+    fn parse_positive_integer(&mut self) -> Result<usize, DkitError> {
+        let start = self.pos;
+        while !self.is_at_end() && self.input[self.pos].is_ascii_digit() {
+            self.pos += 1;
+        }
+        if self.pos == start {
+            return Err(DkitError::QueryError(format!(
+                "expected positive integer at position {}",
+                self.pos
+            )));
+        }
+        let num_str: String = self.input[start..self.pos].iter().collect();
+        num_str.parse().map_err(|_| {
+            DkitError::QueryError(format!(
+                "invalid integer '{}' at position {}",
+                num_str, start
+            ))
+        })
     }
 }
 
@@ -1127,5 +1176,143 @@ mod tests {
     fn test_error_select_missing_fields() {
         let err = parse_query(".[] | select").unwrap_err();
         assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    // --- sort 절 파싱 ---
+
+    #[test]
+    fn test_sort_asc() {
+        let q = parse_query(".users[] | sort age").unwrap();
+        assert_eq!(q.operations.len(), 1);
+        assert_eq!(
+            q.operations[0],
+            Operation::Sort {
+                field: "age".to_string(),
+                descending: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_sort_desc() {
+        let q = parse_query(".users[] | sort age desc").unwrap();
+        assert_eq!(q.operations.len(), 1);
+        assert_eq!(
+            q.operations[0],
+            Operation::Sort {
+                field: "age".to_string(),
+                descending: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_sort_with_extra_whitespace() {
+        let q = parse_query(".[]  |  sort  name  ").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Sort {
+                field: "name".to_string(),
+                descending: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_sort_desc_with_extra_whitespace() {
+        let q = parse_query(".[]  |  sort  name  desc  ").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Sort {
+                field: "name".to_string(),
+                descending: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_sort_field_with_underscore() {
+        let q = parse_query(".[] | sort created_at").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Sort {
+                field: "created_at".to_string(),
+                descending: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_error_sort_missing_field() {
+        let err = parse_query(".[] | sort").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    // --- limit 절 파싱 ---
+
+    #[test]
+    fn test_limit() {
+        let q = parse_query(".users[] | limit 10").unwrap();
+        assert_eq!(q.operations.len(), 1);
+        assert_eq!(q.operations[0], Operation::Limit(10));
+    }
+
+    #[test]
+    fn test_limit_one() {
+        let q = parse_query(".[] | limit 1").unwrap();
+        assert_eq!(q.operations[0], Operation::Limit(1));
+    }
+
+    #[test]
+    fn test_limit_with_extra_whitespace() {
+        let q = parse_query(".[]  |  limit  5  ").unwrap();
+        assert_eq!(q.operations[0], Operation::Limit(5));
+    }
+
+    #[test]
+    fn test_error_limit_missing_number() {
+        let err = parse_query(".[] | limit").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    #[test]
+    fn test_error_limit_negative() {
+        let err = parse_query(".[] | limit -5").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    // --- 복합 파이프라인 ---
+
+    #[test]
+    fn test_where_sort_limit() {
+        let q = parse_query(".users[] | where age > 20 | sort age desc | limit 5").unwrap();
+        assert_eq!(q.operations.len(), 3);
+        assert!(matches!(&q.operations[0], Operation::Where(_)));
+        assert_eq!(
+            q.operations[1],
+            Operation::Sort {
+                field: "age".to_string(),
+                descending: true,
+            }
+        );
+        assert_eq!(q.operations[2], Operation::Limit(5));
+    }
+
+    #[test]
+    fn test_where_select_sort() {
+        let q = parse_query(".users[] | where age > 30 | select name, email | sort name").unwrap();
+        assert_eq!(q.operations.len(), 3);
+        assert!(matches!(&q.operations[0], Operation::Where(_)));
+        assert_eq!(
+            q.operations[1],
+            Operation::Select(vec!["name".to_string(), "email".to_string()])
+        );
+        assert_eq!(
+            q.operations[2],
+            Operation::Sort {
+                field: "name".to_string(),
+                descending: false,
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `sort` / `sort desc` parser and executor for sorting query results by a field
- Add `limit` parser and executor for limiting the number of results
- Supports pipeline chaining: `.users[] | where age > 20 | sort age desc | limit 5`
- Includes comprehensive unit tests for parser and filter (30+ new tests)

Closes #48

## Test plan
- [x] All 337 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] Parser tests: sort asc/desc, limit, error cases, combined pipelines
- [x] Filter tests: sort by integer/float/string, desc, missing fields, limit basic/edge cases
- [x] Integration tests: where+sort+limit, where+select+sort combinations

https://claude.ai/code/session_017wmV4hJy6XGdkhHp1gZJxK