### PR TITLE
feat: add table output customization options for view command

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -156,6 +156,11 @@ dkit view <INPUT> [OPTIONS]
 | `--path <QUERY>` | 중첩 데이터 경로 | root |
 | `--limit <N>` | 표시할 행 수 | 전체 |
 | `--columns <COLS>` | 표시할 컬럼 (쉼표 구분) | 전체 |
+| `--max-width <N>` | 컬럼 최대 너비 (긴 값 잘라내기) | 제한 없음 |
+| `--hide-header` | 헤더 행 숨기기 | false |
+| `--row-numbers` | 행 번호 표시 | false |
+| `--border <STYLE>` | 테이블 테두리 스타일 (none, simple, rounded, heavy) | simple |
+| `--color` | 데이터 타입별 색상 출력 (숫자=청색, null=회색, 불리언=노란색) | false |
 
 ### Examples
 
@@ -164,6 +169,9 @@ dkit view users.csv
 dkit view data.json --path '.users'
 dkit view large_data.csv --limit 20
 dkit view users.csv --columns name,email
+dkit view data.csv --border rounded --color
+dkit view data.json --row-numbers --max-width 30
+dkit view data.json --hide-header --border none
 ```
 
 ## stats

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,7 +103,7 @@ pub enum Commands {
 
     /// View data in a formatted table
     #[command(
-        after_help = "Examples:\n  dkit view data.csv\n  dkit view data.json --path .users --limit 5\n  dkit view data.json --columns name,email"
+        after_help = "Examples:\n  dkit view data.csv\n  dkit view data.json --path .users --limit 5\n  dkit view data.json --columns name,email\n  dkit view data.csv --border rounded --color\n  dkit view data.json --row-numbers --max-width 30"
     )]
     View {
         /// Input file path (use '-' for stdin)
@@ -133,6 +133,26 @@ pub enum Commands {
         /// Treat CSV as having no header row
         #[arg(long)]
         no_header: bool,
+
+        /// Maximum column width (truncate longer values)
+        #[arg(long, value_name = "N")]
+        max_width: Option<u16>,
+
+        /// Hide header row in table output
+        #[arg(long)]
+        hide_header: bool,
+
+        /// Show row numbers
+        #[arg(long)]
+        row_numbers: bool,
+
+        /// Table border style
+        #[arg(long, value_name = "STYLE", default_value = "simple")]
+        border: String,
+
+        /// Colorize output by data type (numbers=blue, null=gray)
+        #[arg(long)]
+        color: bool,
     },
 
     /// Show statistics about data

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -6,9 +6,9 @@ use anyhow::{bail, Context, Result};
 
 use super::{read_file, read_file_bytes};
 use crate::format::csv::{CsvReader, CsvWriter};
+use crate::format::html::HtmlWriter;
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::jsonl::{JsonlReader, JsonlWriter};
-use crate::format::html::HtmlWriter;
 use crate::format::markdown::MarkdownWriter;
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -5,9 +5,9 @@ use anyhow::{bail, Context, Result};
 
 use super::{read_file, read_file_bytes};
 use crate::format::csv::{CsvReader, CsvWriter};
+use crate::format::html::HtmlWriter;
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::jsonl::{JsonlReader, JsonlWriter};
-use crate::format::html::HtmlWriter;
 use crate::format::markdown::MarkdownWriter;
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -5,9 +5,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 
 use crate::format::csv::CsvReader;
+use crate::format::html::HtmlWriter;
 use crate::format::json::{JsonReader, JsonWriter};
 use crate::format::jsonl::{JsonlReader, JsonlWriter};
-use crate::format::html::HtmlWriter;
 use crate::format::markdown::MarkdownWriter;
 use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
 use crate::format::toml::{TomlReader, TomlWriter};

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -14,7 +14,7 @@ use crate::format::{
     default_delimiter, default_delimiter_for_format, detect_format, detect_format_from_content,
     Format, FormatOptions, FormatReader,
 };
-use crate::output::table::render_table;
+use crate::output::table::{render_table, TableOptions};
 use crate::value::Value;
 
 pub struct ViewArgs<'a> {
@@ -25,6 +25,11 @@ pub struct ViewArgs<'a> {
     pub columns: Option<Vec<String>>,
     pub delimiter: Option<char>,
     pub no_header: bool,
+    pub max_width: Option<u16>,
+    pub hide_header: bool,
+    pub row_numbers: bool,
+    pub border: &'a str,
+    pub color: bool,
 }
 
 /// view 서브커맨드 실행
@@ -73,7 +78,16 @@ pub fn run(args: &ViewArgs) -> Result<()> {
         None => value,
     };
 
-    let output = render_table(&target, args.limit, args.columns.as_deref());
+    let table_opts = TableOptions {
+        limit: args.limit,
+        columns: args.columns.as_deref(),
+        max_width: args.max_width,
+        hide_header: args.hide_header,
+        row_numbers: args.row_numbers,
+        border: args.border,
+        color: args.color,
+    };
+    let output = render_table(&target, &table_opts);
 
     println!("{output}");
     Ok(())

--- a/src/format/html.rs
+++ b/src/format/html.rs
@@ -63,7 +63,8 @@ fn wrap_full_html(table: &str, styled: bool) -> String {
     )
 }
 
-const TABLE_STYLE: &str = " style=\"border-collapse: collapse; width: 100%; font-family: sans-serif;\"";
+const TABLE_STYLE: &str =
+    " style=\"border-collapse: collapse; width: 100%; font-family: sans-serif;\"";
 const TH_STYLE: &str = " style=\"border: 1px solid #ddd; padding: 8px; text-align: left; background-color: #4a4a4a; color: white;\"";
 const TD_STYLE: &str = " style=\"border: 1px solid #ddd; padding: 8px; text-align: left;\"";
 
@@ -293,10 +294,7 @@ mod tests {
     #[test]
     fn test_ampersand_escape() {
         let mut m = IndexMap::new();
-        m.insert(
-            "text".to_string(),
-            Value::String("A & B".to_string()),
-        );
+        m.insert("text".to_string(), Value::String("A & B".to_string()));
         let data = Value::Array(vec![Value::Object(m)]);
         let output = HtmlWriter::new(false, false).write(&data).unwrap();
         assert!(output.contains("A &amp; B"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,11 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             columns,
             delimiter,
             no_header,
+            max_width,
+            hide_header,
+            row_numbers,
+            border,
+            color,
         } => {
             commands::view::run(&commands::view::ViewArgs {
                 input: &input,
@@ -108,6 +113,11 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                 columns,
                 delimiter,
                 no_header,
+                max_width,
+                hide_header,
+                row_numbers,
+                border: &border,
+                color,
             })?;
         }
         Commands::Stats {

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -1,6 +1,33 @@
-use comfy_table::{Cell, ContentArrangement, Table};
+use colored::Colorize;
+use comfy_table::presets;
+use comfy_table::{Cell, ColumnConstraint, ContentArrangement, Table, Width};
 
 use crate::value::Value;
+
+/// 테이블 렌더링 옵션
+pub struct TableOptions<'a> {
+    pub limit: Option<usize>,
+    pub columns: Option<&'a [String]>,
+    pub max_width: Option<u16>,
+    pub hide_header: bool,
+    pub row_numbers: bool,
+    pub border: &'a str,
+    pub color: bool,
+}
+
+impl<'a> Default for TableOptions<'a> {
+    fn default() -> Self {
+        Self {
+            limit: None,
+            columns: None,
+            max_width: None,
+            hide_header: false,
+            row_numbers: false,
+            border: "simple",
+            color: false,
+        }
+    }
+}
 
 /// Value 데이터를 테이블 문자열로 렌더링한다.
 ///
@@ -8,57 +35,99 @@ use crate::value::Value;
 /// - Array of primitives → 단일 "value" 컬럼
 /// - Single Object → key/value 2-컬럼 테이블
 /// - Primitive → 단일 값 출력
-pub fn render_table(value: &Value, limit: Option<usize>, columns: Option<&[String]>) -> String {
+pub fn render_table(value: &Value, opts: &TableOptions) -> String {
     match value {
         Value::Array(arr) if !arr.is_empty() && arr[0].as_object().is_some() => {
-            render_array_of_objects(arr, limit, columns)
+            render_array_of_objects(arr, opts)
         }
-        Value::Array(arr) => render_array_of_primitives(arr, limit),
-        Value::Object(_) => render_single_object(value, columns),
+        Value::Array(arr) => render_array_of_primitives(arr, opts),
+        Value::Object(_) => render_single_object(value, opts),
         _ => format!("{value}"),
     }
 }
 
+/// 테이블에 공통 스타일을 적용한다
+fn apply_table_style(table: &mut Table, opts: &TableOptions) {
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+
+    let preset = match opts.border {
+        "none" => presets::NOTHING,
+        "rounded" => presets::UTF8_FULL_CONDENSED,
+        "heavy" => presets::UTF8_FULL,
+        _ => presets::ASCII_FULL_CONDENSED, // "simple" (default)
+    };
+    table.load_preset(preset);
+
+    if let Some(max_w) = opts.max_width {
+        let col_count = table.column_count();
+        let constraints: Vec<ColumnConstraint> = (0..col_count)
+            .map(|_| ColumnConstraint::UpperBoundary(Width::Fixed(max_w)))
+            .collect();
+        table.set_constraints(constraints);
+    }
+}
+
+/// 셀 값을 색상 적용하여 생성
+fn make_cell(v: &Value, color: bool) -> Cell {
+    if !color {
+        return Cell::new(format_cell_value(v));
+    }
+    let text = format_cell_value(v);
+    let colored_text = match v {
+        Value::Integer(_) | Value::Float(_) => text.blue().to_string(),
+        Value::Null => text.dimmed().to_string(),
+        Value::Bool(_) => text.yellow().to_string(),
+        _ => text,
+    };
+    Cell::new(colored_text)
+}
+
 /// Array<Object> → 테이블 (각 object = 1행)
-fn render_array_of_objects(
-    arr: &[Value],
-    limit: Option<usize>,
-    columns: Option<&[String]>,
-) -> String {
-    // 모든 object에서 키를 수집하여 컬럼 헤더 결정 (순서 보존)
+fn render_array_of_objects(arr: &[Value], opts: &TableOptions) -> String {
     let all_keys = collect_keys(arr);
-    let headers: Vec<&String> = match columns {
+    let headers: Vec<&String> = match opts.columns {
         Some(cols) => all_keys.iter().filter(|k| cols.contains(k)).collect(),
         None => all_keys.iter().collect(),
     };
 
     let mut table = Table::new();
-    table.set_content_arrangement(ContentArrangement::Dynamic);
-    table.set_header(headers.iter().copied().map(Cell::new));
 
-    let row_count = match limit {
+    if !opts.hide_header {
+        let mut header_cells: Vec<Cell> = Vec::new();
+        if opts.row_numbers {
+            header_cells.push(Cell::new("#"));
+        }
+        header_cells.extend(headers.iter().copied().map(Cell::new));
+        table.set_header(header_cells);
+    }
+
+    // Apply style after setting header so column_count is correct
+    apply_table_style(&mut table, opts);
+
+    let row_count = match opts.limit {
         Some(n) => n.min(arr.len()),
         None => arr.len(),
     };
 
-    for item in arr.iter().take(row_count) {
+    for (i, item) in arr.iter().take(row_count).enumerate() {
         if let Value::Object(obj) = item {
-            let row: Vec<Cell> = headers
-                .iter()
-                .map(|key| {
-                    let cell_text = match obj.get(*key) {
-                        Some(Value::Null) => "null".to_string(),
-                        Some(v) => format_cell_value(v),
-                        None => "".to_string(),
-                    };
-                    Cell::new(cell_text)
-                })
-                .collect();
+            let mut row: Vec<Cell> = Vec::new();
+            if opts.row_numbers {
+                row.push(Cell::new(i + 1));
+            }
+            row.extend(headers.iter().map(|key| {
+                let val = obj.get(*key).unwrap_or(&Value::Null);
+                if val == &Value::Null && obj.get(*key).is_none() {
+                    Cell::new("")
+                } else {
+                    make_cell(val, opts.color)
+                }
+            }));
             table.add_row(row);
         }
     }
 
-    if let Some(n) = limit {
+    if let Some(n) = opts.limit {
         if n < arr.len() {
             table.add_row(vec![Cell::new(format!(
                 "... ({} more rows)",
@@ -71,21 +140,35 @@ fn render_array_of_objects(
 }
 
 /// Array<Primitive> → 단일 컬럼 테이블
-fn render_array_of_primitives(arr: &[Value], limit: Option<usize>) -> String {
+fn render_array_of_primitives(arr: &[Value], opts: &TableOptions) -> String {
     let mut table = Table::new();
-    table.set_content_arrangement(ContentArrangement::Dynamic);
-    table.set_header(vec![Cell::new("value")]);
 
-    let row_count = match limit {
+    if !opts.hide_header {
+        let mut header_cells: Vec<Cell> = Vec::new();
+        if opts.row_numbers {
+            header_cells.push(Cell::new("#"));
+        }
+        header_cells.push(Cell::new("value"));
+        table.set_header(header_cells);
+    }
+
+    apply_table_style(&mut table, opts);
+
+    let row_count = match opts.limit {
         Some(n) => n.min(arr.len()),
         None => arr.len(),
     };
 
-    for item in arr.iter().take(row_count) {
-        table.add_row(vec![Cell::new(format_cell_value(item))]);
+    for (i, item) in arr.iter().take(row_count).enumerate() {
+        let mut row: Vec<Cell> = Vec::new();
+        if opts.row_numbers {
+            row.push(Cell::new(i + 1));
+        }
+        row.push(make_cell(item, opts.color));
+        table.add_row(row);
     }
 
-    if let Some(n) = limit {
+    if let Some(n) = opts.limit {
         if n < arr.len() {
             table.add_row(vec![Cell::new(format!(
                 "... ({} more rows)",
@@ -98,19 +181,24 @@ fn render_array_of_primitives(arr: &[Value], limit: Option<usize>) -> String {
 }
 
 /// 단일 Object → key | value 테이블
-fn render_single_object(value: &Value, columns: Option<&[String]>) -> String {
+fn render_single_object(value: &Value, opts: &TableOptions) -> String {
     let mut table = Table::new();
-    table.set_content_arrangement(ContentArrangement::Dynamic);
-    table.set_header(vec![Cell::new("key"), Cell::new("value")]);
+
+    if !opts.hide_header {
+        table.set_header(vec![Cell::new("key"), Cell::new("value")]);
+    }
+
+    apply_table_style(&mut table, opts);
 
     if let Value::Object(obj) = value {
         for (k, v) in obj {
-            if let Some(cols) = columns {
+            if let Some(cols) = opts.columns {
                 if !cols.contains(k) {
                     continue;
                 }
             }
-            table.add_row(vec![Cell::new(k), Cell::new(format_cell_value(v))]);
+            let val_cell = make_cell(v, opts.color);
+            table.add_row(vec![Cell::new(k), val_cell]);
         }
     }
 
@@ -153,6 +241,10 @@ mod tests {
     use super::*;
     use indexmap::IndexMap;
 
+    fn default_opts() -> TableOptions<'static> {
+        TableOptions::default()
+    }
+
     fn make_user(name: &str, age: i64) -> Value {
         let mut m = IndexMap::new();
         m.insert("name".to_string(), Value::String(name.to_string()));
@@ -163,7 +255,7 @@ mod tests {
     #[test]
     fn test_render_array_of_objects() {
         let data = Value::Array(vec![make_user("Alice", 30), make_user("Bob", 25)]);
-        let output = render_table(&data, None, None);
+        let output = render_table(&data, &default_opts());
         assert!(output.contains("name"));
         assert!(output.contains("age"));
         assert!(output.contains("Alice"));
@@ -179,7 +271,11 @@ mod tests {
             make_user("Bob", 25),
             make_user("Charlie", 35),
         ]);
-        let output = render_table(&data, Some(2), None);
+        let opts = TableOptions {
+            limit: Some(2),
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
         assert!(output.contains("Alice"));
         assert!(output.contains("Bob"));
         assert!(!output.contains("Charlie"));
@@ -190,11 +286,13 @@ mod tests {
     fn test_render_with_columns() {
         let data = Value::Array(vec![make_user("Alice", 30), make_user("Bob", 25)]);
         let cols = vec!["name".to_string()];
-        let output = render_table(&data, None, Some(&cols));
+        let opts = TableOptions {
+            columns: Some(&cols),
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
         assert!(output.contains("name"));
         assert!(output.contains("Alice"));
-        // age column should not appear in header
-        // (the values 30/25 won't appear since the age column is filtered)
     }
 
     #[test]
@@ -204,7 +302,7 @@ mod tests {
             Value::Integer(2),
             Value::Integer(3),
         ]);
-        let output = render_table(&data, None, None);
+        let output = render_table(&data, &default_opts());
         assert!(output.contains("value"));
         assert!(output.contains('1'));
         assert!(output.contains('2'));
@@ -217,7 +315,7 @@ mod tests {
         m.insert("host".to_string(), Value::String("localhost".to_string()));
         m.insert("port".to_string(), Value::Integer(8080));
         let data = Value::Object(m);
-        let output = render_table(&data, None, None);
+        let output = render_table(&data, &default_opts());
         assert!(output.contains("key"));
         assert!(output.contains("value"));
         assert!(output.contains("host"));
@@ -233,7 +331,11 @@ mod tests {
         m.insert("port".to_string(), Value::Integer(8080));
         let data = Value::Object(m);
         let cols = vec!["host".to_string()];
-        let output = render_table(&data, None, Some(&cols));
+        let opts = TableOptions {
+            columns: Some(&cols),
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
         assert!(output.contains("host"));
         assert!(!output.contains("8080"));
     }
@@ -241,7 +343,7 @@ mod tests {
     #[test]
     fn test_render_primitive() {
         let data = Value::String("hello".to_string());
-        let output = render_table(&data, None, None);
+        let output = render_table(&data, &default_opts());
         assert_eq!(output, "hello");
     }
 
@@ -251,7 +353,7 @@ mod tests {
         m.insert("name".to_string(), Value::String("Alice".to_string()));
         m.insert("email".to_string(), Value::Null);
         let data = Value::Array(vec![Value::Object(m)]);
-        let output = render_table(&data, None, None);
+        let output = render_table(&data, &default_opts());
         assert!(output.contains("null"));
     }
 
@@ -266,23 +368,127 @@ mod tests {
             ]),
         );
         let data = Value::Array(vec![Value::Object(m)]);
-        let output = render_table(&data, None, None);
+        let output = render_table(&data, &default_opts());
         assert!(output.contains("[a, b]"));
     }
 
     #[test]
     fn test_render_empty_array() {
         let data = Value::Array(vec![]);
-        let output = render_table(&data, None, None);
-        // Empty array of primitives path
+        let output = render_table(&data, &default_opts());
         assert!(output.contains("value"));
     }
 
     #[test]
     fn test_limit_larger_than_data() {
         let data = Value::Array(vec![make_user("Alice", 30)]);
-        let output = render_table(&data, Some(100), None);
+        let opts = TableOptions {
+            limit: Some(100),
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
         assert!(output.contains("Alice"));
         assert!(!output.contains("more rows"));
+    }
+
+    #[test]
+    fn test_hide_header() {
+        let data = Value::Array(vec![make_user("Alice", 30)]);
+        let opts = TableOptions {
+            hide_header: true,
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
+        assert!(output.contains("Alice"));
+        assert!(output.contains("30"));
+        // Header row should not appear as a labeled row
+        assert!(!output.contains(" name "));
+    }
+
+    #[test]
+    fn test_row_numbers() {
+        let data = Value::Array(vec![make_user("Alice", 30), make_user("Bob", 25)]);
+        let opts = TableOptions {
+            row_numbers: true,
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
+        assert!(output.contains('#'));
+        assert!(output.contains(" 1 "));
+        assert!(output.contains(" 2 "));
+    }
+
+    #[test]
+    fn test_border_none() {
+        let data = Value::Array(vec![make_user("Alice", 30)]);
+        let opts = TableOptions {
+            border: "none",
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
+        assert!(output.contains("Alice"));
+        // No border characters
+        assert!(!output.contains('+'));
+        assert!(!output.contains('|'));
+    }
+
+    #[test]
+    fn test_border_rounded() {
+        let data = Value::Array(vec![make_user("Alice", 30)]);
+        let opts = TableOptions {
+            border: "rounded",
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
+        assert!(output.contains("Alice"));
+        // UTF8 border characters
+        assert!(output.contains('┌') || output.contains('│'));
+    }
+
+    #[test]
+    fn test_border_heavy() {
+        let data = Value::Array(vec![make_user("Alice", 30)]);
+        let opts = TableOptions {
+            border: "heavy",
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
+        assert!(output.contains("Alice"));
+        assert!(output.contains('┌') || output.contains('│'));
+    }
+
+    #[test]
+    fn test_max_width_truncation() {
+        let mut m = IndexMap::new();
+        m.insert(
+            "text".to_string(),
+            Value::String("This is a very long text that should be truncated".to_string()),
+        );
+        let data = Value::Array(vec![Value::Object(m)]);
+        let opts = TableOptions {
+            max_width: Some(10),
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
+        // The full text should not appear
+        assert!(!output.contains("This is a very long text that should be truncated"));
+    }
+
+    #[test]
+    fn test_row_numbers_with_primitives() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+        ]);
+        let opts = TableOptions {
+            row_numbers: true,
+            ..default_opts()
+        };
+        let output = render_table(&data, &opts);
+        assert!(output.contains('#'));
+        assert!(output.contains(" 1 "));
+        assert!(output.contains(" 2 "));
+        assert!(output.contains(" 3 "));
     }
 }

--- a/tests/markdown_test.rs
+++ b/tests/markdown_test.rs
@@ -103,13 +103,7 @@ fn convert_md_nested_json_inline() {
 #[test]
 fn query_output_as_md() {
     dkit()
-        .args(&[
-            "query",
-            "tests/fixtures/users.json",
-            ".",
-            "--to",
-            "md",
-        ])
+        .args(&["query", "tests/fixtures/users.json", ".", "--to", "md"])
         .assert()
         .success()
         .stdout(predicate::str::contains("| name |"));

--- a/tests/view_test.rs
+++ b/tests/view_test.rs
@@ -147,3 +147,103 @@ fn view_stdin_with_from() {
         .stdout(predicate::str::contains("name"))
         .stdout(predicate::str::contains("Test"));
 }
+
+// --- --hide-header 옵션 ---
+
+#[test]
+fn view_hide_header() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json", "--hide-header"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("name").not());
+}
+
+// --- --row-numbers 옵션 ---
+
+#[test]
+fn view_row_numbers() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json", "--row-numbers"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#"))
+        .stdout(predicate::str::contains(" 1 "));
+}
+
+// --- --border 옵션 ---
+
+#[test]
+fn view_border_none() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json", "--border", "none"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("+").not())
+        .stdout(predicate::str::contains("|").not());
+}
+
+#[test]
+fn view_border_rounded() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json", "--border", "rounded"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+}
+
+#[test]
+fn view_border_heavy() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json", "--border", "heavy"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+}
+
+// --- --max-width 옵션 ---
+
+#[test]
+fn view_max_width() {
+    dkit()
+        .args(&["view", "-", "--from", "json", "--max-width", "5"])
+        .write_stdin("[{\"name\": \"VeryLongNameThatShouldBeTruncated\"}]")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("VeryLongNameThatShouldBeTruncated").not());
+}
+
+// --- --color 옵션 ---
+
+#[test]
+fn view_color() {
+    dkit()
+        .args(&["view", "tests/fixtures/users.json", "--color"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+}
+
+// --- 옵션 조합 ---
+
+#[test]
+fn view_combined_options() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/users.json",
+            "--row-numbers",
+            "--border",
+            "rounded",
+            "-n",
+            "1",
+            "--columns",
+            "name",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#"))
+        .stdout(predicate::str::contains("Alice"));
+}


### PR DESCRIPTION
## Summary
- Fix rustfmt formatting issues from PR #131/#132 (import ordering, line length)
- Add `--max-width`, `--hide-header`, `--row-numbers`, `--border`, and `--color` options to the `view` subcommand
- Refactor table renderer to use `TableOptions` struct for cleaner option passing

## New Options
| Option | Description |
|--------|-------------|
| `--max-width <N>` | Column max width (truncate longer values) |
| `--hide-header` | Hide header row in table output |
| `--row-numbers` | Show row numbers |
| `--border <STYLE>` | Border style: none, simple (default), rounded, heavy |
| `--color` | Colorize by data type (numbers=blue, null=gray, bool=yellow) |

## Test plan
- [x] All 484 unit tests pass
- [x] All existing integration tests pass
- [x] 8 new integration tests for new options (hide-header, row-numbers, border styles, max-width, color, combined)
- [x] cargo clippy clean
- [x] cargo fmt clean

Closes #80

https://claude.ai/code/session_012yaoAdS8egLLqsZADD9X26