### PR TITLE
feat: add TSV format support with auto tab delimiter

### DIFF
--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -10,7 +10,10 @@ use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
-use crate::format::{detect_format, Format, FormatOptions, FormatReader, FormatWriter};
+use crate::format::{
+    default_delimiter, default_delimiter_for_format, detect_format, Format, FormatOptions,
+    FormatReader, FormatWriter,
+};
 use crate::value::Value;
 
 pub struct ConvertArgs<'a> {
@@ -30,8 +33,11 @@ pub struct ConvertArgs<'a> {
 pub fn run(args: &ConvertArgs) -> Result<()> {
     let target_format = Format::from_str(args.to)?;
 
+    let write_delimiter = args
+        .delimiter
+        .or_else(|| default_delimiter_for_format(args.to));
     let write_options = FormatOptions {
-        delimiter: args.delimiter,
+        delimiter: write_delimiter,
         no_header: args.no_header,
         pretty: if args.compact {
             false
@@ -53,8 +59,11 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
             .read_to_string(&mut buf)
             .context("Failed to read from stdin")?;
 
+        let read_delimiter = args
+            .delimiter
+            .or_else(|| args.from.and_then(default_delimiter_for_format));
         let read_options = FormatOptions {
-            delimiter: args.delimiter,
+            delimiter: read_delimiter,
             no_header: args.no_header,
             ..Default::default()
         };
@@ -85,8 +94,9 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
                 None => detect_format(path)?,
             };
 
+            let read_delimiter = args.delimiter.or_else(|| default_delimiter(path));
             let read_options = FormatOptions {
-                delimiter: args.delimiter,
+                delimiter: read_delimiter,
                 no_header: args.no_header,
                 ..Default::default()
             };
@@ -116,8 +126,9 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         None => detect_format(path)?,
     };
 
+    let read_delimiter = args.delimiter.or_else(|| default_delimiter(path));
     let read_options = FormatOptions {
-        delimiter: args.delimiter,
+        delimiter: read_delimiter,
         no_header: args.no_header,
         ..Default::default()
     };

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -9,7 +9,10 @@ use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
-use crate::format::{detect_format, Format, FormatOptions, FormatReader, FormatWriter};
+use crate::format::{
+    default_delimiter, default_delimiter_for_format, detect_format, Format, FormatOptions,
+    FormatReader, FormatWriter,
+};
 use crate::value::Value;
 
 pub struct MergeArgs<'a> {
@@ -30,15 +33,15 @@ pub fn run(args: &MergeArgs) -> Result<()> {
     }
 
     // 각 파일을 Value로 읽기
-    let read_options = FormatOptions {
-        delimiter: args.delimiter,
-        no_header: args.no_header,
-        ..Default::default()
-    };
-
     let mut values = Vec::with_capacity(args.input.len());
     for path in args.input {
         let format = detect_format(path)?;
+        let read_delimiter = args.delimiter.or_else(|| default_delimiter(path));
+        let read_options = FormatOptions {
+            delimiter: read_delimiter,
+            no_header: args.no_header,
+            ..Default::default()
+        };
         let content = read_file(path)?;
         let value = read_value(&content, format, &read_options)?;
         values.push(value);
@@ -56,8 +59,11 @@ pub fn run(args: &MergeArgs) -> Result<()> {
         },
     };
 
+    let write_delimiter = args
+        .delimiter
+        .or_else(|| args.to.and_then(default_delimiter_for_format));
     let write_options = FormatOptions {
-        delimiter: args.delimiter,
+        delimiter: write_delimiter,
         no_header: args.no_header,
         pretty: if args.compact {
             false

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -9,7 +9,10 @@ use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
-use crate::format::{detect_format, Format, FormatOptions, FormatReader, FormatWriter};
+use crate::format::{
+    default_delimiter, default_delimiter_for_format, detect_format, Format, FormatOptions,
+    FormatReader, FormatWriter,
+};
 use crate::query::evaluator::evaluate_path;
 use crate::query::filter::apply_operations;
 use crate::query::parser::parse_query;
@@ -47,7 +50,15 @@ pub fn run(args: &QueryArgs) -> Result<()> {
     };
 
     // 파싱
-    let read_options = FormatOptions::default();
+    let auto_delimiter = if args.input == "-" {
+        args.from.and_then(default_delimiter_for_format)
+    } else {
+        default_delimiter(Path::new(args.input))
+    };
+    let read_options = FormatOptions {
+        delimiter: auto_delimiter,
+        ..Default::default()
+    };
     let value = read_value(&content, source_format, &read_options)?;
 
     // 쿼리 파싱 및 실행

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -6,7 +6,10 @@ use crate::format::json::JsonReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
-use crate::format::{detect_format, Format, FormatOptions, FormatReader};
+use crate::format::{
+    default_delimiter, default_delimiter_for_format, detect_format, Format, FormatOptions,
+    FormatReader,
+};
 use crate::value::Value;
 use anyhow::{bail, Result};
 
@@ -17,7 +20,15 @@ pub struct SchemaArgs<'a> {
 
 pub fn run(args: &SchemaArgs) -> Result<()> {
     let (content, source_format) = read_input(args)?;
-    let options = FormatOptions::default();
+    let auto_delimiter = if args.input == "-" {
+        args.from.and_then(default_delimiter_for_format)
+    } else {
+        default_delimiter(Path::new(args.input))
+    };
+    let options = FormatOptions {
+        delimiter: auto_delimiter,
+        ..Default::default()
+    };
     let value = read_value(&content, source_format, &options)?;
 
     let mut output = String::new();

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -6,7 +6,10 @@ use crate::format::json::JsonReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
-use crate::format::{detect_format, Format, FormatOptions, FormatReader};
+use crate::format::{
+    default_delimiter, default_delimiter_for_format, detect_format, Format, FormatOptions,
+    FormatReader,
+};
 use crate::value::Value;
 use anyhow::{bail, Context, Result};
 
@@ -22,8 +25,13 @@ pub struct StatsArgs<'a> {
 pub fn run(args: &StatsArgs) -> Result<()> {
     let (content, source_format) = read_input(args)?;
 
+    let auto_delimiter = if args.input == "-" {
+        args.from.and_then(default_delimiter_for_format)
+    } else {
+        default_delimiter(Path::new(args.input))
+    };
     let read_options = FormatOptions {
-        delimiter: args.delimiter,
+        delimiter: args.delimiter.or(auto_delimiter),
         no_header: args.no_header,
         ..Default::default()
     };

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -8,7 +8,10 @@ use crate::format::json::JsonReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
-use crate::format::{detect_format, Format, FormatOptions, FormatReader};
+use crate::format::{
+    default_delimiter, default_delimiter_for_format, detect_format, Format, FormatOptions,
+    FormatReader,
+};
 use crate::output::table::render_table;
 use crate::value::Value;
 
@@ -26,8 +29,13 @@ pub struct ViewArgs<'a> {
 pub fn run(args: &ViewArgs) -> Result<()> {
     let (content, source_format) = read_input(args)?;
 
+    let auto_delimiter = if args.input == "-" {
+        args.from.and_then(default_delimiter_for_format)
+    } else {
+        default_delimiter(Path::new(args.input))
+    };
     let read_options = FormatOptions {
-        delimiter: args.delimiter,
+        delimiter: args.delimiter.or(auto_delimiter),
         no_header: args.no_header,
         ..Default::default()
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 /// 지원하는 포맷 목록 (에러 메시지용)
-pub const SUPPORTED_FORMATS: &[&str] = &["json", "csv", "yaml", "yml", "toml", "xml"];
+pub const SUPPORTED_FORMATS: &[&str] = &["json", "csv", "tsv", "yaml", "yml", "toml", "xml"];
 
 /// dkit 에러 타입 정의
 ///

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -24,7 +24,7 @@ impl Format {
     pub fn from_str(s: &str) -> Result<Self, DkitError> {
         match s.to_lowercase().as_str() {
             "json" => Ok(Format::Json),
-            "csv" => Ok(Format::Csv),
+            "csv" | "tsv" => Ok(Format::Csv),
             "yaml" | "yml" => Ok(Format::Yaml),
             "toml" => Ok(Format::Toml),
             "xml" => Ok(Format::Xml),
@@ -55,6 +55,23 @@ pub fn detect_format(path: &Path) -> Result<Format, DkitError> {
         Some("xml") => Ok(Format::Xml),
         Some(ext) => Err(DkitError::UnknownFormat(ext.to_string())),
         None => Err(DkitError::UnknownFormat("(no extension)".to_string())),
+    }
+}
+
+/// 파일 확장자에 따른 기본 delimiter 반환
+/// `.tsv` 파일은 탭 구분자를 사용한다.
+pub fn default_delimiter(path: &Path) -> Option<char> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("tsv") => Some('\t'),
+        _ => None,
+    }
+}
+
+/// `--to` 포맷 문자열에 따른 기본 delimiter 반환
+pub fn default_delimiter_for_format(format_str: &str) -> Option<char> {
+    match format_str.to_lowercase().as_str() {
+        "tsv" => Some('\t'),
+        _ => None,
     }
 }
 
@@ -111,6 +128,8 @@ mod tests {
         assert_eq!(Format::from_str("json").unwrap(), Format::Json);
         assert_eq!(Format::from_str("JSON").unwrap(), Format::Json);
         assert_eq!(Format::from_str("csv").unwrap(), Format::Csv);
+        assert_eq!(Format::from_str("tsv").unwrap(), Format::Csv);
+        assert_eq!(Format::from_str("TSV").unwrap(), Format::Csv);
         assert_eq!(Format::from_str("yaml").unwrap(), Format::Yaml);
         assert_eq!(Format::from_str("yml").unwrap(), Format::Yaml);
         assert_eq!(Format::from_str("toml").unwrap(), Format::Toml);
@@ -198,6 +217,36 @@ mod tests {
     fn test_detect_format_no_extension() {
         let err = detect_format(&PathBuf::from("Makefile")).unwrap_err();
         assert!(matches!(err, DkitError::UnknownFormat(s) if s == "(no extension)"));
+    }
+
+    // --- FormatOptions ---
+
+    // --- default_delimiter ---
+
+    #[test]
+    fn test_default_delimiter_tsv() {
+        assert_eq!(default_delimiter(&PathBuf::from("data.tsv")), Some('\t'));
+    }
+
+    #[test]
+    fn test_default_delimiter_csv() {
+        assert_eq!(default_delimiter(&PathBuf::from("data.csv")), None);
+    }
+
+    #[test]
+    fn test_default_delimiter_json() {
+        assert_eq!(default_delimiter(&PathBuf::from("data.json")), None);
+    }
+
+    #[test]
+    fn test_default_delimiter_for_format_tsv() {
+        assert_eq!(default_delimiter_for_format("tsv"), Some('\t'));
+        assert_eq!(default_delimiter_for_format("TSV"), Some('\t'));
+    }
+
+    #[test]
+    fn test_default_delimiter_for_format_csv() {
+        assert_eq!(default_delimiter_for_format("csv"), None);
     }
 
     // --- FormatOptions ---

--- a/tests/fixtures/users.tsv
+++ b/tests/fixtures/users.tsv
@@ -1,0 +1,3 @@
+name	age	email
+Alice	30	alice@example.com
+Bob	25	bob@example.com

--- a/tests/tsv_test.rs
+++ b/tests/tsv_test.rs
@@ -1,0 +1,150 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// --- TSV 읽기: .tsv 파일은 자동으로 탭 구분자 사용 ---
+
+#[test]
+fn convert_tsv_to_json() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.tsv", "--to", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"name\": \"Alice\""))
+        .stdout(predicate::str::contains("\"age\": 30"));
+}
+
+#[test]
+fn convert_tsv_to_yaml() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.tsv", "--to", "yaml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name: Alice"))
+        .stdout(predicate::str::contains("age: '30'").or(predicate::str::contains("age: 30")));
+}
+
+// --- TSV 쓰기: --to tsv는 자동으로 탭 구분자 사용 ---
+
+#[test]
+fn convert_json_to_tsv() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.json", "--to", "tsv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name\tage\temail").or(predicate::str::contains("\t")));
+}
+
+#[test]
+fn convert_csv_to_tsv() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.csv", "--to", "tsv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\t"));
+}
+
+// --- TSV 출력 파일 ---
+
+#[test]
+fn convert_json_to_tsv_file() {
+    let tmp = TempDir::new().unwrap();
+    let out_path = tmp.path().join("output.tsv");
+
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "--to",
+            "tsv",
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out_path).unwrap();
+    assert!(content.contains('\t'));
+    assert!(content.contains("Alice"));
+}
+
+// --- TSV view ---
+
+#[test]
+fn view_tsv_file() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.tsv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+// --- TSV stats ---
+
+#[test]
+fn stats_tsv_file() {
+    dkit()
+        .args(&["stats", "tests/fixtures/users.tsv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rows: 2"));
+}
+
+// --- TSV schema ---
+
+#[test]
+fn schema_tsv_file() {
+    dkit()
+        .args(&["schema", "tests/fixtures/users.tsv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("age"));
+}
+
+// --- stdin with --from tsv ---
+
+#[test]
+fn convert_stdin_tsv_to_json() {
+    dkit()
+        .args(&["convert", "--from", "tsv", "--to", "json"])
+        .write_stdin("name\tage\nAlice\t30\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+}
+
+// --- TSV 라운드트립: JSON → TSV → JSON ---
+
+#[test]
+fn tsv_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let tsv_path = tmp.path().join("roundtrip.tsv");
+
+    // JSON → TSV
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "--to",
+            "tsv",
+            "-o",
+            tsv_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // TSV → JSON (자동 감지)
+    dkit()
+        .args(&["convert", tsv_path.to_str().unwrap(), "--to", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}


### PR DESCRIPTION
## Summary
- `.tsv` 파일 확장자를 자동 감지하여 탭(`\t`) 구분자를 기본 적용
- `--to tsv`, `--from tsv` 포맷 지정 지원 추가
- 모든 서브커맨드(convert, view, stats, merge, query, schema)에서 TSV 자동 지원
- `SUPPORTED_FORMATS`에 `tsv` 추가

## Test plan
- [x] TSV → JSON 변환 테스트
- [x] JSON → TSV 변환 테스트 (자동 탭 구분자)
- [x] TSV 라운드트립 (JSON → TSV → JSON)
- [x] view, stats, schema 서브커맨드 TSV 테스트
- [x] stdin `--from tsv` 테스트
- [x] 기존 전체 테스트 통과 (379 tests)
- [x] clippy, fmt 통과

Closes #23

https://claude.ai/code/session_015Fj4WHcHfnj2vspWcSJk2d