### PR TITLE
feat: add XML format support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "csv",
  "indexmap",
  "predicates",
+ "quick-xml",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -506,6 +507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 csv = "1"
 toml = "0.8"
+quick-xml = "0.37"
 indexmap = { version = "2", features = ["serde"] }
 comfy-table = "7"
 colored = "2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,8 +7,8 @@ use clap::{Parser, Subcommand};
     name = "dkit",
     version,
     about = "Swiss army knife for data format conversion and querying",
-    long_about = "dkit (Data Kit) — Convert and query data across JSON, CSV, YAML, and TOML.\n\nExamples:\n  dkit convert data.json --to csv\n  dkit convert data.csv --to yaml -o output.yaml\n  dkit query data.json '.users[0].name'\n  dkit view data.csv --limit 10\n  cat data.json | dkit convert --from json --to toml",
-    after_help = "Supported formats: json, csv, yaml (yml), toml\nUse 'dkit <command> --help' for more information about a command."
+    long_about = "dkit (Data Kit) — Convert and query data across JSON, CSV, YAML, TOML, and XML.\n\nExamples:\n  dkit convert data.json --to csv\n  dkit convert data.csv --to yaml -o output.yaml\n  dkit query data.json '.users[0].name'\n  dkit view data.csv --limit 10\n  cat data.json | dkit convert --from json --to toml",
+    after_help = "Supported formats: json, csv, yaml (yml), toml, xml\nUse 'dkit <command> --help' for more information about a command."
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -26,7 +26,7 @@ pub enum Commands {
         #[arg(value_name = "INPUT")]
         input: Vec<PathBuf>,
 
-        /// Output format (json, csv, yaml, toml)
+        /// Output format (json, csv, yaml, toml, xml)
         #[arg(long, value_name = "FORMAT")]
         to: String,
 
@@ -162,7 +162,7 @@ pub enum Commands {
         #[arg(value_name = "INPUT", required = true)]
         input: Vec<PathBuf>,
 
-        /// Output format (json, csv, yaml, toml). Defaults to first input's format
+        /// Output format (json, csv, yaml, toml, xml). Defaults to first input's format
         #[arg(long, value_name = "FORMAT")]
         to: Option<String>,
 

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -8,6 +8,7 @@ use super::read_file;
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
+use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
 use crate::format::{detect_format, Format, FormatOptions, FormatReader, FormatWriter};
 use crate::value::Value;
@@ -158,6 +159,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
+        Format::Xml => XmlReader.read(content),
     }
 }
 
@@ -167,5 +169,6 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Csv => CsvWriter::new(options.clone()).write(value),
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
+        Format::Xml => XmlWriter::new(options.pretty).write(value),
     }
 }

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -7,6 +7,7 @@ use super::read_file;
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
+use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
 use crate::format::{detect_format, Format, FormatOptions, FormatReader, FormatWriter};
 use crate::value::Value;
@@ -136,6 +137,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
+        Format::Xml => XmlReader.read(content),
     }
 }
 
@@ -145,6 +147,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Csv => CsvWriter::new(options.clone()).write(value),
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
+        Format::Xml => XmlWriter::new(options.pretty).write(value),
     }
 }
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context, Result};
 use crate::format::csv::CsvReader;
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
+use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
 use crate::format::{detect_format, Format, FormatOptions, FormatReader, FormatWriter};
 use crate::query::evaluator::evaluate_path;
@@ -98,6 +99,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
+        Format::Xml => XmlReader.read(content),
     }
 }
 
@@ -116,5 +118,6 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         }
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
+        Format::Xml => XmlWriter::new(options.pretty).write(value),
     }
 }

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
 use crate::format::toml::TomlReader;
+use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
 use crate::format::{detect_format, Format, FormatOptions, FormatReader};
 use crate::value::Value;
@@ -178,6 +179,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
+        Format::Xml => XmlReader.read(content),
     }
 }
 

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
 use crate::format::toml::TomlReader;
+use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
 use crate::format::{detect_format, Format, FormatOptions, FormatReader};
 use crate::value::Value;
@@ -274,6 +275,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
+        Format::Xml => XmlReader.read(content),
     }
 }
 

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context, Result};
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
 use crate::format::toml::TomlReader;
+use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
 use crate::format::{detect_format, Format, FormatOptions, FormatReader};
 use crate::output::table::render_table;
