### PR TITLE
Add v0.5.0 integration tests and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ cargo install --path .
 | TOML        | `.toml`             | O    | O     |
 | XML         | `.xml`              | O    | O     |
 | MessagePack | `.msgpack`          | O    | O     |
+| Markdown    | `.md`               | -    | O     |
+| HTML        |                     | -    | O     |
 
-All conversion paths between supported formats are available.
+All conversion paths between supported read/write formats are available. Markdown and HTML are output-only formats for table rendering.
 
 ## Commands
 
@@ -87,6 +89,18 @@ dkit convert data.json --to json --compact     # Minified JSON
 dkit convert data.tsv --to json --delimiter '\t'  # TSV input
 dkit convert data.csv --to json --no-header    # CSV without header
 dkit convert data.json --to xml --root-element users  # Custom XML root element
+
+# Markdown/HTML table output
+dkit convert data.json --to md                 # GFM Markdown table
+dkit convert data.csv --to html                # HTML table
+dkit convert data.json --to html --styled      # HTML with inline CSS
+dkit convert data.json --to html --full-html   # Complete HTML document
+dkit convert data.json --to html --styled --full-html  # Styled full document
+
+# Encoding support
+dkit convert data.csv --to json --encoding euc-kr       # EUC-KR input
+dkit convert data.csv --to json --encoding shift_jis     # Shift-JIS input
+dkit convert data.csv --to json --detect-encoding        # Auto-detect encoding
 ```
 
 ### `query` — Data querying
@@ -146,6 +160,17 @@ dkit view data.json --path '.users'
 
 # Select columns
 dkit view users.csv --columns name,email
+
+# Table customization
+dkit view data.csv --border rounded --color        # Rounded borders with type coloring
+dkit view data.json --row-numbers --max-width 30   # Row numbers, truncate long values
+dkit view data.json --hide-header --border none     # Minimal output
+dkit view data.json --border heavy -n 10            # Heavy borders, limit 10 rows
+
+# Output in different formats
+dkit view data.json --format json                  # JSON output instead of table
+dkit view data.json --format md                    # Markdown table
+dkit view data.json --format html                  # HTML table
 ```
 
 ### `stats` — Data statistics
@@ -212,6 +237,7 @@ dkit merge config1.yaml config2.yaml --to yaml
 | TOML | O | X | X | X |
 | XML | O | X | X | O |
 | MessagePack | O | X | X | X |
+| Markdown/HTML output | O | X | X | X |
 | Cross-format convert | O | X | Partial | Partial |
 | Table output | O | X | O | X |
 | Query (where/select/sort) | O | O | O | O |
@@ -220,6 +246,7 @@ dkit merge config1.yaml config2.yaml --to yaml
 | Schema inspection | O | X | X | X |
 | File merging | O | X | O | X |
 | File diff | O | X | X | X |
+| Multi-encoding support | O | X | X | X |
 | Single binary | O | O | O | O |
 
 dkit focuses on **seamless conversion between all supported formats** with a unified query syntax, eliminating the need for separate tools per format.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,9 @@ src/
 │   ├── yaml.rs
 │   ├── toml.rs
 │   ├── xml.rs              # XML (quick-xml 기반)
-│   └── msgpack.rs          # MessagePack
+│   ├── msgpack.rs          # MessagePack
+│   ├── markdown.rs         # Markdown 테이블 (GFM, 출력 전용)
+│   └── html.rs             # HTML 테이블 (출력 전용)
 │
 ├── query/                  # 쿼리 엔진
 │   ├── mod.rs
