### PR TITLE
feat: add Markdown table output format (GFM compatible)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub enum Commands {
         #[arg(value_name = "INPUT")]
         input: Vec<PathBuf>,
 
-        /// Output format (json, jsonl, csv, yaml, toml, xml)
+        /// Output format (json, jsonl, csv, yaml, toml, xml, md)
         #[arg(long, value_name = "FORMAT")]
         to: String,
 

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -8,6 +8,7 @@ use super::{read_file, read_file_bytes};
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::jsonl::{JsonlReader, JsonlWriter};
+use crate::format::markdown::MarkdownWriter;
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
@@ -183,6 +184,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader::default().read(content),
         Format::Msgpack => MsgpackReader.read(content),
+        Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
     }
 }
 
@@ -224,5 +226,6 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Toml => TomlWriter::new(options.clone()).write(value),
         Format::Xml => XmlWriter::new(options.pretty, options.root_element.clone()).write(value),
         Format::Msgpack => MsgpackWriter.write(value),
+        Format::Markdown => MarkdownWriter.write(value),
     }
 }

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -82,6 +82,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader::default().read(content),
         Format::Msgpack => MsgpackReader.read(content),
+        Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
     }
 }
 

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -7,6 +7,7 @@ use super::{read_file, read_file_bytes};
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::jsonl::{JsonlReader, JsonlWriter};
+use crate::format::markdown::MarkdownWriter;
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
@@ -174,6 +175,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader::default().read(content),
         Format::Msgpack => MsgpackReader.read(content),
+        Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
     }
 }
 
@@ -186,6 +188,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Toml => TomlWriter::new(options.clone()).write(value),
         Format::Xml => XmlWriter::new(options.pretty, options.root_element.clone()).write(value),
         Format::Msgpack => MsgpackWriter.write(value),
+        Format::Markdown => MarkdownWriter.write(value),
     }
 }
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -2,11 +2,12 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 
 use crate::format::csv::CsvReader;
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::jsonl::{JsonlReader, JsonlWriter};
+use crate::format::markdown::MarkdownWriter;
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};
 use crate::format::xml::{XmlReader, XmlWriter};
@@ -142,6 +143,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader::default().read(content),
         Format::Msgpack => MsgpackReader.read(content),
+        Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
     }
 }
 
@@ -163,5 +165,6 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Toml => TomlWriter::new(options.clone()).write(value),
         Format::Xml => XmlWriter::new(options.pretty, options.root_element.clone()).write(value),
         Format::Msgpack => MsgpackWriter.write(value),
+        Format::Markdown => MarkdownWriter.write(value),
     }
 }

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -13,7 +13,7 @@ use crate::format::{
     Format, FormatOptions, FormatReader,
 };
 use crate::value::Value;
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 pub struct SchemaArgs<'a> {
     pub input: &'a str,
@@ -202,6 +202,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader::default().read(content),
         Format::Msgpack => MsgpackReader.read(content),
+        Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
     }
 }
 

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -313,6 +313,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader::default().read(content),
         Format::Msgpack => MsgpackReader.read(content),
+        Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
     }
 }
 

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -130,6 +130,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Toml => TomlReader.read(content),
         Format::Xml => XmlReader::default().read(content),
         Format::Msgpack => MsgpackReader.read(content),
