### PR TITLE
feat: add batch convert support (glob, directory, rename, continue-on-error)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "comfy-table",
  "csv",
  "encoding_rs",
+ "glob",
  "indexmap",
  "predicates",
  "quick-xml 0.37.5",
@@ -470,6 +471,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ encoding_rs = "0.8"
 chardetng = "0.1"
 calamine = "0.26"
 rusqlite = { version = "0.31", features = ["bundled"] }
+glob = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,7 @@ pub struct Cli {
 pub enum Commands {
     /// Convert between data formats (JSON, CSV, YAML, TOML)
     #[command(
-        after_help = "Examples:\n  dkit convert data.json --format csv\n  dkit convert data.csv --format yaml --pretty\n  dkit convert a.json b.json --format csv --outdir ./output\n  cat data.json | dkit convert --from json --format toml\n  dkit convert - --from json --format csv < data.json\n  dkit convert data.json -f csv | dkit query - '.items[]' --from csv"
+        after_help = "Examples:\n  dkit convert data.json --format csv\n  dkit convert data.csv --format yaml --pretty\n  dkit convert a.json b.json --format csv --outdir ./output\n  dkit convert '*.json' --format csv --outdir ./output\n  dkit convert data_dir/ --format yaml --outdir ./output\n  dkit convert '*.json' -f csv --outdir out --rename '{name}.converted.{ext}'\n  dkit convert dir/ -f csv --outdir out --continue-on-error\n  cat data.json | dkit convert --from json --format toml\n  dkit convert - --from json --format csv < data.json\n  dkit convert data.json -f csv | dkit query - '.items[]' --from csv"
     )]
     Convert {
         /// Input file path(s). Use '-' or omit for stdin (auto-detects format or use --from)
@@ -101,6 +101,14 @@ pub enum Commands {
         /// SQL query to execute on SQLite database
         #[arg(long, value_name = "SQL")]
         sql: Option<String>,
+
+        /// Output filename pattern for batch conversion (e.g. '{name}.converted.{ext}')
+        #[arg(long, value_name = "PATTERN")]
+        rename: Option<String>,
+
+        /// Continue processing remaining files when an error occurs
+        #[arg(long)]
+        continue_on_error: bool,
     },
 
     /// Query data using path expressions

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -23,6 +23,12 @@ use crate::format::{
 };
 use crate::value::Value;
 
+/// 지원되는 입력 파일 확장자 목록
+const SUPPORTED_EXTENSIONS: &[&str] = &[
+    "json", "jsonl", "ndjson", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack", "xlsx",
+    "xls", "xlsm", "xlsb", "ods", "db", "sqlite", "sqlite3",
+];
+
 pub struct ConvertArgs<'a> {
     pub input: &'a [PathBuf],
     pub to: &'a str,
@@ -40,6 +46,8 @@ pub struct ConvertArgs<'a> {
     pub encoding_opts: EncodingOptions,
     pub excel_opts: ExcelOptions,
     pub sqlite_opts: SqliteOptions,
+    pub rename: Option<&'a str>,
+    pub continue_on_error: bool,
 }
 
 /// convert 서브커맨드 실행
@@ -108,8 +116,15 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         return Ok(());
     }
 
