### PR TITLE
feat: add MessagePack format support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "indexmap",
  "predicates",
  "quick-xml",
+ "rmp-serde",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -570,6 +571,25 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_yaml = "0.9"
 csv = "1"
 toml = "0.8"
 quick-xml = "0.37"
+rmp-serde = "1"
 indexmap = { version = "2", features = ["serde"] }
 comfy-table = "7"
 colored = "2"

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -1,12 +1,13 @@
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, Read, Write as _};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 
-use super::read_file;
+use super::{read_file, read_file_bytes};
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
+use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
@@ -54,28 +55,30 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
             Some(f) => Format::from_str(f)?,
             None => bail!("--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"),
         };
-        let mut buf = String::new();
-        io::stdin()
-            .read_to_string(&mut buf)
-            .context("Failed to read from stdin")?;
 
-        let read_delimiter = args
-            .delimiter
-            .or_else(|| args.from.and_then(default_delimiter_for_format));
-        let read_options = FormatOptions {
-            delimiter: read_delimiter,
-            no_header: args.no_header,
-            ..Default::default()
-        };
-        let value = read_value(&buf, source_format, &read_options)?;
-        let result = write_value(&value, target_format, &write_options)?;
-
-        if let Some(out_path) = args.output {
-            fs::write(out_path, &result)
-                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        let value = if source_format == Format::Msgpack {
+            let mut buf = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buf)
+                .context("Failed to read from stdin")?;
+            MsgpackReader.read_from_bytes(&buf)?
         } else {
-            print!("{result}");
-        }
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .context("Failed to read from stdin")?;
+            let read_delimiter = args
+                .delimiter
+                .or_else(|| args.from.and_then(default_delimiter_for_format));
+            let read_options = FormatOptions {
+                delimiter: read_delimiter,
+                no_header: args.no_header,
+                ..Default::default()
+            };
+            read_value(&buf, source_format, &read_options)?
+        };
+
+        write_output(&value, target_format, &write_options, args.output)?;
         return Ok(());
     }
 
@@ -101,9 +104,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
                 ..Default::default()
             };
 
-            let content = read_file(path)?;
-            let value = read_value(&content, source_format, &read_options)?;
-            let result = write_value(&value, target_format, &write_options)?;
+            let value = read_value_from_path(path, source_format, &read_options)?;
 
             let out_name = path
                 .file_stem()
@@ -113,8 +114,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
                 + "."
                 + args.to;
             let out_path = outdir.join(out_name);
-            fs::write(&out_path, &result)
-                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+            write_output(&value, target_format, &write_options, Some(&out_path))?;
         }
         return Ok(());
     }
@@ -133,9 +133,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         ..Default::default()
     };
 
-    let content = read_file(path)?;
-    let value = read_value(&content, source_format, &read_options)?;
-    let result = write_value(&value, target_format, &write_options)?;
+    let value = read_value_from_path(path, source_format, &read_options)?;
 
     let outdir_path = args.outdir.map(|d| {
         let name = path
@@ -148,20 +146,29 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         d.join(name)
     });
 
-    if let Some(out_path) = args.output.or(outdir_path.as_deref()) {
+    let out_path = args.output.or(outdir_path.as_deref());
+    if let Some(out_path) = out_path {
         if let Some(parent) = out_path.parent() {
             if !parent.as_os_str().is_empty() {
                 fs::create_dir_all(parent)
                     .with_context(|| format!("Failed to create directory {}", parent.display()))?;
             }
         }
-        fs::write(out_path, &result)
-            .with_context(|| format!("Failed to write to {}", out_path.display()))?;
-    } else {
-        print!("{result}");
     }
+    write_output(&value, target_format, &write_options, out_path)?;
 
     Ok(())
+}
+
+/// 파일 경로에서 Value를 읽는다 (바이너리 포맷 자동 처리)
+fn read_value_from_path(path: &Path, format: Format, options: &FormatOptions) -> Result<Value> {
+    if format == Format::Msgpack {
+        let bytes = read_file_bytes(path)?;
+        MsgpackReader.read_from_bytes(&bytes)
+    } else {
+        let content = read_file(path)?;
+        read_value(&content, format, options)
+    }
 }
 
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
@@ -171,7 +178,37 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader.read(content),
+        Format::Msgpack => MsgpackReader.read(content),
     }
