### PR TITLE
feat: XML Writer에 --root-element 옵션 추가

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,10 @@ pub enum Commands {
         /// Use YAML inline/flow style
         #[arg(long)]
         flow: bool,
+
+        /// XML root element name (default: "root")
+        #[arg(long, value_name = "NAME")]
+        root_element: Option<String>,
     },
 
     /// Query data using path expressions

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -28,6 +28,7 @@ pub struct ConvertArgs<'a> {
     pub compact: bool,
     pub no_header: bool,
     pub flow: bool,
+    pub root_element: Option<String>,
 }
 
 /// convert 서브커맨드 실행
@@ -47,6 +48,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         },
         compact: args.compact,
         flow_style: args.flow,
+        root_element: args.root_element.clone(),
     };
 
     // stdin mode: no input files
@@ -217,7 +219,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Csv => CsvWriter::new(options.clone()).write(value),
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
-        Format::Xml => XmlWriter::new(options.pretty).write(value),
+        Format::Xml => XmlWriter::new(options.pretty, options.root_element.clone()).write(value),
         Format::Msgpack => MsgpackWriter.write(value),
     }
 }

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -78,6 +78,7 @@ pub fn run(args: &MergeArgs) -> Result<()> {
         },
         compact: args.compact,
         flow_style: args.flow,
+        root_element: None,
     };
 
     if target_format == Format::Msgpack {
@@ -180,7 +181,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Csv => CsvWriter::new(options.clone()).write(value),
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
-        Format::Xml => XmlWriter::new(options.pretty).write(value),
+        Format::Xml => XmlWriter::new(options.pretty, options.root_element.clone()).write(value),
         Format::Msgpack => MsgpackWriter.write(value),
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -161,7 +161,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         }
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),
-        Format::Xml => XmlWriter::new(options.pretty).write(value),
+        Format::Xml => XmlWriter::new(options.pretty, options.root_element.clone()).write(value),
         Format::Msgpack => MsgpackWriter.write(value),
     }
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -93,6 +93,8 @@ pub struct FormatOptions {
     pub compact: bool,
     /// YAML inline/flow 스타일
     pub flow_style: bool,
+    /// XML 루트 엘리먼트 이름 (기본: "root")
+    pub root_element: Option<String>,
 }
 
 impl Default for FormatOptions {
@@ -103,6 +105,7 @@ impl Default for FormatOptions {
             pretty: true,
             compact: false,
             flow_style: false,
+            root_element: None,
         }
     }
 }
@@ -279,5 +282,6 @@ mod tests {
         assert!(opts.pretty);
         assert!(!opts.compact);
         assert!(!opts.flow_style);
+        assert_eq!(opts.root_element, None);
     }
 }

--- a/src/format/xml.rs
+++ b/src/format/xml.rs
@@ -426,17 +426,24 @@ impl FormatReader for XmlReader {
 /// XML 포맷 Writer
 pub struct XmlWriter {
     pretty: bool,
+    root_element: String,
 }
 
 impl XmlWriter {
-    pub fn new(pretty: bool) -> Self {
-        Self { pretty }
+    pub fn new(pretty: bool, root_element: Option<String>) -> Self {
+        Self {
+            pretty,
+            root_element: root_element.unwrap_or_else(|| "root".to_string()),
+        }
     }
 }
 
 impl Default for XmlWriter {
     fn default() -> Self {
-        Self { pretty: true }
+        Self {
+            pretty: true,
+            root_element: "root".to_string(),
+        }
     }
 }
 
@@ -462,6 +469,7 @@ impl FormatWriter for XmlWriter {
             None,
         )))?;
 