-    // Multiple files with --outdir
-    if args.input.len() > 1 {
+    // Expand inputs: resolve glob patterns and directories
+    let resolved_files = expand_inputs(args.input)?;
+
+    if resolved_files.is_empty() {
+        bail!("No matching files found");
+    }
+
+    // Multiple files with --outdir (batch mode)
+    if resolved_files.len() > 1 {
         let outdir = match args.outdir {
             Some(d) => d,
             None => bail!("--outdir is required when converting multiple files\n  Hint: specify an output directory, e.g. --outdir ./output"),
@@ -117,43 +132,52 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         fs::create_dir_all(outdir)
             .with_context(|| format!("Failed to create directory {}", outdir.display()))?;
 
-        for path in args.input {
-            let source_format = match args.from {
-                Some(f) => Format::from_str(f)?,
-                None => detect_format(path)?,
-            };
+        let total = resolved_files.len();
+        let mut success_count = 0usize;
+        let mut error_count = 0usize;
+        let mut errors: Vec<(PathBuf, String)> = Vec::new();
 
-            let read_delimiter = args.delimiter.or_else(|| default_delimiter(path));
-            let read_options = FormatOptions {
-                delimiter: read_delimiter,
-                no_header: args.no_header,
-                ..Default::default()
-            };
+        for (idx, path) in resolved_files.iter().enumerate() {
+            eprint!("Converting ({}/{}) {} ... ", idx + 1, total, path.display());
 
-            let value = read_value_from_path(
-                path,
-                source_format,
-                &read_options,
-                &args.encoding_opts,
-                &args.excel_opts,
-                &args.sqlite_opts,
-            )?;
-
-            let out_name = path
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string()
-                + "."
-                + args.to;
-            let out_path = outdir.join(out_name);
-            write_output(&value, target_format, &write_options, Some(&out_path))?;
+            match convert_single_file(path, args, target_format, &write_options, outdir) {
+                Ok(()) => {
+                    success_count += 1;
+                    eprintln!("ok");
+                }
+                Err(e) => {
+                    error_count += 1;
+                    let msg = format!("{e:#}");
+                    eprintln!("FAILED: {msg}");
+                    errors.push((path.clone(), msg));
+                    if !args.continue_on_error {
+                        bail!(
+                            "Conversion failed for {}\n  Use --continue-on-error to skip failed files",
+                            path.display()
+                        );
+                    }
+                }
+            }
         }
+
+        // Print summary
+        eprintln!();
+        eprintln!("Batch conversion complete: {success_count} succeeded, {error_count} failed out of {total} files");
+
+        if !errors.is_empty() {
+            eprintln!();
+            eprintln!("Failed files:");
+            for (path, msg) in &errors {
+                eprintln!("  {}: {msg}", path.display());
+            }
+            bail!("{error_count} file(s) failed to convert");
+        }
+
         return Ok(());
     }
 
     // Single file
-    let path = &args.input[0];
+    let path = &resolved_files[0];
     let source_format = match args.from {
         Some(f) => Format::from_str(f)?,
         None => detect_format(path)?,
@@ -176,13 +200,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
     )?;
 
     let outdir_path = args.outdir.map(|d| {
-        let name = path
-            .file_stem()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string()
-            + "."
-            + args.to;
+        let name = make_output_name(path, args.to, args.rename);
         d.join(name)
     });
 
@@ -198,6 +216,123 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
     write_output(&value, target_format, &write_options, out_path)?;
 
     Ok(())
+}
+
+/// 단일 파일을 변환하여 outdir에 저장한다 (배치 모드용)
+fn convert_single_file(
+    path: &Path,
+    args: &ConvertArgs,
+    target_format: Format,
+    write_options: &FormatOptions,
+    outdir: &Path,
+) -> Result<()> {
+    let source_format = match args.from {
+        Some(f) => Format::from_str(f)?,
+        None => detect_format(path)?,
+    };
+
+    let read_delimiter = args.delimiter.or_else(|| default_delimiter(path));
+    let read_options = FormatOptions {
+        delimiter: read_delimiter,
+        no_header: args.no_header,
+        ..Default::default()
+    };
+
+    let value = read_value_from_path(
+        path,
+        source_format,
+        &read_options,
+        &args.encoding_opts,
+        &args.excel_opts,
+        &args.sqlite_opts,
+    )?;
+
+    let out_name = make_output_name(path, args.to, args.rename);
+    let out_path = outdir.join(out_name);
+    write_output(&value, target_format, write_options, Some(&out_path))
+}
+
+/// 입력 경로를 확장한다: 글롭 패턴, 디렉토리, 일반 파일을 처리
+fn expand_inputs(inputs: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+
+    for input in inputs {
+        let input_str = input.to_string_lossy();
+
+        // Check if the input contains glob metacharacters
+        if contains_glob_chars(&input_str) {
+            let matches: Vec<_> = glob::glob(&input_str)
+                .with_context(|| format!("Invalid glob pattern: {input_str}"))?
+                .collect();
+
+            if matches.is_empty() {
+                bail!("No files matched pattern: {input_str}");
+            }
+
+            for entry in matches {
+                let path =
+                    entry.with_context(|| format!("Error reading glob match for: {input_str}"))?;
+                if path.is_file() {
+                    files.push(path);
+                }
+            }
+        } else if input.is_dir() {
+            // Scan directory for supported files
+            let mut dir_files = collect_supported_files(input)?;
+            if dir_files.is_empty() {
+                bail!("No supported files found in directory: {}", input.display());
+            }
+            dir_files.sort();
+            files.extend(dir_files);
+        } else {
+            // Regular file path
+            files.push(input.clone());
+        }
+    }
+
+    Ok(files)
+}
+
+/// 문자열에 글롭 메타문자가 포함되어 있는지 확인
+fn contains_glob_chars(s: &str) -> bool {
+    s.contains('*') || s.contains('?') || s.contains('[')
+}
+
+/// 디렉토리에서 지원되는 확장자를 가진 파일을 수집한다
+fn collect_supported_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let entries = fs::read_dir(dir)
+        .with_context(|| format!("Failed to read directory: {}", dir.display()))?;
+
+    for entry in entries {
+        let entry = entry.with_context(|| format!("Failed to read entry in: {}", dir.display()))?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                if SUPPORTED_EXTENSIONS.contains(&ext.to_lowercase().as_str()) {
+                    files.push(path);
+                }
+            }
+        }
+    }
+
+    Ok(files)
+}
+
+/// 출력 파일명을 생성한다 (rename 패턴 또는 기본 확장자 교체)
+fn make_output_name(path: &Path, target_ext: &str, rename: Option<&str>) -> String {
+    let stem = path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    match rename {
+        Some(pattern) => pattern
+            .replace("{name}", &stem)
+            .replace("{ext}", target_ext),
+        None => format!("{stem}.{target_ext}"),
+    }
 }
 
 /// stdin에서 인코딩을 고려하여 문자열을 읽는다.