+}
+
+/// Value를 출력한다 (바이너리 포맷 자동 처리)
+fn write_output(
+    value: &Value,
+    format: Format,
+    options: &FormatOptions,
+    output: Option<&Path>,
+) -> Result<()> {
+    if format == Format::Msgpack {
+        let bytes = MsgpackWriter.write_bytes(value)?;
+        if let Some(out_path) = output {
+            fs::write(out_path, &bytes)
+                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        } else {
+            io::stdout()
+                .write_all(&bytes)
+                .context("Failed to write to stdout")?;
+        }
+    } else {
+        let result = write_value(value, format, options)?;
+        if let Some(out_path) = output {
+            fs::write(out_path, &result)
+                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        } else {
+            print!("{result}");
+        }
+    }
+    Ok(())
 }
 
 fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result<String> {
@@ -181,5 +218,6 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
         Format::Xml => XmlWriter::new(options.pretty).write(value),
+        Format::Msgpack => MsgpackWriter.write(value),
     }
 }

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -3,9 +3,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 
-use super::read_file;
+use super::{read_file, read_file_bytes};
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
+use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
@@ -42,8 +43,13 @@ pub fn run(args: &MergeArgs) -> Result<()> {
             no_header: args.no_header,
             ..Default::default()
         };
-        let content = read_file(path)?;
-        let value = read_value(&content, format, &read_options)?;
+        let value = if format == Format::Msgpack {
+            let bytes = read_file_bytes(path)?;
+            MsgpackReader.read_from_bytes(&bytes)?
+        } else {
+            let content = read_file(path)?;
+            read_value(&content, format, &read_options)?
+        };
         values.push(value);
     }
 
@@ -74,19 +80,39 @@ pub fn run(args: &MergeArgs) -> Result<()> {
         flow_style: args.flow,
     };
 
-    let result = write_value(&merged, target_format, &write_options)?;
-
-    if let Some(out_path) = args.output {
-        if let Some(parent) = out_path.parent() {
-            if !parent.as_os_str().is_empty() {
-                fs::create_dir_all(parent)
-                    .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    if target_format == Format::Msgpack {
+        let bytes = MsgpackWriter.write_bytes(&merged)?;
+        if let Some(out_path) = args.output {
+            if let Some(parent) = out_path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("Failed to create directory {}", parent.display())
+                    })?;
+                }
             }
+            fs::write(out_path, &bytes)
+                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        } else {
+            use std::io::Write as _;
+            std::io::stdout()
+                .write_all(&bytes)
+                .context("Failed to write to stdout")?;
         }
-        fs::write(out_path, &result)
-            .with_context(|| format!("Failed to write to {}", out_path.display()))?;
     } else {
-        print!("{result}");
+        let result = write_value(&merged, target_format, &write_options)?;
+        if let Some(out_path) = args.output {
+            if let Some(parent) = out_path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("Failed to create directory {}", parent.display())
+                    })?;
+                }
+            }
+            fs::write(out_path, &result)
+                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        } else {
+            print!("{result}");
+        }
     }
 
     Ok(())
@@ -144,6 +170,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader.read(content),
+        Format::Msgpack => MsgpackReader.read(content),
     }
 }
 
@@ -154,6 +181,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
         Format::Xml => XmlWriter::new(options.pretty).write(value),
+        Format::Msgpack => MsgpackWriter.write(value),
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,26 @@ pub mod view;
 
 use std::path::Path;
 