+        let root_tag = &self.root_element;
         match value {
             Value::Object(map) => {
                 if map.len() == 1 {
@@ -469,8 +477,8 @@ impl FormatWriter for XmlWriter {
                     let (tag, val) = map.iter().next().unwrap();
                     write_element(&mut xml_writer, tag, val)?;
                 } else {
-                    // 여러 키 → <root>로 감싸기
-                    write_element(&mut xml_writer, "root", value)?;
+                    // 여러 키 → 루트 엘리먼트로 감싸기
+                    write_element(&mut xml_writer, root_tag, value)?;
                 }
             }
             Value::Array(_) => {
@@ -478,11 +486,11 @@ impl FormatWriter for XmlWriter {
                 let mut wrapper = IndexMap::new();
                 wrapper.insert("item".to_string(), value.clone());
                 let wrapped = Value::Object(wrapper);
-                write_element(&mut xml_writer, "root", &wrapped)?;
+                write_element(&mut xml_writer, root_tag, &wrapped)?;
             }
             _ => {
                 // 단순 값 → <root>value</root>
-                write_element(&mut xml_writer, "root", value)?;
+                write_element(&mut xml_writer, root_tag, value)?;
             }
         }
 
@@ -637,7 +645,7 @@ mod tests {
         inner.insert("version".to_string(), Value::Integer(1));
         map.insert("root".to_string(), Value::Object(inner));
 
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&Value::Object(map)).unwrap();
         assert!(output.contains("<root>"));
         assert!(output.contains("<name>dkit</name>"));
@@ -653,7 +661,7 @@ mod tests {
         inner.insert("name".to_string(), Value::String("Alice".to_string()));
         map.insert("user".to_string(), Value::Object(inner));
 
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&Value::Object(map)).unwrap();
         assert!(output.contains(r#"<user id="42">"#));
         assert!(output.contains("<name>Alice</name>"));
@@ -670,7 +678,7 @@ mod tests {
         inner.insert("item".to_string(), arr);
         map.insert("root".to_string(), Value::Object(inner));
 
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&Value::Object(map)).unwrap();
         assert!(output.contains("<item>a</item>"));
         assert!(output.contains("<item>b</item>"));
@@ -683,7 +691,7 @@ mod tests {
         inner.insert("empty".to_string(), Value::Null);
         map.insert("root".to_string(), Value::Object(inner));
 
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&Value::Object(map)).unwrap();
         assert!(output.contains("<empty/>"));
     }
@@ -695,14 +703,14 @@ mod tests {
         inner.insert("x".to_string(), Value::Integer(1));
         map.insert("root".to_string(), Value::Object(inner));
 
-        let writer = XmlWriter::new(true);
+        let writer = XmlWriter::new(true, None);
         let output = writer.write(&Value::Object(map)).unwrap();
         assert!(output.contains('\n'));
     }
 
     #[test]
     fn test_write_primitive_root() {
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&Value::Integer(42)).unwrap();
         assert!(output.contains("<root>42</root>"));
     }
@@ -714,7 +722,7 @@ mod tests {
         inner.insert("flag".to_string(), Value::Bool(true));
         map.insert("root".to_string(), Value::Object(inner));
 
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&Value::Object(map)).unwrap();
         assert!(output.contains("<flag>true</flag>"));
     }
@@ -725,7 +733,7 @@ mod tests {
     fn test_roundtrip_simple() {
         let xml = "<config><host>localhost</host><port>8080</port></config>";
         let value = XmlReader::default().read(xml).unwrap();
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&value).unwrap();
         let value2 = XmlReader::default().read(&output).unwrap();
         assert_eq!(value, value2);
@@ -735,7 +743,7 @@ mod tests {
     fn test_roundtrip_with_attributes() {
         let xml = r#"<server host="localhost" port="8080"><name>main</name></server>"#;
         let value = XmlReader::default().read(xml).unwrap();
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&value).unwrap();
         let value2 = XmlReader::default().read(&output).unwrap();
         assert_eq!(value, value2);
@@ -745,7 +753,7 @@ mod tests {
     fn test_roundtrip_nested() {
         let xml = "<root><a><b><c>deep</c></b></a></root>";
         let value = XmlReader::default().read(xml).unwrap();
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&value).unwrap();
         let value2 = XmlReader::default().read(&output).unwrap();
         assert_eq!(value, value2);
@@ -756,7 +764,7 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert("root".to_string(), Value::String("hello".to_string()));
 
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let mut buf = Vec::new();
         writer
             .write_to_writer(&Value::Object(map), &mut buf)
@@ -786,7 +794,7 @@ mod tests {
         );
         map.insert("root".to_string(), Value::Object(inner));
 
-        let writer = XmlWriter::new(false);
+        let writer = XmlWriter::new(false, None);
         let output = writer.write(&Value::Object(map)).unwrap();
         // quick-xml은 자동으로 이스케이프 처리
         assert!(output.contains("&lt;hello&gt;"));
@@ -908,5 +916,54 @@ mod tests {
             data,
             &Value::String("<script>alert('hi')</script>".to_string())
         );
+    }
+
+    // --- root_element 옵션 테스트 ---
+
+    #[test]
+    fn test_write_custom_root_element_multi_key() {
+        let mut map = IndexMap::new();
+        map.insert("name".to_string(), Value::String("dkit".to_string()));
+        map.insert("version".to_string(), Value::Integer(1));
+
+        let writer = XmlWriter::new(false, Some("config".to_string()));
+        let output = writer.write(&Value::Object(map)).unwrap();
+        assert!(output.contains("<config>"));
+        assert!(output.contains("</config>"));
+        assert!(!output.contains("<root>"));
+    }
+
+    #[test]
+    fn test_write_custom_root_element_array() {
+        let arr = Value::Array(vec![
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+        ]);
+
+        let writer = XmlWriter::new(false, Some("items".to_string()));
+        let output = writer.write(&arr).unwrap();
+        assert!(output.contains("<items>"));
+        assert!(output.contains("</items>"));
+        assert!(!output.contains("<root>"));
+    }
+
+    #[test]
+    fn test_write_custom_root_element_primitive() {
+        let writer = XmlWriter::new(false, Some("value".to_string()));
+        let output = writer.write(&Value::Integer(42)).unwrap();
+        assert!(output.contains("<value>42</value>"));
+        assert!(!output.contains("<root>"));
+    }
+
+    #[test]
+    fn test_write_default_root_element() {
+        // 단일 키 Object는 root_element 설정과 무관하게 해당 키를 사용
+        let mut map = IndexMap::new();
+        map.insert("data".to_string(), Value::Integer(1));
+
+        let writer = XmlWriter::new(false, Some("custom".to_string()));
+        let output = writer.write(&Value::Object(map)).unwrap();
+        // 단일 키이므로 "data"를 루트로 사용
+        assert!(output.contains("<data>1</data>"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             compact,
             no_header,
             flow,
+            root_element,
         } => {
             commands::convert::run(&commands::convert::ConvertArgs {
                 input: &input,
@@ -68,6 +69,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                 compact,
                 no_header,
                 flow,
+                root_element,
             })?;
         }
         Commands::Query {


### PR DESCRIPTION
## Summary
- XML Writer에 `--root-element` CLI 옵션을 추가하여 루트 엘리먼트 이름을 지정할 수 있도록 함
- `FormatOptions`에 `root_element` 필드를 추가하고 convert, query, merge 명령에서 활용
- 기존 XML Writer의 `@attr` → 속성 변환, `#text` → 텍스트 콘텐츠, pretty-print, 배열 반복 엘리먼트 기능은 이미 구현되어 있었으며, 누락된 `--root-element` 옵션을 완성

## Test plan
- [x] 기존 417+ 테스트 모두 통과 확인
- [x] `--root-element` 옵션 관련 4개 신규 테스트 추가 (multi-key object, array, primitive, single-key 케이스)
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과

Closes #72

https://claude.ai/code/session_01DD5JfkQVaGyCS5psb9nhJm