### PR TITLE
feat: add sort/filter/head/tail options to convert and view

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,26 @@ pub enum Commands {
         /// Continue processing remaining files when an error occurs
         #[arg(long)]
         continue_on_error: bool,
+
+        /// Sort by field name
+        #[arg(long, value_name = "FIELD")]
+        sort_by: Option<String>,
+
+        /// Sort order (asc or desc, default: asc)
+        #[arg(long, value_name = "ORDER", default_value = "asc")]
+        sort_order: String,
+
+        /// Show only the first N records
+        #[arg(long, value_name = "N")]
+        head: Option<usize>,
+
+        /// Show only the last N records
+        #[arg(long, value_name = "N")]
+        tail: Option<usize>,
+
+        /// Filter expression (e.g. 'age > 30 and city == "Seoul"')
+        #[arg(long, value_name = "EXPR", alias = "where")]
+        filter: Option<String>,
     },
 
     /// Query data using path expressions
@@ -249,6 +269,26 @@ pub enum Commands {
         /// List table names in a SQLite database
         #[arg(long)]
         list_tables: bool,
+
+        /// Sort by field name
+        #[arg(long, value_name = "FIELD")]
+        sort_by: Option<String>,
+
+        /// Sort order (asc or desc, default: asc)
+        #[arg(long, value_name = "ORDER", default_value = "asc")]
+        sort_order: String,
+
+        /// Show only the first N records
+        #[arg(long, value_name = "N")]
+        head: Option<usize>,
+
+        /// Show only the last N records
+        #[arg(long, value_name = "N")]
+        tail: Option<usize>,
+
+        /// Filter expression (e.g. 'age > 30 and city == "Seoul"')
+        #[arg(long, value_name = "EXPR", alias = "where")]
+        filter: Option<String>,
     },
 
     /// Show statistics about data

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -48,6 +48,7 @@ pub struct ConvertArgs<'a> {
     pub sqlite_opts: SqliteOptions,
     pub rename: Option<&'a str>,
     pub continue_on_error: bool,
+    pub data_filter: super::DataFilterOptions,
 }
 
 /// convert 서브커맨드 실행
@@ -112,6 +113,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
             read_value(&buf, source_format, &read_options)?
         };
 
+        let value = super::apply_data_filters(value, &args.data_filter)?;
         write_output(&value, target_format, &write_options, args.output)?;
         return Ok(());
     }
@@ -198,6 +200,7 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         &args.excel_opts,
         &args.sqlite_opts,
     )?;
+    let value = super::apply_data_filters(value, &args.data_filter)?;
 
     let outdir_path = args.outdir.map(|d| {
         let name = make_output_name(path, args.to, args.rename);
@@ -246,6 +249,7 @@ fn convert_single_file(
         &args.excel_opts,
         &args.sqlite_opts,
     )?;
+    let value = super::apply_data_filters(value, &args.data_filter)?;
 
     let out_name = make_output_name(path, args.to, args.rename);
     let out_path = outdir.join(out_name);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -187,6 +187,78 @@ pub fn decode_bytes(bytes: &[u8], opts: &EncodingOptions) -> anyhow::Result<Stri
     })
 }
 