+/// 바이너리 파일 읽기 (MessagePack 등 바이너리 포맷용)
+pub fn read_file_bytes(path: &Path) -> anyhow::Result<Vec<u8>> {
+    std::fs::read(path).map_err(|e| {
+        let hint = if e.kind() == std::io::ErrorKind::NotFound {
+            format!(
+                "\n  Hint: check that the file path '{}' is correct",
+                path.display()
+            )
+        } else if e.kind() == std::io::ErrorKind::PermissionDenied {
+            format!(
+                "\n  Hint: permission denied for '{}' — check file permissions",
+                path.display()
+            )
+        } else {
+            String::new()
+        };
+        anyhow::anyhow!("Failed to read '{}': {e}{hint}", path.display())
+    })
+}
+
 /// 파일 읽기 실패 시 도움말 힌트가 포함된 에러 메시지 생성
 pub fn read_file(path: &Path) -> anyhow::Result<String> {
     std::fs::read_to_string(path).map_err(|e| {

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::format::csv::CsvReader;
 use crate::format::json::{JsonReader, JsonWriter};
+use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
 use crate::format::yaml::{YamlReader, YamlWriter};
@@ -28,38 +29,52 @@ pub struct QueryArgs<'a> {
 
 /// query 서브커맨드 실행
 pub fn run(args: &QueryArgs) -> Result<()> {
-    // 입력 읽기
-    let (content, source_format) = if args.input == "-" {
-        let format = match args.from {
+    // 입력 포맷 결정
+    let source_format = if args.input == "-" {
+        match args.from {
             Some(f) => Format::from_str(f)?,
             None => bail!("--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"),
-        };
-        let mut buf = String::new();
-        io::stdin()
-            .read_to_string(&mut buf)
-            .context("Failed to read from stdin")?;
-        (buf, format)
+        }
     } else {
-        let path = PathBuf::from(args.input);
-        let format = match args.from {
+        match args.from {
             Some(f) => Format::from_str(f)?,
-            None => detect_format(&path)?,
-        };
-        let content = super::read_file(&path)?;
-        (content, format)
+            None => detect_format(&PathBuf::from(args.input))?,
+        }
     };
 
-    // 파싱
-    let auto_delimiter = if args.input == "-" {
-        args.from.and_then(default_delimiter_for_format)
+    // 입력 읽기 (바이너리 포맷 자동 처리)
+    let value = if source_format == Format::Msgpack {
+        if args.input == "-" {
+            let mut buf = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buf)
+                .context("Failed to read from stdin")?;
+            MsgpackReader.read_from_bytes(&buf)?
+        } else {
+            let bytes = super::read_file_bytes(Path::new(args.input))?;
+            MsgpackReader.read_from_bytes(&bytes)?
+        }
     } else {
-        default_delimiter(Path::new(args.input))
+        let content = if args.input == "-" {
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .context("Failed to read from stdin")?;
+            buf
+        } else {
+            super::read_file(&PathBuf::from(args.input))?
+        };
+        let auto_delimiter = if args.input == "-" {
+            args.from.and_then(default_delimiter_for_format)
+        } else {
+            default_delimiter(Path::new(args.input))
+        };
+        let read_options = FormatOptions {
+            delimiter: auto_delimiter,
+            ..Default::default()
+        };
+        read_value(&content, source_format, &read_options)?
     };
-    let read_options = FormatOptions {
-        delimiter: auto_delimiter,
-        ..Default::default()
-    };
-    let value = read_value(&content, source_format, &read_options)?;
 
     // 쿼리 파싱 및 실행
     let query = parse_query(args.query)?;
@@ -75,28 +90,44 @@ pub fn run(args: &QueryArgs) -> Result<()> {
         },
     };
 
-    let write_options = FormatOptions {
-        pretty: true,
-        ..Default::default()
-    };
-    let output = write_value(&result, output_format, &write_options)?;
-
-    // 출력: -o 지정 시 파일에 쓰기, 아니면 stdout
-    match args.output {
-        Some(path) => {
-            let content = if output.ends_with('\n') {
-                output
-            } else {
-                format!("{output}\n")
-            };
-            fs::write(path, &content)
-                .with_context(|| format!("Failed to write to {}", path.display()))?;
+    // 출력
+    if output_format == Format::Msgpack {
+        let bytes = MsgpackWriter.write_bytes(&result)?;
+        match args.output {
+            Some(path) => {
+                fs::write(path, &bytes)
+                    .with_context(|| format!("Failed to write to {}", path.display()))?;
+            }
+            None => {
+                use std::io::Write as _;
+                std::io::stdout()
+                    .write_all(&bytes)
+                    .context("Failed to write to stdout")?;
+            }
         }
-        None => {
-            if output.ends_with('\n') {
-                print!("{output}");
-            } else {
-                println!("{output}");
+    } else {
+        let write_options = FormatOptions {
+            pretty: true,
+            ..Default::default()
+        };
+        let output = write_value(&result, output_format, &write_options)?;
+
+        match args.output {
+            Some(path) => {
+                let content = if output.ends_with('\n') {
+                    output
+                } else {
+                    format!("{output}\n")
+                };
+                fs::write(path, &content)
+                    .with_context(|| format!("Failed to write to {}", path.display()))?;
+            }
+            None => {
+                if output.ends_with('\n') {
+                    print!("{output}");
+                } else {
+                    println!("{output}");
+                }
             }
         }
     }
@@ -111,6 +142,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader.read(content),
+        Format::Msgpack => MsgpackReader.read(content),
     }
 }
 
@@ -130,5 +162,6 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
         Format::Xml => XmlWriter::new(options.pretty).write(value),
+        Format::Msgpack => MsgpackWriter.write(value),
     }
 }

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
+use crate::format::msgpack::MsgpackReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
@@ -19,17 +20,50 @@ pub struct SchemaArgs<'a> {
 }
 
 pub fn run(args: &SchemaArgs) -> Result<()> {
-    let (content, source_format) = read_input(args)?;
-    let auto_delimiter = if args.input == "-" {
-        args.from.and_then(default_delimiter_for_format)
+    let source_format = if args.input == "-" {
+        match args.from {
+            Some(f) => Format::from_str(f)?,
+            None => bail!("--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"),
+        }
     } else {
-        default_delimiter(Path::new(args.input))
+        match args.from {
+            Some(f) => Format::from_str(f)?,
+            None => detect_format(Path::new(args.input))?,
+        }
     };
-    let options = FormatOptions {
-        delimiter: auto_delimiter,
-        ..Default::default()
+
+    let value = if source_format == Format::Msgpack {
+        let bytes = if args.input == "-" {
+            let mut buf = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buf)
+                .map_err(|e| anyhow::anyhow!("Failed to read from stdin: {e}"))?;
+            buf
+        } else {
+            super::read_file_bytes(Path::new(args.input))?
+        };
+        MsgpackReader.read_from_bytes(&bytes)?
+    } else {
+        let content = if args.input == "-" {
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|e| anyhow::anyhow!("Failed to read from stdin: {e}"))?;
+            buf
+        } else {
+            super::read_file(Path::new(args.input))?
+        };
+        let auto_delimiter = if args.input == "-" {
+            args.from.and_then(default_delimiter_for_format)
+        } else {
+            default_delimiter(Path::new(args.input))
+        };
+        let options = FormatOptions {
+            delimiter: auto_delimiter,
+            ..Default::default()
+        };
+        read_value(&content, source_format, &options)?
     };
-    let value = read_value(&content, source_format, &options)?;
 
     let mut output = String::new();
     format_schema(&value, "", true, &mut output);
@@ -160,30 +194,6 @@ fn format_array_children(arr: &[Value], prefix: &str, output: &mut String) {
     }
 }
 
-fn read_input(args: &SchemaArgs) -> Result<(String, Format)> {
-    if args.input == "-" {
-        let format = match args.from {
-            Some(f) => Format::from_str(f)?,
-            None => bail!(
-                "--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"
-            ),
-        };
-        let mut buf = String::new();
-        io::stdin()
-            .read_to_string(&mut buf)
-            .map_err(|e| anyhow::anyhow!("Failed to read from stdin: {e}"))?;
-        Ok((buf, format))
-    } else {
-        let path = Path::new(args.input);
-        let format = match args.from {
-            Some(f) => Format::from_str(f)?,
-            None => detect_format(path)?,
-        };
-        let content = super::read_file(path)?;
-        Ok((content, format))
-    }
-}
-
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
@@ -191,6 +201,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader.read(content),
+        Format::Msgpack => MsgpackReader.read(content),
     }
 }
 

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
+use crate::format::msgpack::MsgpackReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
@@ -23,20 +24,7 @@ pub struct StatsArgs<'a> {
 }
 
 pub fn run(args: &StatsArgs) -> Result<()> {
-    let (content, source_format) = read_input(args)?;
-
-    let auto_delimiter = if args.input == "-" {
-        args.from.and_then(default_delimiter_for_format)
-    } else {
-        default_delimiter(Path::new(args.input))
-    };
-    let read_options = FormatOptions {
-        delimiter: args.delimiter.or(auto_delimiter),
-        no_header: args.no_header,
-        ..Default::default()
-    };
-
-    let value = read_value(&content, source_format, &read_options)?;
+    let (value, _source_format) = read_input_as_value(args)?;
 
     // --path 옵션으로 중첩 데이터 접근
     let target = match args.path {
@@ -277,6 +265,51 @@ fn read_input(args: &StatsArgs) -> Result<(String, Format)> {
     }
 }
 
+/// MessagePack 바이너리 입력을 처리하여 Value를 반환
+fn read_input_as_value(args: &StatsArgs) -> Result<(Value, Format)> {
+    let format = if args.input == "-" {
+        match args.from {
+            Some(f) => Format::from_str(f)?,
+            None => bail!(
+                "--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"
+            ),
+        }
+    } else {
+        match args.from {
+            Some(f) => Format::from_str(f)?,
+            None => detect_format(Path::new(args.input))?,
+        }
+    };
+
+    if format == Format::Msgpack {
+        let bytes = if args.input == "-" {
+            let mut buf = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buf)
+                .context("Failed to read from stdin")?;
+            buf
+        } else {
+            super::read_file_bytes(Path::new(args.input))?
+        };
+        let value = MsgpackReader.read_from_bytes(&bytes)?;
+        Ok((value, format))
+    } else {
+        let (content, format) = read_input(args)?;
+        let auto_delimiter = if args.input == "-" {
+            args.from.and_then(default_delimiter_for_format)
+        } else {
+            default_delimiter(Path::new(args.input))
+        };
+        let read_options = FormatOptions {
+            delimiter: args.delimiter.or(auto_delimiter),
+            no_header: args.no_header,
+            ..Default::default()
+        };
+        let value = read_value(&content, format, &read_options)?;
+        Ok((value, format))
+    }
+}
+
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
@@ -284,6 +317,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader.read(content),
+        Format::Msgpack => MsgpackReader.read(content),
     }
 }
 

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
+use crate::format::msgpack::MsgpackReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
 use crate::format::yaml::YamlReader;