+        Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 /// 지원하는 포맷 목록 (에러 메시지용)
 pub const SUPPORTED_FORMATS: &[&str] = &[
-    "json", "jsonl", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack",
+    "json", "jsonl", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack", "md",
 ];
 
 /// dkit 에러 타입 정의

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -1,0 +1,346 @@
+use std::io::Write;
+
+use crate::format::FormatWriter;
+use crate::value::Value;
+
+/// Markdown 테이블 포맷 Writer (GFM 호환)
+///
+/// - Array<Object> → 컬럼 헤더 + 데이터 행
+/// - Array<Primitive> → 단일 "value" 컬럼
+/// - Single Object → key | value 2-컬럼 테이블
+/// - Primitive → 단일 값 출력
+pub struct MarkdownWriter;
+
+impl FormatWriter for MarkdownWriter {
+    fn write(&self, value: &Value) -> anyhow::Result<String> {
+        Ok(render_markdown(value))
+    }
+
+    fn write_to_writer(&self, value: &Value, mut writer: impl Write) -> anyhow::Result<()> {
+        let output = render_markdown(value);
+        writer.write_all(output.as_bytes())?;
+        Ok(())
+    }
+}
+
+fn render_markdown(value: &Value) -> String {
+    match value {
+        Value::Array(arr) if !arr.is_empty() && arr[0].as_object().is_some() => {
+            render_array_of_objects(arr)
+        }
+        Value::Array(arr) => render_array_of_primitives(arr),
+        Value::Object(_) => render_single_object(value),
+        _ => format_cell_value(value),
+    }
+}
+
+/// Array<Object> → Markdown 테이블
+fn render_array_of_objects(arr: &[Value]) -> String {
+    let headers = collect_keys(arr);
+    if headers.is_empty() {
+        return String::new();
+    }
+
+    let mut lines = Vec::new();
+
+    // 헤더 행
+    let header_line = format!(
+        "| {} |",
+        headers
+            .iter()
+            .map(|h| escape_pipe(h))
+            .collect::<Vec<_>>()
+            .join(" | ")
+    );
+    lines.push(header_line);
+
+    // 구분자 행 (숫자 컬럼은 우측 정렬)
+    let alignments: Vec<Alignment> = headers
+        .iter()
+        .map(|key| detect_column_alignment(arr, key))
+        .collect();
+    let separator_line = format!(
+        "| {} |",
+        alignments
+            .iter()
+            .map(|a| match a {
+                Alignment::Right => "---:".to_string(),
+                Alignment::Left => "---".to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join(" | ")
+    );
+    lines.push(separator_line);
+
+    // 데이터 행
+    for item in arr {
+        if let Value::Object(obj) = item {
+            let row = headers
+                .iter()
+                .map(|key| match obj.get(key) {
+                    Some(Value::Null) => "null".to_string(),
+                    Some(v) => escape_pipe(&format_cell_value(v)),
+                    None => String::new(),
+                })
+                .collect::<Vec<_>>();
+            lines.push(format!("| {} |", row.join(" | ")));
+        }
+    }
+
+    lines.join("\n") + "\n"
+}
+
+/// Array<Primitive> → 단일 컬럼 Markdown 테이블
+fn render_array_of_primitives(arr: &[Value]) -> String {
+    let mut lines = Vec::new();
+    lines.push("| value |".to_string());
+    lines.push("| --- |".to_string());
+
+    for item in arr {
+        lines.push(format!("| {} |", escape_pipe(&format_cell_value(item))));
+    }
+
+    lines.join("\n") + "\n"
+}
+
+/// 단일 Object → key | value 테이블
+fn render_single_object(value: &Value) -> String {
+    let mut lines = Vec::new();
+    lines.push("| key | value |".to_string());
+    lines.push("| --- | --- |".to_string());
+
+    if let Value::Object(obj) = value {
+        for (k, v) in obj {
+            lines.push(format!(
+                "| {} | {} |",
+                escape_pipe(k),
+                escape_pipe(&format_cell_value(v))
+            ));
+        }
+    }
+
+    lines.join("\n") + "\n"
+}
+
+/// 모든 object에서 키를 순서 보존하며 수집
+fn collect_keys(arr: &[Value]) -> Vec<String> {
+    let mut keys: Vec<String> = Vec::new();
+    for item in arr {
+        if let Value::Object(obj) = item {
+            for k in obj.keys() {
+                if !keys.contains(k) {
+                    keys.push(k.clone());
+                }
+            }
+        }
+    }
+    keys
+}
+
+#[derive(Debug)]
+enum Alignment {
+    Left,
+    Right,
+}
+
+/// 컬럼의 값이 모두 숫자이면 우측 정렬, 아니면 좌측 정렬
+fn detect_column_alignment(arr: &[Value], key: &str) -> Alignment {
+    let mut has_value = false;
+    for item in arr {
+        if let Value::Object(obj) = item {
+            match obj.get(key) {
+                Some(Value::Integer(_)) | Some(Value::Float(_)) => {
+                    has_value = true;
+                }
+                Some(Value::Null) | None => {
+                    // null/missing은 무시
+                }
+                _ => return Alignment::Left,
+            }
+        }
+    }
+    if has_value {
+        Alignment::Right
+    } else {
+        Alignment::Left
+    }
+}
+
+/// Value를 셀 표시용 문자열로 변환
+fn format_cell_value(v: &Value) -> String {
+    match v {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Integer(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => s.clone(),
+        Value::Array(_) | Value::Object(_) => {
+            // 중첩 객체/배열은 JSON 문자열로 inline 표시
+            serde_json::to_string(&value_to_json(v)).unwrap_or_else(|_| "{...}".to_string())
+        }
+    }
+}
+
+/// Value를 serde_json::Value로 변환 (중첩 표시용)
+fn value_to_json(v: &Value) -> serde_json::Value {
+    match v {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Integer(n) => serde_json::json!(n),
+        Value::Float(f) => serde_json::json!(f),
+        Value::String(s) => serde_json::Value::String(s.clone()),
+        Value::Array(arr) => serde_json::Value::Array(arr.iter().map(value_to_json).collect()),
+        Value::Object(obj) => {
+            let map: serde_json::Map<String, serde_json::Value> = obj
+                .iter()
+                .map(|(k, v)| (k.clone(), value_to_json(v)))
+                .collect();
+            serde_json::Value::Object(map)
+        }
+    }
+}
+
+/// 파이프 문자(`|`) 이스케이프 처리
+fn escape_pipe(s: &str) -> String {
+    s.replace('|', "\\|")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::FormatWriter;
+    use indexmap::IndexMap;
+
+    fn make_user(name: &str, age: i64) -> Value {
+        let mut m = IndexMap::new();
+        m.insert("name".to_string(), Value::String(name.to_string()));
+        m.insert("age".to_string(), Value::Integer(age));
+        Value::Object(m)
+    }
+
+    #[test]
+    fn test_array_of_objects() {
+        let data = Value::Array(vec![make_user("Alice", 30), make_user("Bob", 25)]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        assert!(output.contains("| name | age |"));
+        assert!(output.contains("| --- | ---: |")); // age는 숫자이므로 우측 정렬
+        assert!(output.contains("| Alice | 30 |"));
+        assert!(output.contains("| Bob | 25 |"));
+    }
+
+    #[test]
+    fn test_numeric_right_alignment() {
+        let mut m1 = IndexMap::new();
+        m1.insert("label".to_string(), Value::String("x".to_string()));
+        m1.insert("count".to_string(), Value::Integer(10));
+        let mut m2 = IndexMap::new();
+        m2.insert("label".to_string(), Value::String("y".to_string()));
+        m2.insert("count".to_string(), Value::Integer(20));
+        let data = Value::Array(vec![Value::Object(m1), Value::Object(m2)]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        // label은 좌측, count는 우측 정렬
+        assert!(output.contains("| --- | ---: |"));
+    }
+
+    #[test]
+    fn test_mixed_column_left_alignment() {
+        let mut m1 = IndexMap::new();
+        m1.insert("val".to_string(), Value::Integer(10));
+        let mut m2 = IndexMap::new();
+        m2.insert("val".to_string(), Value::String("text".to_string()));
+        let data = Value::Array(vec![Value::Object(m1), Value::Object(m2)]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        // 혼합 타입이므로 좌측 정렬
+        assert!(output.contains("| --- |"));
+        assert!(!output.contains("---:"));
+    }
+
+    #[test]
+    fn test_single_object() {
+        let mut m = IndexMap::new();
+        m.insert("host".to_string(), Value::String("localhost".to_string()));
+        m.insert("port".to_string(), Value::Integer(8080));
+        let data = Value::Object(m);
+        let output = MarkdownWriter.write(&data).unwrap();
+        assert!(output.contains("| key | value |"));
+        assert!(output.contains("| host | localhost |"));
+        assert!(output.contains("| port | 8080 |"));
+    }
+
+    #[test]
+    fn test_array_of_primitives() {
+        let data = Value::Array(vec![
+            Value::Integer(1),
+            Value::Integer(2),
+            Value::Integer(3),
+        ]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        assert!(output.contains("| value |"));
+        assert!(output.contains("| 1 |"));
+        assert!(output.contains("| 2 |"));
+        assert!(output.contains("| 3 |"));
+    }
+
+    #[test]
+    fn test_primitive_value() {
+        let data = Value::String("hello".to_string());
+        let output = MarkdownWriter.write(&data).unwrap();
+        assert_eq!(output, "hello");
+    }
+
+    #[test]
+    fn test_null_value_in_cell() {
+        let mut m = IndexMap::new();
+        m.insert("name".to_string(), Value::String("Alice".to_string()));
+        m.insert("email".to_string(), Value::Null);
+        let data = Value::Array(vec![Value::Object(m)]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        assert!(output.contains("null"));
+    }
+
+    #[test]
+    fn test_nested_value_json_inline() {
+        let mut m = IndexMap::new();
+        m.insert(
+            "tags".to_string(),
+            Value::Array(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+            ]),
+        );
+        let data = Value::Array(vec![Value::Object(m)]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        // 중첩 배열은 JSON 문자열로 표시
+        assert!(output.contains(r#"["a","b"]"#));
+    }
+
+    #[test]
+    fn test_pipe_escape() {
+        let mut m = IndexMap::new();
+        m.insert("formula".to_string(), Value::String("a | b".to_string()));
+        let data = Value::Array(vec![Value::Object(m)]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        assert!(output.contains(r"a \| b"));
+    }
+
+    #[test]
+    fn test_empty_array() {
+        let data = Value::Array(vec![]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        assert!(output.contains("| value |"));
+    }
+
+    #[test]
+    fn test_missing_fields() {
+        let mut m1 = IndexMap::new();
+        m1.insert("a".to_string(), Value::Integer(1));
+        m1.insert("b".to_string(), Value::Integer(2));
+        let mut m2 = IndexMap::new();
+        m2.insert("a".to_string(), Value::Integer(3));
+        // m2 has no "b" field
+        let data = Value::Array(vec![Value::Object(m1), Value::Object(m2)]);
+        let output = MarkdownWriter.write(&data).unwrap();
+        assert!(output.contains("| a | b |"));
+        assert!(output.contains("| 3 |  |")); // missing field → empty
+    }
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,6 +1,7 @@
 pub mod csv;
 pub mod json;
 pub mod jsonl;
+pub mod markdown;
 pub mod msgpack;
 pub mod toml;
 pub mod xml;
@@ -22,6 +23,7 @@ pub enum Format {
     Toml,
     Xml,
     Msgpack,
+    Markdown,
 }
 
 impl Format {
@@ -34,6 +36,7 @@ impl Format {
             "toml" => Ok(Format::Toml),
             "xml" => Ok(Format::Xml),
             "msgpack" | "messagepack" => Ok(Format::Msgpack),
+            "md" | "markdown" => Ok(Format::Markdown),
             _ => Err(DkitError::UnknownFormat(s.to_string())),
         }
     }
@@ -49,6 +52,7 @@ impl std::fmt::Display for Format {
             Format::Toml => write!(f, "TOML"),
             Format::Xml => write!(f, "XML"),
             Format::Msgpack => write!(f, "MessagePack"),
+            Format::Markdown => write!(f, "Markdown"),
         }
     }
 }
@@ -63,6 +67,7 @@ pub fn detect_format(path: &Path) -> Result<Format, DkitError> {
         Some("toml") => Ok(Format::Toml),
         Some("xml") => Ok(Format::Xml),
         Some("msgpack") => Ok(Format::Msgpack),
+        Some("md") => Ok(Format::Markdown),
         Some(ext) => Err(DkitError::UnknownFormat(ext.to_string())),
         None => Err(DkitError::UnknownFormat("(no extension)".to_string())),
     }
@@ -265,6 +270,13 @@ mod tests {
     }
 
     #[test]
+    fn test_format_from_str_markdown() {
+        assert_eq!(Format::from_str("md").unwrap(), Format::Markdown);
+        assert_eq!(Format::from_str("markdown").unwrap(), Format::Markdown);
+        assert_eq!(Format::from_str("MD").unwrap(), Format::Markdown);
+    }
+
+    #[test]
     fn test_format_from_str_unknown() {
         let err = Format::from_str("bin").unwrap_err();
         assert!(matches!(err, DkitError::UnknownFormat(s) if s == "bin"));
@@ -281,6 +293,7 @@ mod tests {
         assert_eq!(Format::Jsonl.to_string(), "JSONL");
         assert_eq!(Format::Xml.to_string(), "XML");
         assert_eq!(Format::Msgpack.to_string(), "MessagePack");
+        assert_eq!(Format::Markdown.to_string(), "Markdown");
     }
 
     // --- detect_format ---
@@ -350,6 +363,14 @@ mod tests {
         assert_eq!(
             detect_format(&PathBuf::from("data.msgpack")).unwrap(),
             Format::Msgpack
+        );
+    }
+
+    #[test]
+    fn test_detect_format_markdown() {
+        assert_eq!(
+            detect_format(&PathBuf::from("output.md")).unwrap(),
+            Format::Markdown
         );
     }
 

--- a/tests/markdown_test.rs
+++ b/tests/markdown_test.rs
@@ -1,0 +1,116 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+#[test]
+fn convert_json_to_md() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.json", "--to", "md"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("| age |"))
+        .stdout(predicate::str::contains("| Alice |"));
+}
+
+#[test]
+fn convert_csv_to_md() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.csv", "--to", "md"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("| name |"))
+        .stdout(predicate::str::contains("| --- |"));
+}
+
+#[test]
+fn convert_yaml_to_md() {
+    dkit()
+        .args(&["convert", "tests/fixtures/config.yaml", "--to", "md"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("| key | value |"));
+}
+
+#[test]
+fn convert_json_to_md_output_file() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("output.md");
+
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "--to",
+            "md",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out).unwrap();
+    assert!(content.contains("| age |"));
+    assert!(content.contains("| Alice |"));
+}
+
+#[test]
+fn convert_md_numeric_right_alignment() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.json", "--to", "md"])
+        .assert()
+        .success()
+        // age column should be right-aligned (---:)
+        .stdout(predicate::str::contains("---:"));
+}
+
+#[test]
+fn convert_stdin_to_md() {
+    dkit()
+        .args(&["convert", "--from", "json", "--to", "md"])
+        .write_stdin(r#"[{"x": 1}, {"x": 2}]"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("| x |"))
+        .stdout(predicate::str::contains("| 1 |"))
+        .stdout(predicate::str::contains("| 2 |"));
+}
+
+#[test]
+fn convert_md_pipe_escape() {
+    dkit()
+        .args(&["convert", "--from", "json", "--to", "md"])
+        .write_stdin(r#"[{"col": "a | b"}]"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r"a \| b"));
+}
+
+#[test]
+fn convert_md_nested_json_inline() {
+    dkit()
+        .args(&["convert", "--from", "json", "--to", "md"])
+        .write_stdin(r#"[{"tags": ["a", "b"]}]"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#"["a","b"]"#));
+}
+
+#[test]
+fn query_output_as_md() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/users.json",
+            ".",
+            "--to",
+            "md",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("| name |"));
+}


### PR DESCRIPTION
## Summary
- Markdown 테이블 출력 포맷(GFM 호환) Writer 구현
- 숫자 컬럼 자동 우측 정렬, 파이프 문자 이스케이프, 중첩 객체/배열 JSON inline 표시
- `dkit convert data.json --to md` 또는 `--to markdown`으로 사용 가능
- 출력 전용 포맷 (입력으로 사용 시 명확한 에러 메시지 제공)

Closes #78

## Test plan
- [x] 단위 테스트: MarkdownWriter의 다양한 입력 케이스 (배열/객체/프리미티브/null/중첩/파이프 이스케이프)
- [x] 통합 테스트: JSON/CSV/YAML → Markdown 변환, stdin 입력, 파일 출력, query --to md
- [x] cargo clippy, cargo fmt 통과 확인

https://claude.ai/code/session_013rtM3EkbEZbchvFqDqqLSU