### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-23
+
+### Added
+
+- **XML Reader**: Parse XML files into `Value` with namespace handling (`--ns-mode strip/preserve`) and attribute support. (#71)
+- **XML Writer**: Serialize `Value` to XML with `--root-element` option for custom root element names. (#72)
+- **JSONL (JSON Lines) format**: Read and write `.jsonl` files — one JSON object per line. (#73)
+- **Content sniffing for format detection**: Auto-detect stdin format via content sniffing in addition to file extension detection. (#74)
+- **`convert` subcommand XML/JSONL integration**: Full support for XML and JSONL in all conversion paths. (#75)
+- **Comprehensive v0.4.0 integration tests**: End-to-end tests for XML, JSONL formats across all subcommands. (#76)
+
 ## [0.3.0] - 2026-03-21
 
 ### Added
@@ -48,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI pipeline**: GitHub Actions workflow with test (Linux/macOS/Windows), clippy, and rustfmt checks.
 - **Test suite**: Integration tests covering all conversion paths, query operations, table view, fixture data, edge cases (unicode, empty input, quoted CSV fields).
 
+[0.4.0]: https://github.com/syangkkim/dkit/releases/tag/v0.4.0
 [0.3.0]: https://github.com/syangkkim/dkit/releases/tag/v0.3.0
 [0.2.0]: https://github.com/syangkkim/dkit/releases/tag/v0.2.0
 [0.1.0]: https://github.com/syangkkim/dkit/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dkit"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkit"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Swiss army knife for data format conversion and querying"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Update Cargo.toml version from 0.3.0 to 0.4.0
- Add CHANGELOG entry for v0.4.0 covering XML Reader/Writer (#71, #72), JSONL format (#73), content sniffing (#74), convert integration (#75), and integration tests (#76)
- All checks pass: cargo fmt, cargo clippy, cargo test (94 tests)

Closes #77

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 94 tests pass

https://claude.ai/code/session_01C2zJrqakeDygSSu77mVA6K