@@ -27,7 +28,7 @@ pub struct ViewArgs<'a> {
 
 /// view 서브커맨드 실행
 pub fn run(args: &ViewArgs) -> Result<()> {
-    let (content, source_format) = read_input(args)?;
+    let source_format = determine_format(args)?;
 
     let auto_delimiter = if args.input == "-" {
         args.from.and_then(default_delimiter_for_format)
@@ -40,7 +41,7 @@ pub fn run(args: &ViewArgs) -> Result<()> {
         ..Default::default()
     };
 
-    let value = read_value(&content, source_format, &read_options)?;
+    let value = read_input_value(args, source_format, &read_options)?;
 
     // --path 옵션으로 중첩 데이터 접근
     let target = match args.path {
@@ -54,26 +55,45 @@ pub fn run(args: &ViewArgs) -> Result<()> {
     Ok(())
 }
 
-/// 입력 소스에서 콘텐츠와 포맷을 읽어온다
-fn read_input(args: &ViewArgs) -> Result<(String, Format)> {
+/// 입력 포맷을 결정한다
+fn determine_format(args: &ViewArgs) -> Result<Format> {
     if args.input == "-" {
-        let format = match args.from {
-            Some(f) => Format::from_str(f)?,
+        match args.from {
+            Some(f) => Format::from_str(f),
             None => bail!("--from is required when reading from stdin\n  Hint: specify the input format, e.g. --from json"),
-        };
-        let mut buf = String::new();
-        io::stdin()
-            .read_to_string(&mut buf)
-            .context("Failed to read from stdin")?;
-        Ok((buf, format))
+        }
     } else {
-        let path = Path::new(args.input);
-        let format = match args.from {
-            Some(f) => Format::from_str(f)?,
-            None => detect_format(path)?,
+        match args.from {
+            Some(f) => Format::from_str(f),
+            None => detect_format(Path::new(args.input)),
+        }
+    }.map_err(Into::into)
+}
+
+/// 입력 소스에서 Value를 읽어온다 (바이너리 포맷 자동 처리)
+fn read_input_value(args: &ViewArgs, format: Format, options: &FormatOptions) -> Result<Value> {
+    if format == Format::Msgpack {
+        if args.input == "-" {
+            let mut buf = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buf)
+                .context("Failed to read from stdin")?;
+            MsgpackReader.read_from_bytes(&buf)
+        } else {
+            let bytes = super::read_file_bytes(Path::new(args.input))?;
+            MsgpackReader.read_from_bytes(&bytes)
+        }
+    } else {
+        let content = if args.input == "-" {
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .context("Failed to read from stdin")?;
+            buf
+        } else {
+            super::read_file(Path::new(args.input))?
         };
-        let content = super::read_file(path)?;
-        Ok((content, format))
+        read_value(&content, format, options)
     }
 }
 
@@ -84,6 +104,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader.read(content),
+        Format::Msgpack => MsgpackReader.read(content),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 /// 지원하는 포맷 목록 (에러 메시지용)
-pub const SUPPORTED_FORMATS: &[&str] = &["json", "csv", "tsv", "yaml", "yml", "toml", "xml"];
+pub const SUPPORTED_FORMATS: &[&str] = &[
+    "json", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack",
+];
 
 /// dkit 에러 타입 정의
 ///

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -6,7 +6,7 @@ use crate::format::{FormatOptions, FormatReader, FormatWriter};
 use crate::value::Value;
 
 /// serde_json::Value → 내부 Value 변환
-fn from_json_value(v: serde_json::Value) -> Value {
+pub(crate) fn from_json_value(v: serde_json::Value) -> Value {
     match v {
         serde_json::Value::Null => Value::Null,
         serde_json::Value::Bool(b) => Value::Bool(b),
@@ -35,7 +35,7 @@ fn from_json_value(v: serde_json::Value) -> Value {
 }
 
 /// 내부 Value → serde_json::Value 변환
-fn to_json_value(v: &Value) -> serde_json::Value {
+pub(crate) fn to_json_value(v: &Value) -> serde_json::Value {
     match v {
         Value::Null => serde_json::Value::Null,
         Value::Bool(b) => serde_json::Value::Bool(*b),

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,5 +1,6 @@
 pub mod csv;
 pub mod json;
+pub mod msgpack;
 pub mod toml;
 pub mod xml;
 pub mod yaml;
@@ -18,6 +19,7 @@ pub enum Format {
     Yaml,
     Toml,
     Xml,
+    Msgpack,
 }
 
 impl Format {
@@ -28,6 +30,7 @@ impl Format {
             "yaml" | "yml" => Ok(Format::Yaml),
             "toml" => Ok(Format::Toml),
             "xml" => Ok(Format::Xml),
+            "msgpack" | "messagepack" => Ok(Format::Msgpack),
             _ => Err(DkitError::UnknownFormat(s.to_string())),
         }
     }
@@ -41,6 +44,7 @@ impl std::fmt::Display for Format {
             Format::Yaml => write!(f, "YAML"),
             Format::Toml => write!(f, "TOML"),
             Format::Xml => write!(f, "XML"),
+            Format::Msgpack => write!(f, "MessagePack"),
         }
     }
 }
@@ -53,6 +57,7 @@ pub fn detect_format(path: &Path) -> Result<Format, DkitError> {
         Some("yaml" | "yml") => Ok(Format::Yaml),
         Some("toml") => Ok(Format::Toml),
         Some("xml") => Ok(Format::Xml),
+        Some("msgpack") => Ok(Format::Msgpack),
         Some(ext) => Err(DkitError::UnknownFormat(ext.to_string())),
         None => Err(DkitError::UnknownFormat("(no extension)".to_string())),
     }
@@ -141,6 +146,12 @@ mod tests {
     }
 
     #[test]
+    fn test_format_from_str_msgpack() {
+        assert_eq!(Format::from_str("msgpack").unwrap(), Format::Msgpack);
+        assert_eq!(Format::from_str("messagepack").unwrap(), Format::Msgpack);
+    }
+
+    #[test]
     fn test_format_from_str_unknown() {
         let err = Format::from_str("bin").unwrap_err();
         assert!(matches!(err, DkitError::UnknownFormat(s) if s == "bin"));
@@ -155,6 +166,7 @@ mod tests {
         assert_eq!(Format::Yaml.to_string(), "YAML");
         assert_eq!(Format::Toml.to_string(), "TOML");
         assert_eq!(Format::Xml.to_string(), "XML");
+        assert_eq!(Format::Msgpack.to_string(), "MessagePack");
     }
 
     // --- detect_format ---
@@ -204,6 +216,14 @@ mod tests {
         assert_eq!(
             detect_format(&PathBuf::from("data.xml")).unwrap(),
             Format::Xml
+        );
+    }
+
+    #[test]
+    fn test_detect_format_msgpack() {
+        assert_eq!(
+            detect_format(&PathBuf::from("data.msgpack")).unwrap(),
+            Format::Msgpack
         );
     }
 

--- a/src/format/msgpack.rs
+++ b/src/format/msgpack.rs
@@ -1,0 +1,254 @@
+use std::io::{Read, Write};
+
+use crate::format::json::{from_json_value, to_json_value};
+use crate::format::{FormatReader, FormatWriter};
+use crate::value::Value;
+
+/// MessagePack 포맷 Reader
+pub struct MsgpackReader;
+
+impl FormatReader for MsgpackReader {
+    fn read(&self, input: &str) -> anyhow::Result<Value> {
+        self.read_from_reader(input.as_bytes())
+    }
+
+    fn read_from_reader(&self, mut reader: impl Read) -> anyhow::Result<Value> {
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf)?;
+        self.read_from_bytes(&buf)
+    }
+}
+
+impl MsgpackReader {
+    /// 바이트 슬라이스에서 Value를 읽는다
+    pub fn read_from_bytes(&self, bytes: &[u8]) -> anyhow::Result<Value> {
+        let json_val: serde_json::Value =
+            rmp_serde::from_slice(bytes).map_err(|e| crate::error::DkitError::ParseError {
+                format: "MessagePack".to_string(),
+                source: Box::new(e),
+            })?;
+        Ok(from_json_value(json_val))
+    }
+}
+
+/// MessagePack 포맷 Writer
+pub struct MsgpackWriter;
+
+impl FormatWriter for MsgpackWriter {
+    fn write(&self, _value: &Value) -> anyhow::Result<String> {
+        anyhow::bail!("MessagePack is a binary format. Use write_to_writer or write_bytes instead.")
+    }
+
+    fn write_to_writer(&self, value: &Value, mut writer: impl Write) -> anyhow::Result<()> {
+        let bytes = self.write_bytes(value)?;
+        writer.write_all(&bytes)?;
+        Ok(())
+    }
+}
+
+impl MsgpackWriter {
+    /// Value를 MessagePack 바이너리로 직렬화
+    pub fn write_bytes(&self, value: &Value) -> anyhow::Result<Vec<u8>> {
+        let json_val = to_json_value(value);
+        rmp_serde::to_vec(&json_val).map_err(|e| {
+            crate::error::DkitError::WriteError {
+                format: "MessagePack".to_string(),
+                source: Box::new(e),
+            }
+            .into()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn roundtrip(val: &Value) -> Value {
+        let bytes = MsgpackWriter.write_bytes(val).unwrap();
+        MsgpackReader.read_from_bytes(&bytes).unwrap()
+    }
+
+    // --- 기본 타입 라운드트립 ---
+
+    #[test]
+    fn test_null() {
+        assert_eq!(roundtrip(&Value::Null), Value::Null);
+    }
+
+    #[test]
+    fn test_bool_true() {
+        assert_eq!(roundtrip(&Value::Bool(true)), Value::Bool(true));
+    }
+
+    #[test]
+    fn test_bool_false() {
+        assert_eq!(roundtrip(&Value::Bool(false)), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_integer_positive() {
+        assert_eq!(roundtrip(&Value::Integer(42)), Value::Integer(42));
+    }
+
+    #[test]
+    fn test_integer_negative() {
+        assert_eq!(roundtrip(&Value::Integer(-100)), Value::Integer(-100));
+    }
+
+    #[test]
+    fn test_integer_zero() {
+        assert_eq!(roundtrip(&Value::Integer(0)), Value::Integer(0));
+    }
+
+    #[test]
+    fn test_float() {
+        assert_eq!(roundtrip(&Value::Float(3.14)), Value::Float(3.14));
+    }
+
+    #[test]
+    fn test_float_negative() {
+        assert_eq!(roundtrip(&Value::Float(-2.5)), Value::Float(-2.5));
+    }
+
+    #[test]
+    fn test_string() {
+        let val = Value::String("hello".to_string());
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    #[test]
+    fn test_string_empty() {
+        let val = Value::String(String::new());
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    #[test]
+    fn test_string_unicode() {
+        let val = Value::String("안녕하세요 🌍".to_string());
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    // --- 컬렉션 타입 ---
+
+    #[test]
+    fn test_array_empty() {
+        let val = Value::Array(vec![]);
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    #[test]
+    fn test_array_mixed() {
+        let val = Value::Array(vec![
+            Value::Integer(1),
+            Value::String("two".to_string()),
+            Value::Bool(true),
+            Value::Null,
+        ]);
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    #[test]
+    fn test_object_simple() {
+        let mut map = IndexMap::new();
+        map.insert("name".to_string(), Value::String("Alice".to_string()));
+        map.insert("age".to_string(), Value::Integer(30));
+        let val = Value::Object(map);
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    #[test]
+    fn test_object_empty() {
+        let val = Value::Object(IndexMap::new());
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    // --- 중첩 구조 ---
+
+    #[test]
+    fn test_nested_object() {
+        let mut inner = IndexMap::new();
+        inner.insert("host".to_string(), Value::String("localhost".to_string()));
+        inner.insert("port".to_string(), Value::Integer(5432));
+
+        let mut outer = IndexMap::new();
+        outer.insert("database".to_string(), Value::Object(inner));
+        outer.insert("debug".to_string(), Value::Bool(false));
+
+        let val = Value::Object(outer);
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    #[test]
+    fn test_array_of_objects() {
+        let mut obj1 = IndexMap::new();
+        obj1.insert("id".to_string(), Value::Integer(1));
+        obj1.insert("name".to_string(), Value::String("Alice".to_string()));
+
+        let mut obj2 = IndexMap::new();
+        obj2.insert("id".to_string(), Value::Integer(2));
+        obj2.insert("name".to_string(), Value::String("Bob".to_string()));
+
+        let val = Value::Array(vec![Value::Object(obj1), Value::Object(obj2)]);
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    #[test]
+    fn test_deeply_nested() {
+        let val = Value::Array(vec![Value::Array(vec![Value::Array(vec![
+            Value::Integer(42),
+        ])])]);
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    // --- 경계값 ---
+
+    #[test]
+    fn test_large_integer() {
+        let val = Value::Integer(i64::MAX);
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    #[test]
+    fn test_large_negative_integer() {
+        let val = Value::Integer(i64::MIN);
+        assert_eq!(roundtrip(&val), val);
+    }
+
+    // --- Reader/Writer 인터페이스 ---
+
+    #[test]
+    fn test_read_from_reader() {
+        let val = Value::String("test".to_string());
+        let bytes = MsgpackWriter.write_bytes(&val).unwrap();
+        let cursor = std::io::Cursor::new(bytes);
+        let result = MsgpackReader.read_from_reader(cursor).unwrap();
+        assert_eq!(result, val);
+    }
+
+    #[test]
+    fn test_write_to_writer() {
+        let val = Value::Integer(42);
+        let mut buf = Vec::new();
+        MsgpackWriter.write_to_writer(&val, &mut buf).unwrap();
+        let result = MsgpackReader.read_from_bytes(&buf).unwrap();
+        assert_eq!(result, val);
+    }
+
+    // --- 에러 케이스 ---
+
+    #[test]
+    fn test_invalid_msgpack_data() {
+        let invalid = vec![0xc1]; // MessagePack reserved byte
+        let result = MsgpackReader.read_from_bytes(&invalid);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_write_returns_error_for_string() {
+        let val = Value::Null;
+        let result = MsgpackWriter.write(&val);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Add MessagePack binary format Reader/Writer using `rmp-serde` crate
- Support binary I/O in all commands (convert, query, view, stats, merge, schema)
- Add `read_file_bytes` helper for binary format file reading
- Add comprehensive unit tests for MessagePack roundtrip conversions

## Test plan
- [x] All 395+ unit tests pass
- [x] All integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] Manual test: `dkit convert data.json --to msgpack -o data.msgpack`
- [ ] Manual test: `dkit convert data.msgpack --to json`

Closes #24

https://claude.ai/code/session_01YWe2RGDPbPT8j44zyvHLmW