@@ -86,8 +88,9 @@ pub trait FormatWriter {
 
 포맷 감지는 두 가지 전략을 사용한다:
 
-1. **파일 확장자**: `.json`, `.jsonl`/`.ndjson`, `.csv`/`.tsv`, `.yaml`/`.yml`, `.toml`, `.xml`, `.msgpack`
+1. **파일 확장자**: `.json`, `.jsonl`/`.ndjson`, `.csv`/`.tsv`, `.yaml`/`.yml`, `.toml`, `.xml`, `.msgpack`, `.md` (출력 전용)
 2. **콘텐츠 스니핑**: stdin 입력 시 내용 기반으로 포맷을 추론 (XML → JSONL → JSON → TOML → YAML → CSV 순)
+3. **인코딩 감지**: BOM 우선 → `--encoding` 명시 → `--detect-encoding` 자동 감지 → UTF-8 기본
 
 ## Dependencies
 
@@ -104,17 +107,20 @@ pub trait FormatWriter {
 | 테이블 출력 | comfy-table | 7.x | 예쁜 터미널 테이블 |
 | 색상 출력 | colored | 2.x | 터미널 하이라이팅 |
 | 에러 처리 | thiserror + anyhow | 1.x / 1.x | 라이브러리 + 애플리케이션 에러 |
+| 인코딩 | encoding_rs | 0.8.x | 다중 인코딩 지원 (EUC-KR, Shift-JIS, Latin1 등) |
+| 인코딩 자동 감지 | chardetng | 0.1.x | BOM 없는 파일의 인코딩 휴리스틱 감지 |
 
-## Conversion Matrix (v0.4)
+## Conversion Matrix (v0.5)
 
-| FROM \ TO | JSON | JSONL | CSV | YAML | TOML | XML | MsgPack |
-|-----------|------|-------|-----|------|------|-----|---------|
-| JSON      | -    | O     | O   | O    | O    | O   | O       |
-| JSONL     | O    | -     | O   | O    | O    | O   | O       |
-| CSV       | O    | O     | -   | O    | O    | O   | O       |
-| YAML      | O    | O     | O   | -    | O    | O   | O       |
-| TOML      | O    | O     | O   | O    | -    | O   | O       |
-| XML       | O    | O     | O*  | O    | O    | -   | O       |
-| MsgPack   | O    | O     | O   | O    | O    | O   | -       |
+| FROM \ TO | JSON | JSONL | CSV | YAML | TOML | XML | MsgPack | MD | HTML |
+|-----------|------|-------|-----|------|------|-----|---------|----|------|
+| JSON      | -    | O     | O   | O    | O    | O   | O       | O  | O    |
+| JSONL     | O    | -     | O   | O    | O    | O   | O       | O  | O    |
+| CSV       | O    | O     | -   | O    | O    | O   | O       | O  | O    |
+| YAML      | O    | O     | O   | -    | O    | O   | O       | O  | O    |
+| TOML      | O    | O     | O   | O    | -    | O   | O       | O  | O    |
+| XML       | O    | O     | O*  | O    | O    | -   | O       | O  | O    |
+| MsgPack   | O    | O     | O   | O    | O    | O   | -       | O  | O    |
 
 *XML → CSV는 데이터가 Array of Objects 구조인 경우에만 가능
+**MD, HTML은 출력 전용 포맷 (Write-only)

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -29,7 +29,7 @@ dkit convert --from <FORMAT> --to <FORMAT>  # stdin 사용 시
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--to <FORMAT>` | | 출력 포맷 (json, jsonl, csv, yaml, toml, xml, msgpack) | 필수 |
+| `--to <FORMAT>` | | 출력 포맷 (json, jsonl, csv, yaml, toml, xml, msgpack, md, html) | 필수 |
 | `--from <FORMAT>` | | 입력 포맷 (stdin 사용 시 필수, 콘텐츠 스니핑 지원) | 확장자 자동 감지 |
 | `--output <FILE>` | `-o` | 출력 파일 경로 | stdout |
 | `--outdir <DIR>` | | 여러 파일 변환 시 출력 디렉토리 | |
@@ -39,6 +39,10 @@ dkit convert --from <FORMAT> --to <FORMAT>  # stdin 사용 시
 | `--no-header` | | CSV 헤더 없음 | |
 | `--flow` | | YAML 인라인 스타일 | |
 | `--root-element <NAME>` | | XML 루트 요소 이름 | `root` |
+| `--styled` | | HTML 출력 시 인라인 CSS 스타일 포함 | false |
+| `--full-html` | | HTML 출력 시 완전한 HTML 문서로 출력 | false |
+| `--encoding <ENCODING>` | | 입력 파일 인코딩 (euc-kr, shift_jis, latin1 등) | UTF-8 |
+| `--detect-encoding` | | 입력 파일 인코딩 자동 감지 | false |
 
 ### Examples
 
@@ -73,6 +77,19 @@ cat logs.jsonl | dkit convert --from jsonl --to json
 dkit convert data.tsv --to json --delimiter '\t'
 dkit convert data.csv --to json --compact
 dkit convert data.csv --to json --pretty
+
+# Markdown/HTML 출력
+dkit convert data.json --to md                           # GFM Markdown 테이블
+dkit convert data.csv --to html                          # HTML 테이블
+dkit convert data.json --to html --styled                # 인라인 CSS 스타일
+dkit convert data.json --to html --full-html             # 완전한 HTML 문서
+dkit convert data.json --to html --styled --full-html    # 스타일 포함 HTML 문서
+
+# 인코딩 변환
+dkit convert data.csv --to json --encoding euc-kr        # EUC-KR 입력
+dkit convert data.csv --to json --encoding shift_jis     # Shift-JIS 입력
+dkit convert data.csv --to json --encoding latin1        # Latin1 입력
+dkit convert data.csv --to json --detect-encoding        # 인코딩 자동 감지
 ```
 
 ## query
@@ -161,6 +178,9 @@ dkit view <INPUT> [OPTIONS]
 | `--row-numbers` | 행 번호 표시 | false |
 | `--border <STYLE>` | 테이블 테두리 스타일 (none, simple, rounded, heavy) | simple |
 | `--color` | 데이터 타입별 색상 출력 (숫자=청색, null=회색, 불리언=노란색) | false |
+| `--format <FORMAT>` | 출력 포맷 (table, json, csv, yaml, md, html 등) | table |
+| `--encoding <ENCODING>` | 입력 파일 인코딩 (euc-kr, shift_jis, latin1 등) | UTF-8 |
+| `--detect-encoding` | 입력 파일 인코딩 자동 감지 | false |
 
 ### Examples
 
@@ -172,6 +192,15 @@ dkit view users.csv --columns name,email
 dkit view data.csv --border rounded --color
 dkit view data.json --row-numbers --max-width 30
 dkit view data.json --hide-header --border none
+
+# 출력 포맷 변경
+dkit view data.json --format json
+dkit view data.json --format md
+dkit view data.json --format html
+
+# 인코딩
+dkit view korean.csv --encoding euc-kr
+dkit view data.csv --detect-encoding
 ```
 
 ## stats

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -162,6 +162,49 @@ pub struct FormatOptions {
 - 바이너리 포맷이므로 `read_from_reader`/`write_to_writer` 사용
 - JSON과 유사한 타입 매핑
 
+### Markdown → Value (출력 전용)
+
+- GFM (GitHub Flavored Markdown) 테이블 형식
+- Array<Object> → 컬럼 헤더 + 데이터 행 (숫자 컬럼 우측 정렬 `---:`)
+- Single Object → key | value 2-컬럼 테이블
+- Array<Primitive> → 단일 "value" 컬럼 테이블
+- 파이프 문자 이스케이프 (`|` → `\|`)
+- 중첩 값은 JSON 인라인 표시
+
+### HTML → Value (출력 전용)
+
+- HTML 테이블 생성 (Array<Object>, Single Object, Array<Primitive>)
+- `--styled`: 인라인 CSS 스타일 (border-collapse, 헤더 다크 배경, 줄무늬 행, 호버 효과)
+- `--full-html`: 완전한 HTML 문서 (DOCTYPE, charset, 선택적 style 블록)
+- HTML 엔티티 이스케이프 (`&`, `<`, `>`, `"`, `'`)
+
+## Encoding Support
+
+### 인코딩 감지 우선순위
+
+1. **BOM 감지** (최우선): UTF-8 BOM (`EF BB BF`), UTF-16LE BOM (`FF FE`), UTF-16BE BOM (`FE FF`)
+2. **`--encoding <label>`**: 사용자 명시 인코딩 (encoding_rs 지원 레이블)
+3. **`--detect-encoding`**: chardetng 휴리스틱 자동 감지
+4. **UTF-8 기본값**: 위 3가지 모두 해당 없으면 UTF-8로 디코딩
+
+### 지원 인코딩
+
+- UTF-8 (기본), UTF-16LE, UTF-16BE
+- EUC-KR, Shift-JIS
+- Latin1 (ISO-8859-1), Windows-1252
+- encoding_rs가 지원하는 모든 인코딩
+
+### EncodingOptions
+
+```rust
+pub struct EncodingOptions {
+    pub encoding: Option<String>,    // 명시 인코딩 레이블
+    pub detect_encoding: bool,       // 자동 감지 플래그
+}
+```
+
+모든 서브커맨드(convert, view, query, stats, schema, merge, diff)에서 인코딩 옵션 지원.
+
 ## Query Engine
 
 ### Query Grammar (EBNF)

--- a/tests/v050_integration_test.rs
+++ b/tests/v050_integration_test.rs
@@ -1,0 +1,680 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// ============================================================
+// HTML 출력 포맷 통합 테스트
+// ============================================================
+
+mod html_output {
+    use super::*;
+
+    #[test]
+    fn convert_json_to_html() {
+        dkit()
+            .args(&["convert", "tests/fixtures/users.json", "--to", "html"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<table>"))
+            .stdout(predicate::str::contains("<th>name</th>"))
+            .stdout(predicate::str::contains("<td>Alice</td>"));
+    }
+
+    #[test]
+    fn convert_csv_to_html() {
+        dkit()
+            .args(&["convert", "tests/fixtures/users.csv", "--to", "html"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<table>"))
+            .stdout(predicate::str::contains("<thead>"))
+            .stdout(predicate::str::contains("<tbody>"));
+    }
+
+    #[test]
+    fn convert_yaml_to_html() {
+        dkit()
+            .args(&["convert", "tests/fixtures/config.yaml", "--to", "html"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<th>key</th>"))
+            .stdout(predicate::str::contains("<th>value</th>"));
+    }
+
+    #[test]
+    fn convert_json_to_html_styled() {
+        dkit()
+            .args(&[
+                "convert",
+                "tests/fixtures/users.json",
+                "--to",
+                "html",
+                "--styled",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("style="))
+            .stdout(predicate::str::contains("border-collapse"));
+    }
+
+    #[test]
+    fn convert_json_to_html_full_document() {
+        dkit()
+            .args(&[
+                "convert",
+                "tests/fixtures/users.json",
+                "--to",
+                "html",
+                "--full-html",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<!DOCTYPE html>"))
+            .stdout(predicate::str::contains("<html>"))
+            .stdout(predicate::str::contains("<meta charset=\"UTF-8\">"))
+            .stdout(predicate::str::contains("</html>"));
+    }
+
+    #[test]
+    fn convert_json_to_html_styled_full_document() {
+        dkit()
+            .args(&[
+                "convert",
+                "tests/fixtures/users.json",
+                "--to",
+                "html",
+                "--styled",
+                "--full-html",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<!DOCTYPE html>"))
+            .stdout(predicate::str::contains("<style>"))
+            .stdout(predicate::str::contains("border-collapse"));
+    }
+
+    #[test]
+    fn convert_json_to_html_output_file() {
+        let dir = TempDir::new().unwrap();
+        let out = dir.path().join("output.html");
+
+        dkit()
+            .args(&[
+                "convert",
+                "tests/fixtures/users.json",
+                "--to",
+                "html",
+                "--full-html",
+                "-o",
+                out.to_str().unwrap(),
+            ])
+            .assert()
+            .success();
+
+        let content = fs::read_to_string(&out).unwrap();
+        assert!(content.contains("<!DOCTYPE html>"));
+        assert!(content.contains("Alice"));
+    }
+
+    #[test]
+    fn convert_stdin_to_html() {
+        dkit()
+            .args(&["convert", "--from", "json", "--to", "html"])
+            .write_stdin(r#"[{"x": 1}, {"x": 2}]"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<th>x</th>"))
+            .stdout(predicate::str::contains("<td>1</td>"))
+            .stdout(predicate::str::contains("<td>2</td>"));
+    }
+
+    #[test]
+    fn convert_html_escapes_special_chars() {
+        dkit()
+            .args(&["convert", "--from", "json", "--to", "html"])
+            .write_stdin(r#"[{"text": "<b>bold</b> & \"quoted\""}]"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("&lt;b&gt;bold&lt;/b&gt;"))
+            .stdout(predicate::str::contains("&amp;"));
+    }
+
+    #[test]
+    fn query_output_as_html() {
+        dkit()
+            .args(&["query", "tests/fixtures/users.json", ".", "--to", "html"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<table>"))
+            .stdout(predicate::str::contains("<th>name</th>"));
+    }
+}
+
+// ============================================================
+// Markdown 출력 포맷 통합 테스트 (기존 테스트 보완)
+// ============================================================
+
+mod markdown_output {
+    use super::*;
+
+    #[test]
+    fn convert_toml_to_md() {
+        dkit()
+            .args(&["convert", "tests/fixtures/config.toml", "--to", "md"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("| key | value |"))
+            .stdout(predicate::str::contains("| --- | --- |"));
+    }
+
+    #[test]
+    fn convert_xml_to_md() {
+        dkit()
+            .args(&["convert", "tests/fixtures/users.xml", "--to", "md"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("|"));
+    }
+
+    #[test]
+    fn convert_jsonl_to_md() {
+        dkit()
+            .args(&["convert", "tests/fixtures/users.jsonl", "--to", "md"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("| name |"))
+            .stdout(predicate::str::contains("Alice"));
+    }
+
+    #[test]
+    fn convert_md_null_value_display() {
+        dkit()
+            .args(&["convert", "--from", "json", "--to", "md"])
+            .write_stdin(r#"[{"name": "Alice", "email": null}]"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("null"));
+    }
+
+    #[test]
+    fn convert_md_boolean_values() {
+        dkit()
+            .args(&["convert", "--from", "json", "--to", "md"])
+            .write_stdin(r#"[{"flag": true, "other": false}]"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("true"))
+            .stdout(predicate::str::contains("false"));
+    }
+
+    #[test]
+    fn convert_md_single_object() {
+        dkit()
+            .args(&["convert", "--from", "json", "--to", "md"])
+            .write_stdin(r#"{"host": "localhost", "port": 3000}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("| key | value |"))
+            .stdout(predicate::str::contains("| host | localhost |"))
+            .stdout(predicate::str::contains("| port | 3000 |"));
+    }
+}
+
+// ============================================================
+// 테이블 커스터마이징 옵션 조합 테스트
+// ============================================================
+
+mod table_customization {
+    use super::*;
+
+    #[test]
+    fn view_border_none_with_row_numbers() {
+        dkit()
+            .args(&[
+                "view",
+                "tests/fixtures/users.json",
+                "--border",
+                "none",
+                "--row-numbers",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Alice"))
+            .stdout(predicate::str::contains("|").not());
+    }
+
+    #[test]
+    fn view_border_heavy_with_limit_and_columns() {
+        dkit()
+            .args(&[
+                "view",
+                "tests/fixtures/users.json",
+                "--border",
+                "heavy",
+                "-n",
+                "1",
+                "--columns",
+                "name",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Alice"));
+    }
+
+    #[test]
+    fn view_hide_header_with_row_numbers() {
+        dkit()
+            .args(&[
+                "view",
+                "tests/fixtures/users.json",
+                "--hide-header",
+                "--row-numbers",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Alice"))
+            .stdout(predicate::str::contains("name").not());
+    }
+
+    #[test]
+    fn view_max_width_with_color() {
+        dkit()
+            .args(&[
+                "view",
+                "-",
+                "--from",
+                "json",
+                "--max-width",
+                "10",
+                "--color",
+            ])
+            .write_stdin(r#"[{"description": "This is a very long description that should be truncated", "count": 42}]"#)
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn view_all_options_combined() {
+        dkit()
+            .args(&[
+                "view",
+                "tests/fixtures/users.json",
+                "--border",
+                "rounded",
+                "--row-numbers",
+                "--max-width",
+                "20",
+                "-n",
+                "1",
+                "--columns",
+                "name,age",
+                "--color",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Alice"));
+    }
+
+    #[test]
+    fn view_format_json_output() {
+        dkit()
+            .args(&["view", "tests/fixtures/users.json", "--format", "json"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"name\""));
+    }
+
+    #[test]
+    fn view_format_md_output() {
+        dkit()
+            .args(&["view", "tests/fixtures/users.json", "--format", "md"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("| name |"));
+    }
+
+    #[test]
+    fn view_format_html_output() {
+        dkit()
+            .args(&["view", "tests/fixtures/users.json", "--format", "html"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<table>"));
+    }
+
+    #[test]
+    fn view_format_csv_output() {
+        dkit()
+            .args(&["view", "tests/fixtures/users.json", "--format", "csv"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("name"))
+            .stdout(predicate::str::contains("Alice"));
+    }
+
+    #[test]
+    fn view_format_yaml_output() {
+        dkit()
+            .args(&["view", "tests/fixtures/users.json", "--format", "yaml"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("name: Alice"));
+    }
+
+    #[test]
+    fn query_output_as_table() {
+        dkit()
+            .args(&["query", "tests/fixtures/users.json", ".", "--to", "table"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("name"))
+            .stdout(predicate::str::contains("Alice"));
+    }
+
+    #[test]
+    fn stats_format_table_output() {
+        dkit()
+            .args(&["stats", "tests/fixtures/users.json"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("rows:"))
+            .stdout(predicate::str::contains("columns:"));
+    }
+}
+
+// ============================================================
+// 인코딩 변환 통합 테스트 (크로스 서브커맨드)
+// ============================================================
+
+mod encoding_cross_commands {
+    use super::*;
+
+    #[test]
+    fn query_with_encoding_euc_kr() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("korean.csv");
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"name,value\n");
+        bytes.extend_from_slice(&[0xC8, 0xAB, 0xB1, 0xE6, 0xB5, 0xBF]); // 홍길동 in EUC-KR
+        bytes.extend_from_slice(b",100\n");
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&["query", path.to_str().unwrap(), ".", "--encoding", "euc-kr"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("홍길동"));
+    }
+
+    #[test]
+    fn convert_euc_kr_csv_to_md() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("korean.csv");
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"name,value\n");
+        bytes.extend_from_slice(&[0xC8, 0xAB, 0xB1, 0xE6, 0xB5, 0xBF]); // 홍길동
+        bytes.extend_from_slice(b",100\n");
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&[
+                "convert",
+                path.to_str().unwrap(),
+                "--to",
+                "md",
+                "--encoding",
+                "euc-kr",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("| name |"))
+            .stdout(predicate::str::contains("홍길동"));
+    }
+
+    #[test]
+    fn convert_euc_kr_csv_to_html() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("korean.csv");
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"name,value\n");
+        bytes.extend_from_slice(&[0xC8, 0xAB, 0xB1, 0xE6, 0xB5, 0xBF]); // 홍길동
+        bytes.extend_from_slice(b",100\n");
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&[
+                "convert",
+                path.to_str().unwrap(),
+                "--to",
+                "html",
+                "--encoding",
+                "euc-kr",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<table>"))
+            .stdout(predicate::str::contains("홍길동"));
+    }
+
+    #[test]
+    fn convert_utf16le_csv_to_json() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("utf16le.csv");
+
+        let content = "name,age\nAlice,30\n";
+        let mut bytes = vec![0xFF, 0xFE]; // UTF-16LE BOM
+        for ch in content.encode_utf16() {
+            bytes.push((ch & 0xFF) as u8);
+            bytes.push((ch >> 8) as u8);
+        }
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&["convert", path.to_str().unwrap(), "--format", "json"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Alice"))
+            .stdout(predicate::str::contains("30"));
+    }
+
+    #[test]
+    fn convert_shift_jis_to_yaml() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("japanese.csv");
+
+        // "名前,年齢\n太郎,25\n" in Shift-JIS
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[0x96, 0xBC, 0x91, 0x4F]); // 名前
+        bytes.push(b',');
+        bytes.extend_from_slice(&[0x94, 0x4E, 0x97, 0xEE]); // 年齢
+        bytes.push(b'\n');
+        bytes.extend_from_slice(&[0x91, 0xBE, 0x98, 0x59]); // 太郎
+        bytes.extend_from_slice(b",25\n");
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&[
+                "convert",
+                path.to_str().unwrap(),
+                "--format",
+                "yaml",
+                "--encoding",
+                "shift_jis",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("太郎"));
+    }
+
+    #[test]
+    fn schema_with_encoding_euc_kr() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("korean.csv");
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"name,value\n");
+        bytes.extend_from_slice(b"test,100\n");
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&["schema", path.to_str().unwrap(), "--encoding", "euc-kr"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("name"));
+    }
+
+    #[test]
+    fn merge_with_encoding() {
+        let dir = TempDir::new().unwrap();
+        let path1 = dir.path().join("a.csv");
+        let path2 = dir.path().join("b.csv");
+
+        // Both files as EUC-KR
+        let mut bytes1 = Vec::new();
+        bytes1.extend_from_slice(b"name,value\n");
+        bytes1.extend_from_slice(b"test1,100\n");
+        fs::write(&path1, &bytes1).unwrap();
+
+        let mut bytes2 = Vec::new();
+        bytes2.extend_from_slice(b"name,value\n");
+        bytes2.extend_from_slice(b"test2,200\n");
+        fs::write(&path2, &bytes2).unwrap();
+
+        dkit()
+            .args(&[
+                "merge",
+                path1.to_str().unwrap(),
+                path2.to_str().unwrap(),
+                "--format",
+                "json",
+                "--encoding",
+                "euc-kr",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("test1"))
+            .stdout(predicate::str::contains("test2"));
+    }
+
+    #[test]
+    fn diff_with_encoding() {
+        let dir = TempDir::new().unwrap();
+        let path1 = dir.path().join("a.csv");
+        let path2 = dir.path().join("b.csv");
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"name,value\ntest,100\n");
+        fs::write(&path1, &bytes).unwrap();
+        fs::write(&path2, &bytes).unwrap();
+
+        dkit()
+            .args(&[
+                "diff",
+                path1.to_str().unwrap(),
+                path2.to_str().unwrap(),
+                "--encoding",
+                "euc-kr",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No differences found"));
+    }
+}
+
+// ============================================================
+// Markdown/HTML + 인코딩 크로스 테스트
+// ============================================================
+
+mod cross_format_encoding {
+    use super::*;
+
+    #[test]
+    fn convert_utf8_bom_json_to_md() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bom.json");
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice(b"[{\"name\": \"Alice\", \"age\": 30}]");
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&["convert", path.to_str().unwrap(), "--to", "md"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("| name |"))
+            .stdout(predicate::str::contains("| Alice |"));
+    }
+
+    #[test]
+    fn convert_utf8_bom_json_to_html() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bom.json");
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice(b"[{\"name\": \"Alice\", \"age\": 30}]");
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&["convert", path.to_str().unwrap(), "--to", "html"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("<table>"))
+            .stdout(predicate::str::contains("<td>Alice</td>"));
+    }
+
+    #[test]
+    fn convert_latin1_csv_to_html_styled() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("latin1.csv");
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"name,city\n");
+        bytes.extend_from_slice(b"Jos");
+        bytes.push(0xE9); // é in Latin1
+        bytes.push(b',');
+        bytes.extend_from_slice(b"M");
+        bytes.push(0xFC); // ü in Latin1
+        bytes.extend_from_slice(b"nchen\n");
+        fs::write(&path, &bytes).unwrap();
+
+        dkit()
+            .args(&[
+                "convert",
+                path.to_str().unwrap(),
+                "--to",
+                "html",
+                "--styled",
+                "--encoding",
+                "latin1",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("José"))
+            .stdout(predicate::str::contains("München"))
+            .stdout(predicate::str::contains("style="));
+    }
+}
+
+// ============================================================
+// --list-formats 테스트
+// ============================================================
+
+mod list_formats {
+    use super::*;
+
+    #[test]
+    fn list_formats_shows_md_and_html() {
+        dkit()
+            .args(&["--list-formats"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("md"))
+            .stdout(predicate::str::contains("html"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add 40 integration tests for v0.5.0 features: HTML output (10 tests), Markdown output (6 tests), table customization combinations (12 tests), encoding across all subcommands (9 tests), cross-format encoding (3 tests)
- Update README.md with Markdown/HTML formats, encoding support, table customization examples
- Update docs/ (architecture.md, cli-spec.md, technical-spec.md) with v0.5.0 feature documentation

## Test plan
- [x] All 40 new integration tests pass (`cargo test --test v050_integration_test`)
- [x] All existing tests still pass (933 total tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

Closes #83

https://claude.ai/code/session_01RjiJGTCqdsKzmJXWAAJYgm