+/// 데이터 정렬 및 필터링 옵션 (convert/view 공통)
+#[derive(Debug, Clone, Default)]
+pub struct DataFilterOptions {
+    /// 정렬 기준 필드
+    pub sort_by: Option<String>,
+    /// 내림차순 정렬 여부
+    pub descending: bool,
+    /// 상위 N개 레코드
+    pub head: Option<usize>,
+    /// 하위 N개 레코드
+    pub tail: Option<usize>,
+    /// 필터 표현식 문자열
+    pub filter: Option<String>,
+}
+
+/// 데이터 필터/정렬 옵션을 Value에 적용한다.
+/// 적용 순서: where → sort → head/tail
+pub fn apply_data_filters(
+    value: crate::value::Value,
+    opts: &DataFilterOptions,
+) -> anyhow::Result<crate::value::Value> {
+    use crate::query::filter::apply_operations;
+    use crate::query::parser::{parse_condition_expr, Operation};
+
+    let mut operations = Vec::new();
+
+    // 1. where 필터
+    if let Some(ref expr) = opts.filter {
+        let condition = parse_condition_expr(expr).map_err(|e| {
+            anyhow::anyhow!(
+                "Invalid --filter expression: {e}\n  Hint: use format like 'age > 30' or 'name == \"Alice\"'"
+            )
+        })?;
+        operations.push(Operation::Where(condition));
+    }
+
+    // 2. sort
+    if let Some(ref field) = opts.sort_by {
+        operations.push(Operation::Sort {
+            field: field.clone(),
+            descending: opts.descending,
+        });
+    }
+
+    // 3. head (= limit)
+    if let Some(n) = opts.head {
+        operations.push(Operation::Limit(n));
+    }
+
+    // head와 tail이 동시에 지정된 경우 head를 먼저 적용하고 tail을 적용하므로
+    // 별도 처리가 필요
+    if operations.is_empty() && opts.tail.is_none() {
+        return Ok(value);
+    }
+
+    let mut result = if operations.is_empty() {
+        value
+    } else {
+        apply_operations(value, &operations)?
+    };
+
+    // 4. tail: 배열의 마지막 N개 요소 추출
+    if let Some(n) = opts.tail {
+        if let crate::value::Value::Array(ref arr) = result {
+            let start = arr.len().saturating_sub(n);
+            result = crate::value::Value::Array(arr[start..].to_vec());
+        }
+    }
+
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -296,5 +368,175 @@ mod tests {
         let opts = EncodingOptions::default();
         let result = decode_bytes(bytes, &opts).unwrap();
         assert_eq!(result, "hi");
+    }
+
+    // --- apply_data_filters tests ---
+
+    use crate::value::Value;
+    use indexmap::IndexMap;
+
+    fn make_record(name: &str, age: i64) -> Value {
+        let mut m = IndexMap::new();
+        m.insert("name".to_string(), Value::String(name.to_string()));
+        m.insert("age".to_string(), Value::Integer(age));
+        Value::Object(m)
+    }
+
+    fn sample_data() -> Value {
+        Value::Array(vec![
+            make_record("Alice", 30),
+            make_record("Bob", 25),
+            make_record("Charlie", 35),
+            make_record("Diana", 28),
+            make_record("Eve", 22),
+        ])
+    }
+
+    #[test]
+    fn test_data_filter_no_ops() {
+        let data = sample_data();
+        let opts = DataFilterOptions::default();
+        let result = apply_data_filters(data.clone(), &opts).unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_data_filter_sort_asc() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            sort_by: Some("age".to_string()),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_object().unwrap()["name"].as_str().unwrap(), "Eve");
+        assert_eq!(
+            arr[4].as_object().unwrap()["name"].as_str().unwrap(),
+            "Charlie"
+        );
+    }
+
+    #[test]
+    fn test_data_filter_sort_desc() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            sort_by: Some("age".to_string()),
+            descending: true,
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0].as_object().unwrap()["name"].as_str().unwrap(),
+            "Charlie"
+        );
+        assert_eq!(arr[4].as_object().unwrap()["name"].as_str().unwrap(), "Eve");
+    }
+
+    #[test]
+    fn test_data_filter_head() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            head: Some(2),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].as_object().unwrap()["name"].as_str().unwrap(),
+            "Alice"
+        );
+        assert_eq!(arr[1].as_object().unwrap()["name"].as_str().unwrap(), "Bob");
+    }
+
+    #[test]
+    fn test_data_filter_tail() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            tail: Some(2),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].as_object().unwrap()["name"].as_str().unwrap(),
+            "Diana"
+        );
+        assert_eq!(arr[1].as_object().unwrap()["name"].as_str().unwrap(), "Eve");
+    }
+
+    #[test]
+    fn test_data_filter_where() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            filter: Some("age > 27".to_string()),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // Alice(30), Charlie(35), Diana(28)
+    }
+
+    #[test]
+    fn test_data_filter_where_and_sort() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            filter: Some("age > 27".to_string()),
+            sort_by: Some("age".to_string()),
+            descending: true,
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(
+            arr[0].as_object().unwrap()["name"].as_str().unwrap(),
+            "Charlie"
+        );
+        assert_eq!(
+            arr[2].as_object().unwrap()["name"].as_str().unwrap(),
+            "Diana"
+        );
+    }
+
+    #[test]
+    fn test_data_filter_sort_and_head() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            sort_by: Some("age".to_string()),
+            head: Some(3),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // youngest 3
+        assert_eq!(arr[0].as_object().unwrap()["name"].as_str().unwrap(), "Eve");
+        assert_eq!(arr[1].as_object().unwrap()["name"].as_str().unwrap(), "Bob");
+        assert_eq!(
+            arr[2].as_object().unwrap()["name"].as_str().unwrap(),
+            "Diana"
+        );
+    }
+
+    #[test]
+    fn test_data_filter_invalid_expr() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            filter: Some("invalid!!!".to_string()),
+            ..Default::default()
+        };
+        assert!(apply_data_filters(data, &opts).is_err());
+    }
+
+    #[test]
+    fn test_data_filter_non_array() {
+        // Non-array data should pass through for no-ops
+        let data = Value::Integer(42);
+        let opts = DataFilterOptions::default();
+        let result = apply_data_filters(data, &opts).unwrap();
+        assert_eq!(result, Value::Integer(42));
     }
 }

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -43,6 +43,7 @@ pub struct ViewArgs<'a> {
     pub list_sheets: bool,
     pub sqlite_opts: SqliteOptions,
     pub list_tables: bool,
