### PR TITLE
feat: implement JSONL (JSON Lines) Reader/Writer

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
     version,
     about = "Swiss army knife for data format conversion and querying",
     long_about = "dkit (Data Kit) — Convert and query data across JSON, CSV, YAML, TOML, and XML.\n\nExamples:\n  dkit convert data.json --to csv\n  dkit convert data.csv --to yaml -o output.yaml\n  dkit query data.json '.users[0].name'\n  dkit view data.csv --limit 10\n  cat data.json | dkit convert --from json --to toml",
-    after_help = "Supported formats: json, csv, yaml (yml), toml, xml\nUse 'dkit <command> --help' for more information about a command."
+    after_help = "Supported formats: json, jsonl, csv, yaml (yml), toml, xml\nUse 'dkit <command> --help' for more information about a command."
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -26,7 +26,7 @@ pub enum Commands {
         #[arg(value_name = "INPUT")]
         input: Vec<PathBuf>,
 
-        /// Output format (json, csv, yaml, toml, xml)
+        /// Output format (json, jsonl, csv, yaml, toml, xml)
         #[arg(long, value_name = "FORMAT")]
         to: String,
 
@@ -166,7 +166,7 @@ pub enum Commands {
         #[arg(value_name = "INPUT", required = true)]
         input: Vec<PathBuf>,
 
-        /// Output format (json, csv, yaml, toml, xml). Defaults to first input's format
+        /// Output format (json, jsonl, csv, yaml, toml, xml). Defaults to first input's format
         #[arg(long, value_name = "FORMAT")]
         to: Option<String>,
 

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context, Result};
 use super::{read_file, read_file_bytes};
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
+use crate::format::jsonl::{JsonlReader, JsonlWriter};
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
@@ -176,6 +177,7 @@ fn read_value_from_path(path: &Path, format: Format, options: &FormatOptions) ->
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
+        Format::Jsonl => JsonlReader.read(content),
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
@@ -216,6 +218,7 @@ fn write_output(
 fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result<String> {
     match format {
         Format::Json => JsonWriter::new(options.clone()).write(value),
+        Format::Jsonl => JsonlWriter.write(value),
         Format::Csv => CsvWriter::new(options.clone()).write(value),
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -6,6 +6,7 @@ use colored::Colorize;
 use super::{read_file, read_file_bytes};
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
+use crate::format::jsonl::JsonlReader;
 use crate::format::msgpack::MsgpackReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
@@ -75,6 +76,7 @@ fn read_value_from_path(path: &Path) -> Result<Value> {
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
+        Format::Jsonl => JsonlReader.read(content),
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context, Result};
 use super::{read_file, read_file_bytes};
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
+use crate::format::jsonl::{JsonlReader, JsonlWriter};
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
@@ -167,6 +168,7 @@ fn merge_values(values: Vec<Value>) -> Result<Value> {
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
+        Format::Jsonl => JsonlReader.read(content),
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
@@ -178,6 +180,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
 fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result<String> {
     match format {
         Format::Json => JsonWriter::new(options.clone()).write(value),
+        Format::Jsonl => JsonlWriter.write(value),
         Format::Csv => CsvWriter::new(options.clone()).write(value),
         Format::Yaml => YamlWriter::new(options.clone()).write(value),
         Format::Toml => TomlWriter::new(options.clone()).write(value),

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::format::csv::CsvReader;
 use crate::format::json::{JsonReader, JsonWriter};
+use crate::format::jsonl::{JsonlReader, JsonlWriter};
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
@@ -138,6 +139,7 @@ pub fn run(args: &QueryArgs) -> Result<()> {
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
+        Format::Jsonl => JsonlReader.read(content),
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),
@@ -149,6 +151,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
 fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result<String> {
     match format {
         Format::Json => JsonWriter::new(options.clone()).write(value),
+        Format::Jsonl => JsonlWriter.write(value),
         Format::Csv => {
             // CSV 출력 시 배열 형태가 아닌 단일 값은 JSON으로 출력
             match value {

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
+use crate::format::jsonl::JsonlReader;
 use crate::format::msgpack::MsgpackReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
@@ -197,6 +198,7 @@ fn format_array_children(arr: &[Value], prefix: &str, output: &mut String) {
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
+        Format::Jsonl => JsonlReader.read(content),
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
+use crate::format::jsonl::JsonlReader;
 use crate::format::msgpack::MsgpackReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
@@ -313,6 +314,7 @@ fn read_input_as_value(args: &StatsArgs) -> Result<(Value, Format)> {
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
+        Format::Jsonl => JsonlReader.read(content),
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
+use crate::format::jsonl::JsonlReader;
 use crate::format::msgpack::MsgpackReader;
 use crate::format::toml::TomlReader;
 use crate::format::xml::XmlReader;
@@ -100,6 +101,7 @@ fn read_input_value(args: &ViewArgs, format: Format, options: &FormatOptions) ->
 fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
     match format {
         Format::Json => JsonReader.read(content),
+        Format::Jsonl => JsonlReader.read(content),
         Format::Csv => CsvReader::new(options.clone()).read(content),
         Format::Yaml => YamlReader.read(content),
         Format::Toml => TomlReader.read(content),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 /// 지원하는 포맷 목록 (에러 메시지용)
 pub const SUPPORTED_FORMATS: &[&str] = &[
-    "json", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack",
+    "json", "jsonl", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack",
 ];
 
 /// dkit 에러 타입 정의

--- a/src/format/jsonl.rs
+++ b/src/format/jsonl.rs
@@ -1,0 +1,391 @@
+use std::io::{BufRead, Read, Write};
+
+use crate::format::{FormatReader, FormatWriter};
+use crate::value::Value;
+
+use super::json::{from_json_value, to_json_value};
+
+/// JSONL (JSON Lines) 포맷 Reader
+///
+/// 한 줄에 하나의 JSON 객체를 읽어 배열(Value::Array)로 변환한다.
+/// 빈 줄은 무시하고, 파싱 실패 시 줄 번호를 포함한 에러를 반환한다.
+pub struct JsonlReader;
+
+impl JsonlReader {
+    fn parse_lines(&self, input: &str) -> anyhow::Result<Value> {
+        let mut items = Vec::new();
+        for (line_num, line) in input.lines().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let json_val: serde_json::Value =
+                serde_json::from_str(trimmed).map_err(|e| crate::error::DkitError::ParseError {
+                    format: "JSONL".to_string(),
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("line {}: {e}", line_num + 1),
+                    )),
+                })?;
+            items.push(from_json_value(json_val));
+        }
+        Ok(Value::Array(items))
+    }
+}
+
+impl FormatReader for JsonlReader {
+    fn read(&self, input: &str) -> anyhow::Result<Value> {
+        self.parse_lines(input)
+    }
+
+    fn read_from_reader(&self, reader: impl Read) -> anyhow::Result<Value> {
+        let buf_reader = std::io::BufReader::new(reader);
+        let mut items = Vec::new();
+        for (line_num, line_result) in buf_reader.lines().enumerate() {
+            let line = line_result.map_err(|e| crate::error::DkitError::ParseError {
+                format: "JSONL".to_string(),
+                source: Box::new(e),
+            })?;
+            let trimmed = line.trim().to_string();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let json_val: serde_json::Value = serde_json::from_str(&trimmed).map_err(|e| {
+                crate::error::DkitError::ParseError {
+                    format: "JSONL".to_string(),
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("line {}: {e}", line_num + 1),
+                    )),
+                }
+            })?;
+            items.push(from_json_value(json_val));
+        }
+        Ok(Value::Array(items))
+    }
+}
+
+/// JSONL (JSON Lines) 포맷 Writer
+///
+/// Value::Array의 각 원소를 한 줄씩 JSON으로 직렬화한다.
+/// Array가 아닌 값은 단일 줄로 출력한다.
+pub struct JsonlWriter;
+
+impl FormatWriter for JsonlWriter {
+    fn write(&self, value: &Value) -> anyhow::Result<String> {
+        let mut output = String::new();
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    let json_val = to_json_value(item);
+                    let line = serde_json::to_string(&json_val).map_err(|e| {
+                        crate::error::DkitError::WriteError {
+                            format: "JSONL".to_string(),
+                            source: Box::new(e),
+                        }
+                    })?;
+                    output.push_str(&line);
+                    output.push('\n');
+                }
+            }
+            other => {
+                let json_val = to_json_value(other);
+                let line = serde_json::to_string(&json_val).map_err(|e| {
+                    crate::error::DkitError::WriteError {
+                        format: "JSONL".to_string(),
+                        source: Box::new(e),
+                    }
+                })?;
+                output.push_str(&line);
+                output.push('\n');
+            }
+        }
+        Ok(output)
+    }
+
+    fn write_to_writer(&self, value: &Value, mut writer: impl Write) -> anyhow::Result<()> {
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    let json_val = to_json_value(item);
+                    serde_json::to_writer(&mut writer, &json_val).map_err(|e| {
+                        crate::error::DkitError::WriteError {
+                            format: "JSONL".to_string(),
+                            source: Box::new(e),
+                        }
+                    })?;
+                    writer
+                        .write_all(b"\n")
+                        .map_err(|e| crate::error::DkitError::WriteError {
+                            format: "JSONL".to_string(),
+                            source: Box::new(e),
+                        })?;
+                }
+            }
+            other => {
+                let json_val = to_json_value(other);
+                serde_json::to_writer(&mut writer, &json_val).map_err(|e| {
+                    crate::error::DkitError::WriteError {
+                        format: "JSONL".to_string(),
+                        source: Box::new(e),
+                    }
+                })?;
+                writer
+                    .write_all(b"\n")
+                    .map_err(|e| crate::error::DkitError::WriteError {
+                        format: "JSONL".to_string(),
+                        source: Box::new(e),
+                    })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    // --- JsonlReader 테스트 ---
+
+    #[test]
+    fn test_read_basic() {
+        let reader = JsonlReader;
+        let input = r#"{"name":"Alice","age":30}
+{"name":"Bob","age":25}"#;
+        let result = reader.read(input).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("age"),
+            Some(&Value::Integer(25))
+        );
+    }
+
+    #[test]
+    fn test_read_skip_empty_lines() {
+        let reader = JsonlReader;
+        let input = r#"{"a":1}
+
+{"b":2}
+
+"#;
+        let result = reader.read(input).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_read_single_line() {
+        let reader = JsonlReader;
+        let input = r#"{"key":"value"}"#;
+        let result = reader.read(input).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn test_read_empty_input() {
+        let reader = JsonlReader;
+        let result = reader.read("").unwrap();
+        let arr = result.as_array().unwrap();
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn test_read_only_empty_lines() {
+        let reader = JsonlReader;
+        let result = reader.read("\n\n\n").unwrap();
+        let arr = result.as_array().unwrap();
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn test_read_various_json_types() {
+        let reader = JsonlReader;
+        let input = "42\n\"hello\"\ntrue\nnull\n[1,2,3]";
+        let result = reader.read(input).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr[0], Value::Integer(42));
+        assert_eq!(arr[1], Value::String("hello".to_string()));
+        assert_eq!(arr[2], Value::Bool(true));
+        assert_eq!(arr[3], Value::Null);
+        assert_eq!(arr[4].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_read_malformed_line_error_with_line_number() {
+        let reader = JsonlReader;
+        let input = r#"{"a":1}
+{invalid json}
+{"b":2}"#;
+        let err = reader.read(input).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("JSONL"));
+        assert!(msg.contains("line 2"));
+    }
+
+    #[test]
+    fn test_read_from_reader() {
+        let reader = JsonlReader;
+        let input = b"{\"x\":1}\n{\"x\":2}\n";
+        let result = reader.read_from_reader(&input[..]).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_read_whitespace_trimmed() {
+        let reader = JsonlReader;
+        let input = "  {\"a\":1}  \n  {\"b\":2}  ";
+        let result = reader.read(input).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_read_unicode() {
+        let reader = JsonlReader;
+        let input = r#"{"emoji":"🎉","korean":"한글"}"#;
+        let result = reader.read(input).unwrap();
+        let arr = result.as_array().unwrap();
+        let obj = arr[0].as_object().unwrap();
+        assert_eq!(obj.get("emoji"), Some(&Value::String("🎉".to_string())));
+        assert_eq!(obj.get("korean"), Some(&Value::String("한글".to_string())));
+    }
+
+    // --- JsonlWriter 테스트 ---
+
+    #[test]
+    fn test_write_array() {
+        let writer = JsonlWriter;
+        let value = Value::Array(vec![
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Alice".to_string()));
+                m.insert("age".to_string(), Value::Integer(30));
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Bob".to_string()));
+                m.insert("age".to_string(), Value::Integer(25));
+                m
+            }),
+        ]);
+        let output = writer.write(&value).unwrap();
+        let lines: Vec<&str> = output.trim_end().split('\n').collect();
+        assert_eq!(lines.len(), 2);
+        // Each line should be valid JSON containing the expected fields
+        let parsed0: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(parsed0["name"], "Alice");
+        assert_eq!(parsed0["age"], 30);
+        let parsed1: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(parsed1["name"], "Bob");
+        assert_eq!(parsed1["age"], 25);
+    }
+
+    #[test]
+    fn test_write_empty_array() {
+        let writer = JsonlWriter;
+        let output = writer.write(&Value::Array(vec![])).unwrap();
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn test_write_non_array() {
+        let writer = JsonlWriter;
+        let output = writer.write(&Value::Integer(42)).unwrap();
+        assert_eq!(output, "42\n");
+    }
+
+    #[test]
+    fn test_write_to_writer() {
+        let writer = JsonlWriter;
+        let value = Value::Array(vec![Value::Integer(1), Value::Integer(2)]);
+        let mut buf = Vec::new();
+        writer.write_to_writer(&value, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "1\n2\n");
+    }
+
+    // --- 라운드트립 테스트 ---
+
+    #[test]
+    fn test_roundtrip() {
+        let original = Value::Array(vec![
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("id".to_string(), Value::Integer(1));
+                m.insert("name".to_string(), Value::String("test".to_string()));
+                m.insert("active".to_string(), Value::Bool(true));
+                m
+            }),
+            Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("id".to_string(), Value::Integer(2));
+                m.insert("name".to_string(), Value::String("other".to_string()));
+                m.insert("active".to_string(), Value::Bool(false));
+                m
+            }),
+        ]);
+
+        let writer = JsonlWriter;
+        let written = writer.write(&original).unwrap();
+
+        let reader = JsonlReader;
+        let parsed = reader.read(&written).unwrap();
+
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn test_roundtrip_nested() {
+        let original = Value::Array(vec![Value::Object({
+            let mut m = IndexMap::new();
+            m.insert(
+                "data".to_string(),
+                Value::Array(vec![Value::Integer(1), Value::Integer(2)]),
+            );
+            m.insert(
+                "nested".to_string(),
+                Value::Object({
+                    let mut inner = IndexMap::new();
+                    inner.insert("key".to_string(), Value::String("val".to_string()));
+                    inner
+                }),
+            );
+            m
+        })]);
+
+        let writer = JsonlWriter;
+        let written = writer.write(&original).unwrap();
+        let reader = JsonlReader;
+        let parsed = reader.read(&written).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    // --- 대용량 테스트 ---
+
+    #[test]
+    fn test_large_input() {
+        let lines: Vec<String> = (0..1000)
+            .map(|i| format!(r#"{{"id":{i},"value":"item_{i}"}}"#))
+            .collect();
+        let input = lines.join("\n");
+
+        let reader = JsonlReader;
+        let result = reader.read(&input).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1000);
+        assert_eq!(
+            arr[999].as_object().unwrap().get("id"),
+            Some(&Value::Integer(999))
+        );
+    }
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,5 +1,6 @@
 pub mod csv;
 pub mod json;
+pub mod jsonl;
 pub mod msgpack;
 pub mod toml;
 pub mod xml;
@@ -15,6 +16,7 @@ use crate::value::Value;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Format {
     Json,
+    Jsonl,
     Csv,
     Yaml,
     Toml,
@@ -26,6 +28,7 @@ impl Format {
     pub fn from_str(s: &str) -> Result<Self, DkitError> {
         match s.to_lowercase().as_str() {
             "json" => Ok(Format::Json),
+            "jsonl" | "jsonlines" | "ndjson" => Ok(Format::Jsonl),
             "csv" | "tsv" => Ok(Format::Csv),
             "yaml" | "yml" => Ok(Format::Yaml),
             "toml" => Ok(Format::Toml),
@@ -40,6 +43,7 @@ impl std::fmt::Display for Format {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Format::Json => write!(f, "JSON"),
+            Format::Jsonl => write!(f, "JSONL"),
             Format::Csv => write!(f, "CSV"),
             Format::Yaml => write!(f, "YAML"),
             Format::Toml => write!(f, "TOML"),
@@ -53,6 +57,7 @@ impl std::fmt::Display for Format {
 pub fn detect_format(path: &Path) -> Result<Format, DkitError> {
     match path.extension().and_then(|e| e.to_str()) {
         Some("json") => Ok(Format::Json),
+        Some("jsonl" | "ndjson") => Ok(Format::Jsonl),
         Some("csv" | "tsv") => Ok(Format::Csv),
         Some("yaml" | "yml") => Ok(Format::Yaml),
         Some("toml") => Ok(Format::Toml),
@@ -144,6 +149,14 @@ mod tests {
     }
 
     #[test]
+    fn test_format_from_str_jsonl() {
+        assert_eq!(Format::from_str("jsonl").unwrap(), Format::Jsonl);
+        assert_eq!(Format::from_str("jsonlines").unwrap(), Format::Jsonl);
+        assert_eq!(Format::from_str("ndjson").unwrap(), Format::Jsonl);
+        assert_eq!(Format::from_str("JSONL").unwrap(), Format::Jsonl);
+    }
+
+    #[test]
     fn test_format_from_str_xml() {
         assert_eq!(Format::from_str("xml").unwrap(), Format::Xml);
     }
@@ -168,6 +181,7 @@ mod tests {
         assert_eq!(Format::Csv.to_string(), "CSV");
         assert_eq!(Format::Yaml.to_string(), "YAML");
         assert_eq!(Format::Toml.to_string(), "TOML");
+        assert_eq!(Format::Jsonl.to_string(), "JSONL");
         assert_eq!(Format::Xml.to_string(), "XML");
         assert_eq!(Format::Msgpack.to_string(), "MessagePack");
     }
@@ -211,6 +225,18 @@ mod tests {
         assert_eq!(
             detect_format(&PathBuf::from("config.toml")).unwrap(),
             Format::Toml
+        );
+    }
+
+    #[test]
+    fn test_detect_format_jsonl() {
+        assert_eq!(
+            detect_format(&PathBuf::from("data.jsonl")).unwrap(),
+            Format::Jsonl
+        );
+        assert_eq!(
+            detect_format(&PathBuf::from("data.ndjson")).unwrap(),
+            Format::Jsonl
         );
     }
 


### PR DESCRIPTION
## Summary

- Implement `JsonlReader` that parses JSONL (one JSON object per line) into `Value::Array`, with empty line skipping and line-numbered error reporting
- Implement `JsonlWriter` that serializes `Value::Array` elements as one compact JSON per line
- Register `Format::Jsonl` variant in the format enum, `detect_format`, `from_str`, and `Display`
- Add JSONL support (`.jsonl`, `.ndjson` extensions; `jsonl`/`jsonlines`/`ndjson` format strings) across all subcommands (convert, view, query, stats, schema, diff, merge)
- Comprehensive unit tests: basic read/write, empty input, various JSON types, error handling with line numbers, round-trip, large input (1000 lines)

## Test plan

- [x] `cargo test` — all 436 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — formatting clean

Closes #73

https://claude.ai/code/session_018m4L4sQb3icBQ2c2LwoR39