@@ -74,6 +75,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
+        Format::Xml => XmlReader.read(content),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 /// 지원하는 포맷 목록 (에러 메시지용)
-pub const SUPPORTED_FORMATS: &[&str] = &["json", "csv", "yaml", "yml", "toml"];
+pub const SUPPORTED_FORMATS: &[&str] = &["json", "csv", "yaml", "yml", "toml", "xml"];
 
 /// dkit 에러 타입 정의
 ///
@@ -48,9 +48,9 @@ mod tests {
 
     #[test]
     fn test_unknown_format_display() {
-        let err = DkitError::UnknownFormat("xml".to_string());
+        let err = DkitError::UnknownFormat("bin".to_string());
         let msg = err.to_string();
-        assert!(msg.contains("Unknown format: 'xml'"));
+        assert!(msg.contains("Unknown format: 'bin'"));
         assert!(msg.contains("Supported formats:"));
         assert!(msg.contains("json"));
         assert!(msg.contains("csv"));

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,6 +1,7 @@
 pub mod csv;
 pub mod json;
 pub mod toml;
+pub mod xml;
 pub mod yaml;
 
 use std::io::{Read, Write};
@@ -16,6 +17,7 @@ pub enum Format {
     Csv,
     Yaml,
     Toml,
+    Xml,
 }
 
 impl Format {
@@ -25,6 +27,7 @@ impl Format {
             "csv" => Ok(Format::Csv),
             "yaml" | "yml" => Ok(Format::Yaml),
             "toml" => Ok(Format::Toml),
+            "xml" => Ok(Format::Xml),
             _ => Err(DkitError::UnknownFormat(s.to_string())),
         }
     }
@@ -37,6 +40,7 @@ impl std::fmt::Display for Format {
             Format::Csv => write!(f, "CSV"),
             Format::Yaml => write!(f, "YAML"),
             Format::Toml => write!(f, "TOML"),
+            Format::Xml => write!(f, "XML"),
         }
     }
 }
@@ -48,6 +52,7 @@ pub fn detect_format(path: &Path) -> Result<Format, DkitError> {
         Some("csv" | "tsv") => Ok(Format::Csv),
         Some("yaml" | "yml") => Ok(Format::Yaml),
         Some("toml") => Ok(Format::Toml),
+        Some("xml") => Ok(Format::Xml),
         Some(ext) => Err(DkitError::UnknownFormat(ext.to_string())),
         None => Err(DkitError::UnknownFormat("(no extension)".to_string())),
     }
@@ -112,9 +117,14 @@ mod tests {
     }
 
     #[test]
+    fn test_format_from_str_xml() {
+        assert_eq!(Format::from_str("xml").unwrap(), Format::Xml);
+    }
+
+    #[test]
     fn test_format_from_str_unknown() {
-        let err = Format::from_str("xml").unwrap_err();
-        assert!(matches!(err, DkitError::UnknownFormat(s) if s == "xml"));
+        let err = Format::from_str("bin").unwrap_err();
+        assert!(matches!(err, DkitError::UnknownFormat(s) if s == "bin"));
     }
 
     // --- Format::Display ---
@@ -125,6 +135,7 @@ mod tests {
         assert_eq!(Format::Csv.to_string(), "CSV");
         assert_eq!(Format::Yaml.to_string(), "YAML");
         assert_eq!(Format::Toml.to_string(), "TOML");
+        assert_eq!(Format::Xml.to_string(), "XML");
     }
 
     // --- detect_format ---
@@ -170,9 +181,17 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_format_xml() {
+        assert_eq!(
+            detect_format(&PathBuf::from("data.xml")).unwrap(),
+            Format::Xml
+        );
+    }
+
+    #[test]
     fn test_detect_format_unknown_ext() {
-        let err = detect_format(&PathBuf::from("data.xml")).unwrap_err();
-        assert!(matches!(err, DkitError::UnknownFormat(s) if s == "xml"));
+        let err = detect_format(&PathBuf::from("data.bin")).unwrap_err();
+        assert!(matches!(err, DkitError::UnknownFormat(s) if s == "bin"));
     }
 
     #[test]