@@ -307,5 +442,43 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
             use crate::output::table::{render_table, TableOptions};
             Ok(render_table(value, &TableOptions::default()) + "\n")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_contains_glob_chars() {
+        assert!(contains_glob_chars("*.json"));
+        assert!(contains_glob_chars("data?.csv"));
+        assert!(contains_glob_chars("data[0-9].json"));
+        assert!(!contains_glob_chars("data.json"));
+        assert!(!contains_glob_chars("path/to/file.csv"));
+    }
+
+    #[test]
+    fn test_make_output_name_default() {
+        let path = Path::new("data.json");
+        assert_eq!(make_output_name(path, "csv", None), "data.csv");
+    }
+
+    #[test]
+    fn test_make_output_name_with_rename_pattern() {
+        let path = Path::new("data.json");
+        assert_eq!(
+            make_output_name(path, "csv", Some("{name}.converted.{ext}")),
+            "data.converted.csv"
+        );
+    }
+
+    #[test]
+    fn test_make_output_name_custom_pattern() {
+        let path = Path::new("/some/dir/users.json");
+        assert_eq!(
+            make_output_name(path, "yaml", Some("output_{name}.{ext}")),
+            "output_users.yaml"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             header_row,
             table,
             sql,
+            rename,
+            continue_on_error,
         } => {
             commands::convert::run(&commands::convert::ConvertArgs {
                 input: &input,
@@ -112,6 +114,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                 },
                 excel_opts: ExcelOptions { sheet, header_row },
                 sqlite_opts: SqliteOptions { table, sql },
+                rename: rename.as_deref(),
+                continue_on_error,
             })?;
         }
         Commands::Query {

--- a/tests/batch_convert_test.rs
+++ b/tests/batch_convert_test.rs
@@ -1,0 +1,259 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// --- Multiple explicit files ---
+
+#[test]
+fn batch_convert_multiple_files() {
+    let outdir = TempDir::new().unwrap();
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users.csv",
+            "--format",
+            "yaml",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "2 succeeded, 0 failed out of 2 files",
+        ));
+
+    assert!(outdir.path().join("users.yaml").exists());
+}
+
+// --- Glob pattern ---
+
+#[test]
+fn batch_convert_glob_pattern() {
+    let outdir = TempDir::new().unwrap();
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/*.json",
+            "--format",
+            "yaml",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("succeeded"));
+
+    // At least users.json should be converted
+    assert!(outdir.path().join("users.yaml").exists());
+}
+
+// --- Directory input ---
+
+#[test]
+fn batch_convert_directory_input() {
+    // Create a temp dir with some json files
+    let input_dir = TempDir::new().unwrap();
+    let outdir = TempDir::new().unwrap();
+
+    fs::write(input_dir.path().join("a.json"), r#"[{"x": 1}]"#).unwrap();
+    fs::write(input_dir.path().join("b.json"), r#"[{"y": 2}]"#).unwrap();
+    // Non-supported file should be ignored
+    fs::write(input_dir.path().join("readme.txt"), "hello").unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input_dir.path().to_str().unwrap(),
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "2 succeeded, 0 failed out of 2 files",
+        ));
+
+    assert!(outdir.path().join("a.csv").exists());
+    assert!(outdir.path().join("b.csv").exists());
+}
+
+// --- Rename pattern ---
+
+#[test]
+fn batch_convert_rename_pattern() {
+    let outdir = TempDir::new().unwrap();
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users.csv",
+            "--format",
+            "yaml",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+            "--rename",
+            "{name}.converted.{ext}",
+        ])
+        .assert()
+        .success();
+
+    assert!(outdir.path().join("users.converted.yaml").exists());
+}
+
+// --- Continue on error ---
+
+#[test]
+fn batch_convert_continue_on_error() {
+    let input_dir = TempDir::new().unwrap();
+    let outdir = TempDir::new().unwrap();
+
+    // Valid file
+    fs::write(input_dir.path().join("good.json"), r#"[{"a": 1}]"#).unwrap();
+    // Invalid file
+    fs::write(
+        input_dir.path().join("bad.json"),
+        "this is not valid json {{{",
+    )
+    .unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input_dir.path().to_str().unwrap(),
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+            "--continue-on-error",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("1 succeeded"))
+        .stderr(predicate::str::contains("1 failed"))
+        .stderr(predicate::str::contains("Failed files:"));
+
+    assert!(outdir.path().join("good.csv").exists());
+    assert!(!outdir.path().join("bad.csv").exists());
+}
+
+// --- Error without --continue-on-error stops immediately ---
+
+#[test]
+fn batch_convert_stops_on_error_by_default() {
+    let input_dir = TempDir::new().unwrap();
+    let outdir = TempDir::new().unwrap();
+
+    fs::write(input_dir.path().join("bad.json"), "not json").unwrap();
+    fs::write(input_dir.path().join("good.json"), r#"[{"a": 1}]"#).unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input_dir.path().to_str().unwrap(),
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--continue-on-error"));
+}
+
+// --- Multiple files without --outdir should fail ---
+
+#[test]
+fn batch_convert_requires_outdir() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users.csv",
+            "--format",
+            "yaml",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--outdir is required"));
+}
+
+// --- Single file still works normally ---
+
+#[test]
+fn single_file_convert_still_works() {
+    dkit()
+        .args(&["convert", "tests/fixtures/users.json", "--format", "csv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+}
+
+// --- Glob pattern with no matches ---
+
+#[test]
+fn glob_no_matches() {
+    let outdir = TempDir::new().unwrap();
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/*.nonexistent",
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No files matched pattern"));
+}
+
+// --- Empty directory ---
+
+#[test]
+fn batch_convert_empty_directory() {
+    let input_dir = TempDir::new().unwrap();
+    let outdir = TempDir::new().unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input_dir.path().to_str().unwrap(),
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No supported files found"));
+}
+
+// --- Progress output ---
+
+#[test]
+fn batch_convert_shows_progress() {
+    let outdir = TempDir::new().unwrap();
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users.csv",
+            "--format",
+            "yaml",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("(1/2)"))
+        .stderr(predicate::str::contains("(2/2)"))
+        .stderr(predicate::str::contains("ok"));
+}


### PR DESCRIPTION
## Summary
- **Glob pattern support**: `dkit convert '*.json' -f csv --outdir out` expands glob patterns to match multiple files
- **Directory input**: `dkit convert data_dir/ -f yaml --outdir out` scans directories for supported file formats
- **`--rename` pattern**: Custom output filenames with `{name}` and `{ext}` placeholders (e.g., `--rename '{name}.converted.{ext}'`)
- **`--continue-on-error`**: Skip failed files and continue processing remaining ones
- **Progress display**: Shows `(N/M) filename ... ok/FAILED` for each file during batch conversion
- **Summary report**: Prints success/failure counts and lists failed files at the end

## Test plan
- [x] Multiple explicit files batch conversion
- [x] Glob pattern expansion (`*.json`)
- [x] Directory input with supported file filtering
- [x] Rename pattern with `{name}` and `{ext}` placeholders
- [x] `--continue-on-error` skips bad files and reports summary
- [x] Default behavior stops on first error with hint
- [x] `--outdir` required for multiple files
- [x] Single file conversion still works as before
- [x] Glob with no matches shows error
- [x] Empty directory shows error
- [x] Progress output format verified

Closes #88

https://claude.ai/code/session_01T8FC5pztEK6NwvQ6TsChT2