+    pub data_filter: super::DataFilterOptions,
 }
 
 /// view 서브커맨드 실행
@@ -112,6 +113,9 @@ pub fn run(args: &ViewArgs) -> Result<()> {
         Some(path_expr) => resolve_path(&value, path_expr)?,
         None => value,
     };
+
+    // 데이터 필터/정렬 적용
+    let target = super::apply_data_filters(target, &args.data_filter)?;
 
     // 출력 포맷 결정: --format 옵션 또는 기본 table
     let output_format = match args.format {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,11 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             sql,
             rename,
             continue_on_error,
+            sort_by,
+            sort_order,
+            head,
+            tail,
+            filter,
         } => {
             commands::convert::run(&commands::convert::ConvertArgs {
                 input: &input,
@@ -116,6 +121,13 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                 sqlite_opts: SqliteOptions { table, sql },
                 rename: rename.as_deref(),
                 continue_on_error,
+                data_filter: commands::DataFilterOptions {
+                    sort_by,
+                    descending: sort_order.eq_ignore_ascii_case("desc"),
+                    head,
+                    tail,
+                    filter,
+                },
             })?;
         }
         Commands::Query {
@@ -167,6 +179,11 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             table,
             sql,
             list_tables,
+            sort_by,
+            sort_order,
+            head,
+            tail,
+            filter,
         } => {
             commands::view::run(&commands::view::ViewArgs {
                 input: &input,
@@ -190,6 +207,13 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                 list_sheets,
                 sqlite_opts: SqliteOptions { table, sql },
                 list_tables,
+                data_filter: commands::DataFilterOptions {
+                    sort_by,
+                    descending: sort_order.eq_ignore_ascii_case("desc"),
+                    head,
+                    tail,
+                    filter,
+                },
             })?;
         }
         Commands::Stats {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -610,6 +610,22 @@ pub fn parse_query(input: &str) -> Result<Query, DkitError> {
     Parser::new(input).parse()
 }
 
+/// where 절의 조건식만 파싱하는 편의 함수
+/// 예: "age > 30 and city == \"Seoul\""
+pub fn parse_condition_expr(input: &str) -> Result<Condition, DkitError> {
+    let mut parser = Parser::new(input);
+    parser.skip_whitespace();
+    let condition = parser.parse_condition()?;
+    parser.skip_whitespace();
+    if parser.pos != parser.input.len() {
+        return Err(DkitError::QueryError(format!(
+            "unexpected character '{}' at position {} in where expression",
+            parser.input[parser.pos], parser.pos
+        )));
+    }
+    Ok(condition)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- `convert`/`view` 서브커맨드에 `--sort-by`, `--sort-order`, `--head`, `--tail`, `--filter` (alias `--where`) 옵션 추가
- query 서브커맨드의 축약형으로, 별도 쿼리 없이 간단한 정렬/필터링 가능
- 기존 쿼리 엔진의 파서와 필터 로직을 재사용하여 일관된 동작 보장

## 사용 예시
```bash
dkit convert data.csv -f json --sort-by age --sort-order desc
dkit view data.json --filter 'price > 100' --head 10
dkit convert data.json -f csv --tail 5
dkit view data.csv --sort-by name --head 20 --filter 'status == "active"'
```

## Test plan
- [x] `apply_data_filters` 단위 테스트 (sort asc/desc, head, tail, where, 조합)
- [x] 기존 533+ 단위 테스트 및 통합 테스트 전체 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과

Closes #89

https://claude.ai/code/session_01MXgjTzra6ri9sSJudmgwjk