--- a/src/format/xml.rs
+++ b/src/format/xml.rs
@@ -1,0 +1,709 @@
+use std::io::{Read, Write};
+
+use indexmap::IndexMap;
+use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::reader::Reader as XmlEventReader;
+use quick_xml::writer::Writer as XmlEventWriter;
+
+use crate::error::DkitError;
+use crate::format::{FormatReader, FormatWriter};
+use crate::value::Value;
+
+/// XML → Value 변환
+///
+/// XML 구조를 Value로 매핑하는 규칙:
+/// - 루트 엘리먼트 → Object { tag_name: content }
+/// - 속성 → "@attr_name" 키로 저장
+/// - 텍스트 내용 → "#text" 키로 저장
+/// - 자식 엘리먼트 → 같은 태그가 여러 개면 Array, 하나면 단일 값
+/// - 텍스트만 있는 엘리먼트 → 문자열로 단순화
+fn parse_element(reader: &mut XmlEventReader<&[u8]>) -> anyhow::Result<(String, Value)> {
+    let mut tag_name = String::new();
+    let mut attrs: IndexMap<String, Value> = IndexMap::new();
+    let mut children: IndexMap<String, Vec<Value>> = IndexMap::new();
+    let mut text_content = String::new();
+
+    // 첫 이벤트는 Start 또는 Empty
+    loop {
+        match reader.read_event()? {
+            Event::Start(e) => {
+                tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                // 속성 처리
+                for attr in e.attributes() {
+                    let attr = attr?;
+                    let key = format!("@{}", String::from_utf8_lossy(attr.key.as_ref()));
+                    let val = attr.unescape_value()?.to_string();
+                    attrs.insert(key, infer_value(&val));
+                }
+                // 자식 파싱
+                parse_children(reader, &mut children, &mut text_content)?;
+                break;
+            }
+            Event::Empty(e) => {
+                tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                for attr in e.attributes() {
+                    let attr = attr?;
+                    let key = format!("@{}", String::from_utf8_lossy(attr.key.as_ref()));
+                    let val = attr.unescape_value()?.to_string();
+                    attrs.insert(key, infer_value(&val));
+                }
+                break;
+            }
+            Event::Eof => {
+                anyhow::bail!("Unexpected EOF while parsing XML element");
+            }
+            Event::Comment(_) | Event::Decl(_) | Event::PI(_) | Event::DocType(_) => continue,
+            Event::Text(t) => {
+                let s = t.unescape()?.to_string();
+                if !s.trim().is_empty() {
+                    text_content.push_str(&s);
+                }
+            }
+            Event::End(_) => break,
+            Event::CData(cd) => {
+                text_content.push_str(&String::from_utf8_lossy(&cd));
+            }
+        }
+    }
+
+    // 결과 구성
+    let value = build_element_value(attrs, children, text_content);
+    Ok((tag_name, value))
+}
+
+/// 엘리먼트의 자식을 파싱 (End 이벤트를 만나면 종료)
+fn parse_children(
+    reader: &mut XmlEventReader<&[u8]>,
+    children: &mut IndexMap<String, Vec<Value>>,
+    text_content: &mut String,
+) -> anyhow::Result<()> {
+    loop {
+        match reader.read_event()? {
+            Event::Start(e) => {
+                let child_tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let mut child_attrs: IndexMap<String, Value> = IndexMap::new();
+                let mut child_children: IndexMap<String, Vec<Value>> = IndexMap::new();
+                let mut child_text = String::new();
+
+                for attr in e.attributes() {
+                    let attr = attr?;
+                    let key = format!("@{}", String::from_utf8_lossy(attr.key.as_ref()));
+                    let val = attr.unescape_value()?.to_string();
+                    child_attrs.insert(key, infer_value(&val));
+                }
+
+                parse_children(reader, &mut child_children, &mut child_text)?;
+
+                let child_value = build_element_value(child_attrs, child_children, child_text);
+                children.entry(child_tag).or_default().push(child_value);
+            }
+            Event::Empty(e) => {
+                let child_tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let mut child_attrs: IndexMap<String, Value> = IndexMap::new();
+
+                for attr in e.attributes() {
+                    let attr = attr?;
+                    let key = format!("@{}", String::from_utf8_lossy(attr.key.as_ref()));
+                    let val = attr.unescape_value()?.to_string();
+                    child_attrs.insert(key, infer_value(&val));
+                }
+
+                let child_value = if child_attrs.is_empty() {
+                    Value::Null
+                } else {
+                    Value::Object(child_attrs)
+                };
+                children.entry(child_tag).or_default().push(child_value);
+            }
+            Event::Text(t) => {
+                let s = t.unescape()?.to_string();
+                if !s.trim().is_empty() {
+                    text_content.push_str(s.trim());
+                }
+            }
+            Event::CData(cd) => {
+                text_content.push_str(&String::from_utf8_lossy(&cd));
+            }
+            Event::End(_) => break,
+            Event::Eof => break,
+            Event::Comment(_) | Event::Decl(_) | Event::PI(_) | Event::DocType(_) => continue,
+        }
+    }
+    Ok(())
+}
+
+/// 속성, 자식, 텍스트로부터 Value 구성
+fn build_element_value(
+    attrs: IndexMap<String, Value>,
+    children: IndexMap<String, Vec<Value>>,
+    text_content: String,
+) -> Value {
+    let has_attrs = !attrs.is_empty();
+    let has_children = !children.is_empty();
+    let has_text = !text_content.is_empty();
+
+    // 텍스트만 있는 단순 엘리먼트 → 값으로 단순화
+    if !has_attrs && !has_children && has_text {
+        return infer_value(&text_content);
+    }
+
+    // 아무것도 없는 빈 엘리먼트
+    if !has_attrs && !has_children && !has_text {
+        return Value::Null;
+    }
+
+    // Object 구성
+    let mut map: IndexMap<String, Value> = IndexMap::new();
+
+    // 속성 추가
+    for (k, v) in attrs {
+        map.insert(k, v);
+    }
+
+    // 자식 엘리먼트 추가
+    for (tag, values) in children {
+        if values.len() == 1 {
+            map.insert(tag, values.into_iter().next().unwrap());
+        } else {
+            map.insert(tag, Value::Array(values));
+        }
+    }
+
+    // 텍스트가 있으면 #text로 추가
+    if has_text {
+        map.insert("#text".to_string(), infer_value(&text_content));
+    }
+
+    Value::Object(map)
+}
+
+/// 문자열 → 적절한 Value 타입 추론
+fn infer_value(s: &str) -> Value {
+    if s.eq_ignore_ascii_case("null") || s.eq_ignore_ascii_case("~") {
+        return Value::Null;
+    }
+    if s.eq_ignore_ascii_case("true") {
+        return Value::Bool(true);
+    }
+    if s.eq_ignore_ascii_case("false") {
+        return Value::Bool(false);
+    }
+    if let Ok(i) = s.parse::<i64>() {
+        return Value::Integer(i);
+    }
+    if let Ok(f) = s.parse::<f64>() {
+        return Value::Float(f);
+    }
+    Value::String(s.to_string())
+}
+
+// ============== Value → XML 변환 ==============
+
+/// Value를 XML 이벤트로 변환하여 Writer에 작성
+fn write_element(
+    writer: &mut XmlEventWriter<Vec<u8>>,
+    tag: &str,
+    value: &Value,
+) -> anyhow::Result<()> {
+    match value {
+        Value::Null => {
+            // 빈 엘리먼트
+            let elem = BytesStart::new(tag);
+            writer.write_event(Event::Empty(elem))?;
+        }
+        Value::Bool(b) => {
+            let elem = BytesStart::new(tag);
+            writer.write_event(Event::Start(elem))?;
+            writer.write_event(Event::Text(BytesText::new(&b.to_string())))?;
+            writer.write_event(Event::End(BytesEnd::new(tag)))?;
+        }
+        Value::Integer(n) => {
+            let elem = BytesStart::new(tag);
+            writer.write_event(Event::Start(elem))?;
+            writer.write_event(Event::Text(BytesText::new(&n.to_string())))?;
+            writer.write_event(Event::End(BytesEnd::new(tag)))?;
+        }
+        Value::Float(f) => {
+            let text = if f.is_nan() || f.is_infinite() {
+                "null".to_string()
+            } else {
+                f.to_string()
+            };
+            let elem = BytesStart::new(tag);
+            writer.write_event(Event::Start(elem))?;
+            writer.write_event(Event::Text(BytesText::new(&text)))?;
+            writer.write_event(Event::End(BytesEnd::new(tag)))?;
+        }
+        Value::String(s) => {
+            let elem = BytesStart::new(tag);
+            writer.write_event(Event::Start(elem))?;
+            writer.write_event(Event::Text(BytesText::new(s)))?;
+            writer.write_event(Event::End(BytesEnd::new(tag)))?;
+        }
+        Value::Array(arr) => {
+            // 배열의 각 항목을 같은 태그로 반복
+            for item in arr {
+                write_element(writer, tag, item)?;
+            }
+        }
+        Value::Object(map) => {
+            let mut elem = BytesStart::new(tag);
+
+            // @로 시작하는 키는 속성으로
+            for (k, v) in map {
+                if let Some(attr_name) = k.strip_prefix('@') {
+                    let attr_val = match v {
+                        Value::String(s) => s.clone(),
+                        Value::Integer(n) => n.to_string(),
+                        Value::Float(f) => f.to_string(),
+                        Value::Bool(b) => b.to_string(),
+                        Value::Null => "".to_string(),
+                        _ => serde_json::to_string(v).unwrap_or_default(),
+                    };
+                    elem.push_attribute((attr_name, attr_val.as_str()));
+                }
+            }
+
+            // 속성이 아닌 키가 있는지 확인
+            let has_content = map.iter().any(|(k, _)| !k.starts_with('@'));
+
+            if !has_content {
+                writer.write_event(Event::Empty(elem))?;
+            } else {
+                writer.write_event(Event::Start(elem))?;
+
+                for (k, v) in map {
+                    if k.starts_with('@') {
+                        continue;
+                    }
+                    if k == "#text" {
+                        // 텍스트 내용
+                        let text = match v {
+                            Value::String(s) => s.clone(),
+                            Value::Integer(n) => n.to_string(),
+                            Value::Float(f) => f.to_string(),
+                            Value::Bool(b) => b.to_string(),
+                            _ => String::new(),
+                        };
+                        writer.write_event(Event::Text(BytesText::new(&text)))?;
+                    } else {
+                        write_element(writer, k, v)?;
+                    }
+                }
+
+                writer.write_event(Event::End(BytesEnd::new(tag)))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// XML 포맷 Reader
+pub struct XmlReader;
+
+impl FormatReader for XmlReader {
+    fn read(&self, input: &str) -> anyhow::Result<Value> {
+        let mut reader = XmlEventReader::from_str(input);
+        reader.config_mut().trim_text(true);
+
+        let (tag, value) = parse_element(&mut reader).map_err(|e| DkitError::ParseError {
+            format: "XML".to_string(),
+            source: e.into(),
+        })?;
+
+        // 루트 엘리먼트를 { tag_name: value } 형태로 반환
+        let mut root = IndexMap::new();
+        root.insert(tag, value);
+        Ok(Value::Object(root))
+    }
+
+    fn read_from_reader(&self, mut reader: impl Read) -> anyhow::Result<Value> {
+        let mut buf = String::new();
+        reader.read_to_string(&mut buf)?;
+        self.read(&buf)
+    }
+}
+
+/// XML 포맷 Writer
+pub struct XmlWriter {
+    pretty: bool,
+}
+
+impl XmlWriter {
+    pub fn new(pretty: bool) -> Self {
+        Self { pretty }
+    }
+}
+
+impl Default for XmlWriter {
+    fn default() -> Self {
+        Self { pretty: true }
+    }
+}
+
+impl FormatWriter for XmlWriter {
+    fn write(&self, value: &Value) -> anyhow::Result<String> {
+        let mut buf = Vec::new();
+        self.write_to_writer(value, &mut buf)?;
+        Ok(String::from_utf8(buf)?)
+    }
+
+    fn write_to_writer(&self, value: &Value, writer: impl Write) -> anyhow::Result<()> {
+        let xml_buf = Vec::new();
+        let mut xml_writer = if self.pretty {
+            XmlEventWriter::new_with_indent(xml_buf, b' ', 2)
+        } else {
+            XmlEventWriter::new(xml_buf)
+        };
+
+        // XML 선언
+        xml_writer.write_event(Event::Decl(quick_xml::events::BytesDecl::new(
+            "1.0",
+            Some("UTF-8"),
+            None,
+        )))?;
+
+        match value {
+            Value::Object(map) => {
+                if map.len() == 1 {
+                    // 단일 루트: { "root": ... } → <root>...</root>
+                    let (tag, val) = map.iter().next().unwrap();
+                    write_element(&mut xml_writer, tag, val)?;
+                } else {
+                    // 여러 키 → <root>로 감싸기
+                    write_element(&mut xml_writer, "root", value)?;
+                }
+            }
+            Value::Array(_) => {
+                // 배열 → <root><item>...</item></root> 형태
+                let mut wrapper = IndexMap::new();
+                wrapper.insert("item".to_string(), value.clone());
+                let wrapped = Value::Object(wrapper);
+                write_element(&mut xml_writer, "root", &wrapped)?;
+            }
+            _ => {
+                // 단순 값 → <root>value</root>
+                write_element(&mut xml_writer, "root", value)?;
+            }
+        }
+
+        let xml_buf = xml_writer.into_inner();
+
+        let mut dest = writer;
+        dest.write_all(&xml_buf)?;
+        if self.pretty {
+            dest.write_all(b"\n")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::{FormatReader, FormatWriter};
+
+    // --- XmlReader 기본 테스트 ---
+
+    #[test]
+    fn test_read_simple_element() {
+        let xml = "<root><name>dkit</name><version>1</version></root>";
+        let value = XmlReader.read(xml).unwrap();
+        let root = value.as_object().unwrap().get("root").unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(obj.get("name"), Some(&Value::String("dkit".to_string())));
+        assert_eq!(obj.get("version"), Some(&Value::Integer(1)));
+    }
+
+    #[test]
+    fn test_read_attributes() {
+        let xml = r#"<user id="42" active="true"><name>Alice</name></user>"#;
+        let value = XmlReader.read(xml).unwrap();
+        let user = value.as_object().unwrap().get("user").unwrap();
+        let obj = user.as_object().unwrap();
+        assert_eq!(obj.get("@id"), Some(&Value::Integer(42)));
+        assert_eq!(obj.get("@active"), Some(&Value::Bool(true)));
+        assert_eq!(obj.get("name"), Some(&Value::String("Alice".to_string())));
+    }
+
+    #[test]
+    fn test_read_repeated_elements_as_array() {
+        let xml = "<users><user>Alice</user><user>Bob</user><user>Charlie</user></users>";
+        let value = XmlReader.read(xml).unwrap();
+        let users = value.as_object().unwrap().get("users").unwrap();
+        let arr = users
+            .as_object()
+            .unwrap()
+            .get("user")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0], Value::String("Alice".to_string()));
+        assert_eq!(arr[1], Value::String("Bob".to_string()));
+    }
+
+    #[test]
+    fn test_read_nested() {
+        let xml = "<config><db><host>localhost</host><port>5432</port></db></config>";
+        let value = XmlReader.read(xml).unwrap();
+        let config = value.as_object().unwrap().get("config").unwrap();
+        let db = config.as_object().unwrap().get("db").unwrap();
+        let obj = db.as_object().unwrap();
+        assert_eq!(
+            obj.get("host"),
+            Some(&Value::String("localhost".to_string()))
+        );
+        assert_eq!(obj.get("port"), Some(&Value::Integer(5432)));
+    }
+
+    #[test]
+    fn test_read_empty_element() {
+        let xml = "<root><empty/></root>";
+        let value = XmlReader.read(xml).unwrap();
+        let root = value.as_object().unwrap().get("root").unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(obj.get("empty"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn test_read_text_with_attributes() {
+        let xml = r#"<item price="9.99">Widget</item>"#;
+        let value = XmlReader.read(xml).unwrap();
+        let item = value.as_object().unwrap().get("item").unwrap();
+        let obj = item.as_object().unwrap();
+        assert_eq!(obj.get("@price"), Some(&Value::Float(9.99)));
+        assert_eq!(obj.get("#text"), Some(&Value::String("Widget".to_string())));
+    }
+
+    #[test]
+    fn test_read_xml_declaration() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?><root><value>42</value></root>"#;
+        let value = XmlReader.read(xml).unwrap();
+        let root = value.as_object().unwrap().get("root").unwrap();
+        assert_eq!(
+            root.as_object().unwrap().get("value"),
+            Some(&Value::Integer(42))
+        );
+    }
+
+    #[test]
+    fn test_read_unicode() {
+        let xml = "<root><greeting>안녕하세요</greeting><emoji>🎉</emoji></root>";
+        let value = XmlReader.read(xml).unwrap();
+        let root = value.as_object().unwrap().get("root").unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(
+            obj.get("greeting"),
+            Some(&Value::String("안녕하세요".to_string()))
+        );
+        assert_eq!(obj.get("emoji"), Some(&Value::String("🎉".to_string())));
+    }
+
+    #[test]
+    fn test_read_type_inference() {
+        let xml =
+            "<data><int>42</int><float>3.14</float><bool>true</bool><text>hello</text></data>";
+        let value = XmlReader.read(xml).unwrap();
+        let data = value.as_object().unwrap().get("data").unwrap();
+        let obj = data.as_object().unwrap();
+        assert_eq!(obj.get("int"), Some(&Value::Integer(42)));
+        assert_eq!(obj.get("float"), Some(&Value::Float(3.14)));
+        assert_eq!(obj.get("bool"), Some(&Value::Bool(true)));
+        assert_eq!(obj.get("text"), Some(&Value::String("hello".to_string())));
+    }
+
+    #[test]
+    fn test_read_invalid_xml() {
+        // 빈 입력은 루트 엘리먼트가 없으므로 에러
+        let result = XmlReader.read("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_from_reader() {
+        let xml = b"<root><x>1</x></root>" as &[u8];
+        let value = XmlReader.read_from_reader(xml).unwrap();
+        let root = value.as_object().unwrap().get("root").unwrap();
+        assert_eq!(root.as_object().unwrap().get("x"), Some(&Value::Integer(1)));
+    }
+
+    // --- XmlWriter 기본 테스트 ---
+
+    #[test]
+    fn test_write_simple_object() {
+        let mut map = IndexMap::new();
+        let mut inner = IndexMap::new();
+        inner.insert("name".to_string(), Value::String("dkit".to_string()));
+        inner.insert("version".to_string(), Value::Integer(1));
+        map.insert("root".to_string(), Value::Object(inner));
+
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&Value::Object(map)).unwrap();
+        assert!(output.contains("<root>"));
+        assert!(output.contains("<name>dkit</name>"));
+        assert!(output.contains("<version>1</version>"));
+        assert!(output.contains("</root>"));
+    }
+
+    #[test]
+    fn test_write_with_attributes() {
+        let mut map = IndexMap::new();
+        let mut inner = IndexMap::new();
+        inner.insert("@id".to_string(), Value::Integer(42));
+        inner.insert("name".to_string(), Value::String("Alice".to_string()));
+        map.insert("user".to_string(), Value::Object(inner));
+
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&Value::Object(map)).unwrap();
+        assert!(output.contains(r#"<user id="42">"#));
+        assert!(output.contains("<name>Alice</name>"));
+    }
+
+    #[test]
+    fn test_write_array() {
+        let arr = Value::Array(vec![
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+        ]);
+        let mut map = IndexMap::new();
+        let mut inner = IndexMap::new();
+        inner.insert("item".to_string(), arr);
+        map.insert("root".to_string(), Value::Object(inner));
+
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&Value::Object(map)).unwrap();
+        assert!(output.contains("<item>a</item>"));
+        assert!(output.contains("<item>b</item>"));
+    }
+
+    #[test]
+    fn test_write_null() {
+        let mut map = IndexMap::new();
+        let mut inner = IndexMap::new();
+        inner.insert("empty".to_string(), Value::Null);
+        map.insert("root".to_string(), Value::Object(inner));
+
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&Value::Object(map)).unwrap();
+        assert!(output.contains("<empty/>"));
+    }
+
+    #[test]
+    fn test_write_pretty() {
+        let mut map = IndexMap::new();
+        let mut inner = IndexMap::new();
+        inner.insert("x".to_string(), Value::Integer(1));
+        map.insert("root".to_string(), Value::Object(inner));
+
+        let writer = XmlWriter::new(true);
+        let output = writer.write(&Value::Object(map)).unwrap();
+        assert!(output.contains('\n'));
+    }
+
+    #[test]
+    fn test_write_primitive_root() {
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&Value::Integer(42)).unwrap();
+        assert!(output.contains("<root>42</root>"));
+    }
+
+    #[test]
+    fn test_write_bool() {
+        let mut map = IndexMap::new();
+        let mut inner = IndexMap::new();
+        inner.insert("flag".to_string(), Value::Bool(true));
+        map.insert("root".to_string(), Value::Object(inner));
+
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&Value::Object(map)).unwrap();
+        assert!(output.contains("<flag>true</flag>"));
+    }
+
+    // --- 왕복(roundtrip) 테스트 ---
+
+    #[test]
+    fn test_roundtrip_simple() {
+        let xml = "<config><host>localhost</host><port>8080</port></config>";
+        let value = XmlReader.read(xml).unwrap();
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&value).unwrap();
+        let value2 = XmlReader.read(&output).unwrap();
+        assert_eq!(value, value2);
+    }
+
+    #[test]
+    fn test_roundtrip_with_attributes() {
+        let xml = r#"<server host="localhost" port="8080"><name>main</name></server>"#;
+        let value = XmlReader.read(xml).unwrap();
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&value).unwrap();
+        let value2 = XmlReader.read(&output).unwrap();
+        assert_eq!(value, value2);
+    }
+
+    #[test]
+    fn test_roundtrip_nested() {
+        let xml = "<root><a><b><c>deep</c></b></a></root>";
+        let value = XmlReader.read(xml).unwrap();
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&value).unwrap();
+        let value2 = XmlReader.read(&output).unwrap();
+        assert_eq!(value, value2);
+    }
+
+    #[test]
+    fn test_write_to_writer() {
+        let mut map = IndexMap::new();
+        map.insert("root".to_string(), Value::String("hello".to_string()));
+
+        let writer = XmlWriter::new(false);
+        let mut buf = Vec::new();
+        writer
+            .write_to_writer(&Value::Object(map), &mut buf)
+            .unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("<root>hello</root>"));
+    }
+
+    // --- 특수 문자 이스케이프 ---
+
+    #[test]
+    fn test_special_chars_escaped() {
+        let xml = "<root><text>&lt;hello&gt; &amp; &quot;world&quot;</text></root>";
+        let value = XmlReader.read(xml).unwrap();
+        let root = value.as_object().unwrap().get("root").unwrap();
+        let text = root.as_object().unwrap().get("text").unwrap();
+        assert_eq!(text, &Value::String("<hello> & \"world\"".to_string()));
+    }
+
+    #[test]
+    fn test_write_special_chars() {
+        let mut map = IndexMap::new();
+        let mut inner = IndexMap::new();
+        inner.insert(
+            "text".to_string(),
+            Value::String("<hello> & \"world\"".to_string()),
+        );
+        map.insert("root".to_string(), Value::Object(inner));
+
+        let writer = XmlWriter::new(false);
+        let output = writer.write(&Value::Object(map)).unwrap();
+        // quick-xml은 자동으로 이스케이프 처리
+        assert!(output.contains("&lt;hello&gt;"));
+        assert!(output.contains("&amp;"));
+    }
+
+    #[test]
+    fn test_empty_element_with_attrs() {
+        let xml = r#"<root><link href="https://example.com"/></root>"#;
+        let value = XmlReader.read(xml).unwrap();
+        let root = value.as_object().unwrap().get("root").unwrap();
+        let link = root.as_object().unwrap().get("link").unwrap();
+        let obj = link.as_object().unwrap();
+        assert_eq!(
+            obj.get("@href"),
+            Some(&Value::String("https://example.com".to_string()))
+        );
+    }
+}

