### PR TITLE
v0.3.0 릴리스 준비 및 게시

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-03-21
+
+### Added
+
+- **XML format support**: Read and write XML files via `quick-xml` crate. Supports conversion between XML and all other formats. (#22)
+- **TSV format support**: Tab-separated values with automatic `.tsv` extension detection. Leverages CSV Reader's delimiter option. (#23)
+- **MessagePack format support**: Binary MessagePack format via `rmp-serde` crate. Read and write `.msgpack` files. (#24)
+- **`diff` subcommand**: Compare two data files and display differences with colored output (added: green, removed: red, changed: yellow). Supports cross-format comparison, `--path` for nested data, and `--quiet` mode. (#35)
+- **Comprehensive v0.3.0 integration tests**: End-to-end tests for XML, TSV, MessagePack formats, diff subcommand, and cross-format conversions. (#52)
+
 ## [0.2.0] - 2026-03-21
 
 ### Added
@@ -38,5 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI pipeline**: GitHub Actions workflow with test (Linux/macOS/Windows), clippy, and rustfmt checks.
 - **Test suite**: Integration tests covering all conversion paths, query operations, table view, fixture data, edge cases (unicode, empty input, quoted CSV fields).
 
+[0.3.0]: https://github.com/syangkkim/dkit/releases/tag/v0.3.0
 [0.2.0]: https://github.com/syangkkim/dkit/releases/tag/v0.2.0
 [0.1.0]: https://github.com/syangkkim/dkit/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dkit"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkit"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Swiss army knife for data format conversion and querying"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Swiss army knife for data format conversion and querying.**
 
-Convert between JSON, CSV, YAML, and TOML with a single CLI. Query nested data, preview as tables, and pipe everything together.
+Convert between JSON, CSV, YAML, TOML, XML, TSV, and MessagePack with a single CLI. Query nested data, compare files, preview as tables, and pipe everything together.
 
 ## Quick Start
 
@@ -38,14 +38,17 @@ cargo install --path .
 
 ## Supported Formats
 
-| Format | Extensions | Read | Write |
-|--------|-----------|------|-------|
-| JSON   | `.json`   | O    | O     |
-| CSV    | `.csv`    | O    | O     |
-| YAML   | `.yaml`, `.yml` | O | O  |
-| TOML   | `.toml`   | O    | O     |
+| Format      | Extensions       | Read | Write |
+|-------------|-----------------|------|-------|
+| JSON        | `.json`         | O    | O     |
+| CSV         | `.csv`          | O    | O     |
+| TSV         | `.tsv`          | O    | O     |
+| YAML        | `.yaml`, `.yml` | O    | O     |
+| TOML        | `.toml`         | O    | O     |
+| XML         | `.xml`          | O    | O     |
+| MessagePack | `.msgpack`      | O    | O     |
 
-All 12 conversion paths (4 x 3) are supported.
+All conversion paths between supported formats are available.
 
 ## Commands
 
@@ -156,6 +159,23 @@ dkit schema data.json
 cat data.json | dkit schema - --from json
 ```
 
+### `diff` — Compare data files
+
+```bash
+# Compare same-format files
+dkit diff old.json new.json
+dkit diff config_dev.yaml config_prod.yaml
+
+# Cross-format comparison
+dkit diff data.json data.yaml
+
+# Compare nested path only
+dkit diff old.json new.json --path '.database'
+
+# Quiet mode (exit code: 0=same, 1=different)
+dkit diff a.json b.json --quiet && echo 'same' || echo 'different'
+```
+
 ### `merge` — Combine multiple files
 
 ```bash
@@ -174,9 +194,11 @@ dkit merge config1.yaml config2.yaml --to yaml
 | Feature | dkit | jq | miller | yq |
 |---------|------|-----|--------|----|
 | JSON | O | O | O | O |
-| CSV | O | X | O | X |
+| CSV/TSV | O | X | O | X |
 | YAML | O | X | X | O |
 | TOML | O | X | X | X |
+| XML | O | X | X | O |
+| MessagePack | O | X | X | X |
 | Cross-format convert | O | X | Partial | Partial |
 | Table output | O | X | O | X |
 | Query (where/select/sort) | O | O | O | O |
@@ -184,6 +206,7 @@ dkit merge config1.yaml config2.yaml --to yaml
 | Statistics | O | X | O | X |
 | Schema inspection | O | X | X | X |
 | File merging | O | X | O | X |
+| File diff | O | X | X | X |
 | Single binary | O | O | O | O |
 
 dkit focuses on **seamless conversion between all supported formats** with a unified query syntax, eliminating the need for separate tools per format.


### PR DESCRIPTION
## Summary
- Cargo.toml 버전을 0.3.0으로 업데이트
- CHANGELOG.md에 v0.3.0 변경사항 추가 (XML, TSV, MessagePack 포맷 지원, diff 서브커맨드, 통합 테스트)
- README.md에 새 포맷(XML, TSV, MessagePack), diff 서브커맨드, 비교 테이블 업데이트

Closes #53

## Test plan
- [x] `cargo clippy -- -D warnings` 통과 확인
- [x] `cargo test` 전체 통과 확인 (모든 테스트 pass)
- [ ] GitHub Release 생성 및 crates.io 게시 (merge 후 수동 진행)

https://claude.ai/code/session_011a9THaUwv8ecY8Rn6MxgWA