--- a/tests/convert_test.rs
+++ b/tests/convert_test.rs
@@ -251,9 +251,27 @@ fn convert_missing_to_flag() {
 #[test]
 fn convert_unknown_format() {
     dkit()
-        .args(&["convert", "tests/fixtures/users.json", "--to", "xml"])
+        .args(&["convert", "tests/fixtures/users.json", "--to", "bin"])
         .assert()
         .failure();
+}
+
+#[test]
+fn convert_json_to_xml() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.json", "--to", "xml"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("<name>Alice</name>"));
+}
+
+#[test]
+fn convert_xml_to_json() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.xml", "--to", "json"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Alice"));
 }
 
 #[test]

--- a/tests/fixtures/config.xml
+++ b/tests/fixtures/config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+  <database>
+    <host>localhost</host>
+    <port>5432</port>
+    <name>mydb</name>
+  </database>
+  <server>
+    <host>0.0.0.0</host>
+    <port>8080</port>
+    <debug>true</debug>
+  </server>
+</config>

--- a/tests/fixtures/users.xml
+++ b/tests/fixtures/users.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<users>
+  <user>
+    <name>Alice</name>
+    <age>30</age>
+    <email>alice@example.com</email>
+    <active>true</active>
+  </user>
+  <user>
+    <name>Bob</name>
+    <age>25</age>
+    <email>bob@example.com</email>
+    <active>false</active>
+  </user>
+  <user>
+    <name>Charlie</name>
+    <age>35</age>
+    <email>charlie@example.com</email>
+    <active>true</active>
+  </user>
+</users>


### PR DESCRIPTION
## Summary
- XML Reader/Writer 구현 (`quick-xml` 크레이트 사용)
- XML ↔ Value 양방향 변환 지원
  - 속성 → `@attr` 키, 반복 자식 → Array, 텍스트 → 타입 추론
- 모든 서브커맨드(convert, query, view, stats, merge, schema)에서 XML 지원
- 27개 단위 테스트 + 2개 통합 테스트 + fixture 파일 추가

## Test plan
- [x] `cargo test` — 540 tests all passing
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] JSON → XML 변환 동작 확인
- [x] XML → JSON 변환 동작 확인
- [x] 속성, 중첩, 반복 엘리먼트, 유니코드, 특수문자 라운드트립 테스트

Closes #22

https://claude.ai/code/session_011wK6zU6u7LbEaZLe2v4VSp