### PR TITLE
feat: implement Parquet Reader (v0.7.0 #92)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -27,6 +29,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -95,6 +112,179 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a3ec4fe573f9d1f59d99c085197ef669b00b088ba1d7bb75224732d9357a74"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dcf19f07792d8c7f91086c67b574a79301e367029b17fcf63fb854332246a10"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7845c32b41f7053e37a075b3c2f29c6f5ea1b3ca6e5df7a2d325ee6e1b4a63cf"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5c681a99606f3316f2a99d9c8b6fa3aad0b1d34d8f6d7a1b471893940219d8"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365f8527d4f87b133eeb862f9b8093c009d41a210b8f101f91aa2392f61daac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd962fc3bf7f60705b25bcaa8eb3318b2545aa1d528656525ebdd6a17a6cd6fb"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3527365b24372f9c948f16e53738eb098720eea2093ae73c7af04ac5e30a39b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af2db0e62a508d34ddf4f76bfd6109b6ecc845257c9cba6f939653668f89ac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-row"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da30e9d10e9c52f09ea0cf15086d6d785c11ae8dcc3ea5f16d402221b6ac7735"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b0f9c0c3582dd55db0f136d3b44bfa0189df07adcf7dc7f2f2e74db0f52eb8"
+
+[[package]]
+name = "arrow-select"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fc337f01635218493c23da81a364daf38c694b05fc20569c3193c11c561984"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d596a9fc25dae556672d5069b090331aca8acb93cae426d8b7dcdf1c558fa0ce"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,10 +300,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -143,6 +354,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calamine"
@@ -184,6 +401,18 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "memchr",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets",
 ]
 
 [[package]]
@@ -263,6 +492,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,7 +538,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -299,6 +554,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csv"
@@ -354,7 +615,9 @@ name = "dkit"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "arrow",
  "assert_cmd",
+ "bytes",
  "calamine",
  "chardetng",
  "clap",
@@ -364,6 +627,7 @@ dependencies = [
  "encoding_rs",
  "glob",
  "indexmap",
+ "parquet",
  "predicates",
  "quick-xml 0.37.5",
  "rmp-serde",
@@ -435,6 +699,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,13 +735,36 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -477,6 +774,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -518,6 +827,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +869,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +885,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -560,10 +909,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -626,12 +1038,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -645,6 +1122,15 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -668,6 +1154,39 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parquet"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8cf58b29782a7add991f655ff42929e31a7859f5319e53db9e39a714cb113c"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pkg-config"
@@ -754,6 +1273,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -764,7 +1289,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -821,7 +1346,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -830,17 +1355,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -859,6 +1399,12 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -944,6 +1490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,7 +1519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1020,6 +1572,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1631,16 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1118,6 +1700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1721,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1163,7 +1796,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1192,10 +1825,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1346,7 +2032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ encoding_rs = "0.8"
 chardetng = "0.1"
 calamine = "0.26"
 rusqlite = { version = "0.31", features = ["bundled"] }
+arrow = { version = "53", default-features = false, features = ["prettyprint"] }
+parquet = { version = "53", default-features = false, features = ["arrow"] }
+bytes = "1"
 glob = "0.3"
 
 [dev-dependencies]
@@ -34,3 +37,5 @@ assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
 rusqlite = { version = "0.31", features = ["bundled"] }
+arrow = { version = "53", default-features = false }
+parquet = { version = "53", default-features = false, features = ["arrow"] }

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 
 use super::{
-    read_file_bytes, read_file_with_encoding, read_sqlite_from_path, read_xlsx_from_bytes,
-    EncodingOptions, ExcelOptions, SqliteOptions,
+    read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
+    read_xlsx_from_bytes, EncodingOptions, ExcelOptions, SqliteOptions,
 };
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::html::HtmlWriter;
@@ -26,7 +26,7 @@ use crate::value::Value;
 /// 지원되는 입력 파일 확장자 목록
 const SUPPORTED_EXTENSIONS: &[&str] = &[
     "json", "jsonl", "ndjson", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack", "xlsx",
-    "xls", "xlsm", "xlsb", "ods", "db", "sqlite", "sqlite3",
+    "xls", "xlsm", "xlsb", "ods", "db", "sqlite", "sqlite3", "parquet", "pq",
 ];
 
 pub struct ConvertArgs<'a> {
@@ -95,6 +95,12 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
                 .read_to_end(&mut buf)
                 .context("Failed to read from stdin")?;
             MsgpackReader.read_from_bytes(&buf)?
+        } else if args.from == Some("parquet") || args.from == Some("pq") {
+            let mut buf = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buf)
+                .context("Failed to read from stdin")?;
+            read_parquet_from_bytes(&buf)?
         } else {
             let buf = read_stdin_with_encoding(&args.encoding_opts)?;
             let (source_format, sniffed_delimiter) = match args.from {
@@ -373,6 +379,9 @@ fn read_value_from_path(
         read_xlsx_from_bytes(&bytes, excel_opts)
     } else if format == Format::Sqlite {
         read_sqlite_from_path(path, sqlite_opts)
+    } else if format == Format::Parquet {
+        let bytes = read_file_bytes(path)?;
+        read_parquet_from_bytes(&bytes)
     } else {
         let content = read_file_with_encoding(path, encoding_opts)?;
         read_value(&content, format, options)
@@ -393,6 +402,9 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         }
         Format::Sqlite => {
             bail!("SQLite files must be read from a file path, not from text input")
+        }
+        Format::Parquet => {
+            bail!("Parquet files must be read from a file path, not from text input")
         }
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
@@ -440,6 +452,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),
+        Format::Parquet => bail!("Parquet is an input-only format and cannot be used as output\n  Hint: Parquet Writer will be available in a future version"),
         Format::Markdown => MarkdownWriter.write(value),
         Format::Html => HtmlWriter::new(options.styled, options.full_html).write(value),
         Format::Table => {

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -4,8 +4,8 @@ use anyhow::{bail, Result};
 use colored::Colorize;
 
 use super::{
-    read_file_bytes, read_file_with_encoding, read_sqlite_from_path, read_xlsx_from_bytes,
-    EncodingOptions, ExcelOptions, SqliteOptions,
+    read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
+    read_xlsx_from_bytes, EncodingOptions, ExcelOptions, SqliteOptions,
 };
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
@@ -93,6 +93,9 @@ fn read_value_from_path(
         read_xlsx_from_bytes(&bytes, excel_opts)
     } else if format == Format::Sqlite {
         read_sqlite_from_path(path, sqlite_opts)
+    } else if format == Format::Parquet {
+        let bytes = read_file_bytes(path)?;
+        read_parquet_from_bytes(&bytes)
     } else {
         let content = read_file_with_encoding(path, encoding_opts)?;
         read_value(&content, format, &options)
@@ -113,6 +116,9 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         }
         Format::Sqlite => {
             bail!("SQLite files must be read from a file path, not from text input")
+        }
+        Format::Parquet => {
+            bail!("Parquet files must be read from a file path, not from text input")
         }
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 
 use super::{
-    read_file_bytes, read_file_with_encoding, read_sqlite_from_path, read_xlsx_from_bytes,
-    EncodingOptions, ExcelOptions, SqliteOptions,
+    read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
+    read_xlsx_from_bytes, EncodingOptions, ExcelOptions, SqliteOptions,
 };
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::html::HtmlWriter;
@@ -60,6 +60,9 @@ pub fn run(args: &MergeArgs) -> Result<()> {
             read_xlsx_from_bytes(&bytes, &args.excel_opts)?
         } else if format == Format::Sqlite {
             read_sqlite_from_path(path, &args.sqlite_opts)?
+        } else if format == Format::Parquet {
+            let bytes = read_file_bytes(path)?;
+            read_parquet_from_bytes(&bytes)?
         } else {
             let content = read_file_with_encoding(path, &args.encoding_opts)?;
             read_value(&content, format, &read_options)?
@@ -195,6 +198,9 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Sqlite => {
             bail!("SQLite files must be read from a file path, not from text input")
         }
+        Format::Parquet => {
+            bail!("Parquet files must be read from a file path, not from text input")
+        }
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
@@ -212,6 +218,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),
+        Format::Parquet => bail!("Parquet is an input-only format and cannot be used as output"),
         Format::Markdown => MarkdownWriter.write(value),
         Format::Html => HtmlWriter::new(options.styled, options.full_html).write(value),
         Format::Table => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -120,6 +120,12 @@ pub fn list_sqlite_tables(path: &std::path::Path) -> anyhow::Result<Vec<String>>
     crate::format::sqlite::SqliteReader::list_tables(path)
 }
 
+/// Parquet 파일을 바이트에서 Value로 읽는다.
+pub fn read_parquet_from_bytes(bytes: &[u8]) -> anyhow::Result<crate::value::Value> {
+    use crate::format::parquet::{ParquetOptions, ParquetReader};
+    ParquetReader::new(ParquetOptions::default()).read_from_bytes(bytes)
+}
+
 /// 인코딩을 고려하여 파일을 읽는다.
 ///
 /// 동작 우선순위:

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 
 use super::{
-    read_file_bytes, read_file_with_encoding, read_sqlite_from_path, read_xlsx_from_bytes,
-    EncodingOptions, ExcelOptions, SqliteOptions,
+    read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
+    read_xlsx_from_bytes, EncodingOptions, ExcelOptions, SqliteOptions,
 };
 use crate::format::csv::CsvReader;
 use crate::format::html::HtmlWriter;
@@ -74,6 +74,9 @@ pub fn run(args: &QueryArgs) -> Result<()> {
             read_xlsx_from_bytes(&bytes, &args.excel_opts)?
         } else if source_format == Format::Sqlite {
             read_sqlite_from_path(Path::new(args.input), &args.sqlite_opts)?
+        } else if source_format == Format::Parquet {
+            let bytes = read_file_bytes(Path::new(args.input))?;
+            read_parquet_from_bytes(&bytes)?
         } else {
             let content = read_file_with_encoding(Path::new(args.input), &args.encoding_opts)?;
             let auto_delimiter = default_delimiter(Path::new(args.input));
@@ -182,6 +185,9 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Sqlite => {
             bail!("SQLite files must be read from a file path, not from text input")
         }
+        Format::Parquet => {
+            bail!("Parquet files must be read from a file path, not from text input")
+        }
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
@@ -208,6 +214,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),
+        Format::Parquet => bail!("Parquet is an input-only format and cannot be used as output"),
         Format::Markdown => MarkdownWriter.write(value),
         Format::Html => HtmlWriter::new(options.styled, options.full_html).write(value),
         Format::Table => {

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -2,8 +2,8 @@ use std::io::{self, Read};
 use std::path::Path;
 
 use super::{
-    read_file_bytes, read_file_with_encoding, read_sqlite_from_path, read_xlsx_from_bytes,
-    EncodingOptions, ExcelOptions, SqliteOptions,
+    read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
+    read_xlsx_from_bytes, EncodingOptions, ExcelOptions, SqliteOptions,
 };
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
@@ -62,6 +62,9 @@ pub fn run(args: &SchemaArgs) -> Result<()> {
             read_xlsx_from_bytes(&bytes, &args.excel_opts)?
         } else if source_format == Format::Sqlite {
             read_sqlite_from_path(Path::new(args.input), &args.sqlite_opts)?
+        } else if source_format == Format::Parquet {
+            let bytes = read_file_bytes(Path::new(args.input))?;
+            read_parquet_from_bytes(&bytes)?
         } else {
             let content = read_file_with_encoding(Path::new(args.input), &args.encoding_opts)?;
             let auto_delimiter = default_delimiter(Path::new(args.input));
@@ -233,6 +236,9 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         }
         Format::Sqlite => {
             bail!("SQLite files must be read from a file path, not from text input")
+        }
+        Format::Parquet => {
+            bail!("Parquet files must be read from a file path, not from text input")
         }
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -2,8 +2,8 @@ use std::io::{self, Read};
 use std::path::Path;
 
 use super::{
-    read_file_bytes, read_file_with_encoding, read_sqlite_from_path, read_xlsx_from_bytes,
-    EncodingOptions, ExcelOptions, SqliteOptions,
+    read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
+    read_xlsx_from_bytes, EncodingOptions, ExcelOptions, SqliteOptions,
 };
 use crate::format::csv::CsvReader;
 use crate::format::json::JsonReader;
@@ -320,6 +320,10 @@ fn read_input_as_value(args: &StatsArgs) -> Result<(Value, Format)> {
         } else if format == Format::Sqlite {
             let value = read_sqlite_from_path(Path::new(args.input), &args.sqlite_opts)?;
             Ok((value, format))
+        } else if format == Format::Parquet {
+            let bytes = read_file_bytes(Path::new(args.input))?;
+            let value = read_parquet_from_bytes(&bytes)?;
+            Ok((value, format))
         } else {
             let (content, format) = read_input(args)?;
             let auto_delimiter = default_delimiter(Path::new(args.input));
@@ -348,6 +352,9 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         }
         Format::Sqlite => {
             bail!("SQLite files must be read from a file path, not from text input")
+        }
+        Format::Parquet => {
+            bail!("Parquet files must be read from a file path, not from text input")
         }
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -5,7 +5,8 @@ use anyhow::{bail, Context as _, Result};
 
 use super::{
     list_sqlite_tables, list_xlsx_sheets, read_file_bytes, read_file_with_encoding,
-    read_sqlite_from_path, read_xlsx_from_bytes, EncodingOptions, ExcelOptions, SqliteOptions,
+    read_parquet_from_bytes, read_sqlite_from_path, read_xlsx_from_bytes, EncodingOptions,
+    ExcelOptions, SqliteOptions,
 };
 use crate::format::csv::CsvReader;
 use crate::format::csv::CsvWriter;
@@ -213,6 +214,17 @@ fn read_input_value(args: &ViewArgs, format: Format, options: &FormatOptions) ->
             bail!("SQLite files cannot be read from stdin; provide a file path");
         }
         read_sqlite_from_path(Path::new(args.input), &args.sqlite_opts)
+    } else if format == Format::Parquet {
+        if args.input == "-" {
+            let mut buf = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buf)
+                .context("Failed to read from stdin")?;
+            read_parquet_from_bytes(&buf)
+        } else {
+            let bytes = read_file_bytes(Path::new(args.input))?;
+            read_parquet_from_bytes(&bytes)
+        }
     } else {
         let content = if args.input == "-" {
             read_stdin_with_encoding(&args.encoding_opts)?
@@ -238,6 +250,9 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Sqlite => {
             bail!("SQLite files must be read from a file path, not from text input")
         }
+        Format::Parquet => {
+            bail!("Parquet files must be read from a file path, not from text input")
+        }
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
@@ -255,6 +270,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),
+        Format::Parquet => bail!("Parquet is an input-only format and cannot be used as output"),
         Format::Markdown => MarkdownWriter.write(value),
         Format::Html => HtmlWriter::new(options.styled, options.full_html).write(value),
         Format::Table => bail!("Table format is handled separately"),

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -4,6 +4,7 @@ pub mod json;
 pub mod jsonl;
 pub mod markdown;
 pub mod msgpack;
+pub mod parquet;
 pub mod sqlite;
 pub mod toml;
 pub mod xlsx;
@@ -28,6 +29,7 @@ pub enum Format {
     Msgpack,
     Xlsx,
     Sqlite,
+    Parquet,
     Markdown,
     Html,
     Table,
@@ -45,6 +47,7 @@ impl Format {
             "msgpack" | "messagepack" => Ok(Format::Msgpack),
             "xlsx" | "excel" | "xls" => Ok(Format::Xlsx),
             "sqlite" | "sqlite3" | "db" => Ok(Format::Sqlite),
+            "parquet" | "pq" => Ok(Format::Parquet),
             "md" | "markdown" => Ok(Format::Markdown),
             "html" => Ok(Format::Html),
             "table" => Ok(Format::Table),
@@ -65,6 +68,7 @@ impl Format {
             ("msgpack", "MessagePack binary format"),
             ("xlsx", "Excel spreadsheet (input only)"),
             ("sqlite", "SQLite database (input only)"),
+            ("parquet", "Apache Parquet columnar format (input only)"),
             ("md", "Markdown table"),
             ("html", "HTML table"),
             ("table", "Terminal table (default for view)"),
@@ -84,6 +88,7 @@ impl std::fmt::Display for Format {
             Format::Msgpack => write!(f, "MessagePack"),
             Format::Xlsx => write!(f, "Excel"),
             Format::Sqlite => write!(f, "SQLite"),
+            Format::Parquet => write!(f, "Parquet"),
             Format::Markdown => write!(f, "Markdown"),
             Format::Html => write!(f, "HTML"),
             Format::Table => write!(f, "Table"),
@@ -103,6 +108,7 @@ pub fn detect_format(path: &Path) -> Result<Format, DkitError> {
         Some("msgpack") => Ok(Format::Msgpack),
         Some("xlsx" | "xls" | "xlsm" | "xlsb" | "ods") => Ok(Format::Xlsx),
         Some("db" | "sqlite" | "sqlite3") => Ok(Format::Sqlite),
+        Some("parquet" | "pq") => Ok(Format::Parquet),
         Some("md") => Ok(Format::Markdown),
         Some("html") => Ok(Format::Html),
         Some(ext) => Err(DkitError::UnknownFormat(ext.to_string())),

--- a/src/format/parquet.rs
+++ b/src/format/parquet.rs
@@ -1,0 +1,568 @@
+use anyhow::bail;
+use arrow::array::{
+    Array, AsArray, BinaryArray, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
+    Int64Array, Int8Array, LargeBinaryArray, LargeStringArray, StringArray, StructArray,
+    UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::datatypes::DataType;
+use bytes::Bytes;
+use indexmap::IndexMap;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use crate::error::DkitError;
+use crate::value::Value;
+
+/// Parquet 파일 읽기 옵션
+#[derive(Debug, Clone, Default)]
+pub struct ParquetOptions {
+    /// 특정 Row Group만 읽기 (None이면 전체)
+    pub row_group: Option<usize>,
+}
+
+/// Parquet Reader
+pub struct ParquetReader {
+    options: ParquetOptions,
+}
+
+impl ParquetReader {
+    pub fn new(options: ParquetOptions) -> Self {
+        Self { options }
+    }
+
+    /// 바이트 슬라이스에서 Parquet 파일을 읽어 Value로 변환한다.
+    pub fn read_from_bytes(&self, bytes: &[u8]) -> anyhow::Result<Value> {
+        let bytes = Bytes::copy_from_slice(bytes);
+        let builder =
+            ParquetRecordBatchReaderBuilder::try_new(bytes).map_err(|e| DkitError::ParseError {
+                format: "Parquet".to_string(),
+                source: Box::new(e),
+            })?;
+
+        // Row Group 필터링
+        let builder = if let Some(rg) = self.options.row_group {
+            let metadata = builder.metadata().clone();
+            let num_row_groups = metadata.num_row_groups();
+            if rg >= num_row_groups {
+                bail!(
+                    "Row group index {} out of range (file has {} row groups)",
+                    rg,
+                    num_row_groups
+                );
+            }
+            builder.with_row_groups(vec![rg])
+        } else {
+            builder
+        };
+
+        let reader = builder.build().map_err(|e| DkitError::ParseError {
+            format: "Parquet".to_string(),
+            source: Box::new(e),
+        })?;
+
+        let mut rows: Vec<Value> = Vec::new();
+
+        for batch_result in reader {
+            let batch = batch_result.map_err(|e| DkitError::ParseError {
+                format: "Parquet".to_string(),
+                source: Box::new(e),
+            })?;
+
+            let schema = batch.schema();
+            let num_rows = batch.num_rows();
+
+            for row_idx in 0..num_rows {
+                let mut obj = IndexMap::new();
+
+                for (col_idx, field) in schema.fields().iter().enumerate() {
+                    let col = batch.column(col_idx);
+                    let value = arrow_value_to_value(col.as_ref(), row_idx);
+                    obj.insert(field.name().clone(), value);
+                }
+
+                rows.push(Value::Object(obj));
+            }
+        }
+
+        Ok(Value::Array(rows))
+    }
+
+    /// Parquet 파일의 메타데이터를 반환한다.
+    #[allow(dead_code)]
+    pub fn read_metadata(bytes: &[u8]) -> anyhow::Result<ParquetMetadata> {
+        let bytes = Bytes::copy_from_slice(bytes);
+        let builder =
+            ParquetRecordBatchReaderBuilder::try_new(bytes).map_err(|e| DkitError::ParseError {
+                format: "Parquet".to_string(),
+                source: Box::new(e),
+            })?;
+
+        let metadata = builder.metadata().clone();
+        let schema = builder.schema().clone();
+
+        let columns: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+        let column_types: Vec<String> = schema
+            .fields()
+            .iter()
+            .map(|f| format!("{}", f.data_type()))
+            .collect();
+
+        Ok(ParquetMetadata {
+            num_rows: metadata.file_metadata().num_rows() as usize,
+            num_row_groups: metadata.num_row_groups(),
+            columns,
+            column_types,
+        })
+    }
+}
+
+/// Parquet 파일 메타데이터
+#[allow(dead_code)]
+pub struct ParquetMetadata {
+    pub num_rows: usize,
+    pub num_row_groups: usize,
+    pub columns: Vec<String>,
+    pub column_types: Vec<String>,
+}
+
+/// Arrow 배열의 특정 행 값을 Value로 변환한다.
+fn arrow_value_to_value(array: &dyn Array, idx: usize) -> Value {
+    if array.is_null(idx) {
+        return Value::Null;
+    }
+
+    match array.data_type() {
+        DataType::Null => Value::Null,
+        DataType::Boolean => {
+            let arr = array.as_any().downcast_ref::<BooleanArray>().unwrap();
+            Value::Bool(arr.value(idx))
+        }
+        DataType::Int8 => {
+            let arr = array.as_any().downcast_ref::<Int8Array>().unwrap();
+            Value::Integer(arr.value(idx) as i64)
+        }
+        DataType::Int16 => {
+            let arr = array.as_any().downcast_ref::<Int16Array>().unwrap();
+            Value::Integer(arr.value(idx) as i64)
+        }
+        DataType::Int32 => {
+            let arr = array.as_any().downcast_ref::<Int32Array>().unwrap();
+            Value::Integer(arr.value(idx) as i64)
+        }
+        DataType::Int64 => {
+            let arr = array.as_any().downcast_ref::<Int64Array>().unwrap();
+            Value::Integer(arr.value(idx))
+        }
+        DataType::UInt8 => {
+            let arr = array.as_any().downcast_ref::<UInt8Array>().unwrap();
+            Value::Integer(arr.value(idx) as i64)
+        }
+        DataType::UInt16 => {
+            let arr = array.as_any().downcast_ref::<UInt16Array>().unwrap();
+            Value::Integer(arr.value(idx) as i64)
+        }
+        DataType::UInt32 => {
+            let arr = array.as_any().downcast_ref::<UInt32Array>().unwrap();
+            Value::Integer(arr.value(idx) as i64)
+        }
+        DataType::UInt64 => {
+            let arr = array.as_any().downcast_ref::<UInt64Array>().unwrap();
+            let v = arr.value(idx);
+            if v <= i64::MAX as u64 {
+                Value::Integer(v as i64)
+            } else {
+                Value::Float(v as f64)
+            }
+        }
+        DataType::Float32 => {
+            let arr = array.as_any().downcast_ref::<Float32Array>().unwrap();
+            Value::Float(arr.value(idx) as f64)
+        }
+        DataType::Float64 => {
+            let arr = array.as_any().downcast_ref::<Float64Array>().unwrap();
+            Value::Float(arr.value(idx))
+        }
+        DataType::Utf8 => {
+            let arr = array.as_any().downcast_ref::<StringArray>().unwrap();
+            Value::String(arr.value(idx).to_string())
+        }
+        DataType::LargeUtf8 => {
+            let arr = array.as_any().downcast_ref::<LargeStringArray>().unwrap();
+            Value::String(arr.value(idx).to_string())
+        }
+        DataType::Binary => {
+            let arr = array.as_any().downcast_ref::<BinaryArray>().unwrap();
+            let hex = arr
+                .value(idx)
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>();
+            Value::String(format!("0x{}", hex))
+        }
+        DataType::LargeBinary => {
+            let arr = array.as_any().downcast_ref::<LargeBinaryArray>().unwrap();
+            let hex = arr
+                .value(idx)
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>();
+            Value::String(format!("0x{}", hex))
+        }
+        DataType::Date32 => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<arrow::array::Date32Array>()
+                .unwrap();
+            let days = arr.value(idx);
+            Value::String(chrono_date_from_days(days))
+        }
+        DataType::Date64 => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<arrow::array::Date64Array>()
+                .unwrap();
+            let ms = arr.value(idx);
+            Value::String(format_epoch_secs(ms / 1000))
+        }
+        DataType::Timestamp(unit, tz) => {
+            let secs = match unit {
+                arrow::datatypes::TimeUnit::Second => {
+                    let arr = array
+                        .as_any()
+                        .downcast_ref::<arrow::array::TimestampSecondArray>()
+                        .unwrap();
+                    arr.value(idx)
+                }
+                arrow::datatypes::TimeUnit::Millisecond => {
+                    let arr = array
+                        .as_any()
+                        .downcast_ref::<arrow::array::TimestampMillisecondArray>()
+                        .unwrap();
+                    arr.value(idx) / 1000
+                }
+                arrow::datatypes::TimeUnit::Microsecond => {
+                    let arr = array
+                        .as_any()
+                        .downcast_ref::<arrow::array::TimestampMicrosecondArray>()
+                        .unwrap();
+                    arr.value(idx) / 1_000_000
+                }
+                arrow::datatypes::TimeUnit::Nanosecond => {
+                    let arr = array
+                        .as_any()
+                        .downcast_ref::<arrow::array::TimestampNanosecondArray>()
+                        .unwrap();
+                    arr.value(idx) / 1_000_000_000
+                }
+            };
+            let s = format_epoch_secs(secs);
+            if tz.is_some() {
+                Value::String(format!("{}Z", s))
+            } else {
+                Value::String(s)
+            }
+        }
+        DataType::List(_) => {
+            let list_arr = array.as_list::<i32>();
+            let value_arr = list_arr.value(idx);
+            let mut items = Vec::new();
+            for i in 0..value_arr.len() {
+                items.push(arrow_value_to_value(value_arr.as_ref(), i));
+            }
+            Value::Array(items)
+        }
+        DataType::LargeList(_) => {
+            let list_arr = array.as_list::<i64>();
+            let value_arr = list_arr.value(idx);
+            let mut items = Vec::new();
+            for i in 0..value_arr.len() {
+                items.push(arrow_value_to_value(value_arr.as_ref(), i));
+            }
+            Value::Array(items)
+        }
+        DataType::Struct(_) => {
+            let struct_arr = array.as_any().downcast_ref::<StructArray>().unwrap();
+            let mut obj = IndexMap::new();
+            for (i, field) in struct_arr.fields().iter().enumerate() {
+                let col = struct_arr.column(i);
+                obj.insert(
+                    field.name().clone(),
+                    arrow_value_to_value(col.as_ref(), idx),
+                );
+            }
+            Value::Object(obj)
+        }
+        DataType::Map(_, _) => {
+            let map_arr = array
+                .as_any()
+                .downcast_ref::<arrow::array::MapArray>()
+                .unwrap();
+            let entries = map_arr.value(idx);
+            let struct_arr = entries.as_any().downcast_ref::<StructArray>().unwrap();
+            let keys = struct_arr.column(0);
+            let values = struct_arr.column(1);
+            let mut obj = IndexMap::new();
+            for i in 0..struct_arr.len() {
+                let key = arrow_value_to_value(keys.as_ref(), i);
+                let val = arrow_value_to_value(values.as_ref(), i);
+                let key_str = match key {
+                    Value::String(s) => s,
+                    other => format!("{}", other),
+                };
+                obj.insert(key_str, val);
+            }
+            Value::Object(obj)
+        }
+        _ => {
+            // Fallback for Dictionary, FixedSizeBinary, FixedSizeList, etc.
+            // Use Arrow's display formatting
+            let formatter = arrow::util::display::ArrayFormatter::try_new(
+                array,
+                &arrow::util::display::FormatOptions::default(),
+            );
+            match formatter {
+                Ok(f) => Value::String(f.value(idx).to_string()),
+                Err(_) => Value::String("<unsupported>".to_string()),
+            }
+        }
+    }
+}
+
+/// epoch days → "YYYY-MM-DD" 문자열 변환
+fn chrono_date_from_days(days: i32) -> String {
+    let (y, m, d) = civil_from_days(days as i64);
+    format!("{:04}-{:02}-{:02}", y, m, d)
+}
+
+/// epoch seconds → "YYYY-MM-DDTHH:MM:SS" 문자열 변환
+fn format_epoch_secs(secs: i64) -> String {
+    let days = if secs >= 0 {
+        secs / 86400
+    } else {
+        (secs - 86399) / 86400
+    };
+    let day_secs = (secs - days * 86400) as u32;
+    let h = day_secs / 3600;
+    let m = (day_secs % 3600) / 60;
+    let s = day_secs % 60;
+
+    let (y, mo, d) = civil_from_days(days);
+    format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}", y, mo, d, h, m, s)
+}
+
+/// Unix epoch 기준 일 수에서 (year, month, day) 계산
+/// Howard Hinnant's civil_from_days algorithm
+/// https://howardhinnant.github.io/date_algorithms.html
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use std::sync::Arc;
+
+    /// 테스트용 Parquet 바이트를 생성한다
+    fn make_test_parquet() -> Vec<u8> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+            Field::new("score", DataType::Float64, true),
+            Field::new("active", DataType::Boolean, false),
+        ]));
+
+        let names: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie"]));
+        let ages: ArrayRef = Arc::new(Int64Array::from(vec![30, 25, 35]));
+        let scores: ArrayRef = Arc::new(Float64Array::from(vec![Some(95.5), None, Some(87.3)]));
+        let actives: ArrayRef = Arc::new(BooleanArray::from(vec![true, false, true]));
+
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![names, ages, scores, actives]).unwrap();
+
+        let mut buf = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        buf
+    }
+
+    #[test]
+    fn test_read_basic_parquet() {
+        let bytes = make_test_parquet();
+        let reader = ParquetReader::new(ParquetOptions::default());
+        let value = reader.read_from_bytes(&bytes).unwrap();
+
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+
+        let row0 = arr[0].as_object().unwrap();
+        assert_eq!(row0["name"], Value::String("Alice".to_string()));
+        assert_eq!(row0["age"], Value::Integer(30));
+        assert_eq!(row0["score"], Value::Float(95.5));
+        assert_eq!(row0["active"], Value::Bool(true));
+
+        let row1 = arr[1].as_object().unwrap();
+        assert_eq!(row1["name"], Value::String("Bob".to_string()));
+        assert_eq!(row1["score"], Value::Null);
+
+        let row2 = arr[2].as_object().unwrap();
+        assert_eq!(row2["name"], Value::String("Charlie".to_string()));
+        assert_eq!(row2["age"], Value::Integer(35));
+    }
+
+    #[test]
+    fn test_read_metadata() {
+        let bytes = make_test_parquet();
+        let meta = ParquetReader::read_metadata(&bytes).unwrap();
+
+        assert_eq!(meta.num_rows, 3);
+        assert_eq!(meta.num_row_groups, 1);
+        assert_eq!(meta.columns, vec!["name", "age", "score", "active"]);
+    }
+
+    #[test]
+    fn test_read_row_group_filter() {
+        let bytes = make_test_parquet();
+        let reader = ParquetReader::new(ParquetOptions { row_group: Some(0) });
+        let value = reader.read_from_bytes(&bytes).unwrap();
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_read_row_group_out_of_range() {
+        let bytes = make_test_parquet();
+        let reader = ParquetReader::new(ParquetOptions {
+            row_group: Some(99),
+        });
+        let result = reader.read_from_bytes(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_parquet() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+
+        let ids: ArrayRef = Arc::new(Int64Array::from(Vec::<i64>::new()));
+        let batch = RecordBatch::try_new(schema.clone(), vec![ids]).unwrap();
+
+        let mut buf = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let reader = ParquetReader::new(ParquetOptions::default());
+        let value = reader.read_from_bytes(&buf).unwrap();
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_chrono_date_from_days() {
+        assert_eq!(chrono_date_from_days(0), "1970-01-01");
+        assert_eq!(chrono_date_from_days(1), "1970-01-02");
+        assert_eq!(chrono_date_from_days(365), "1971-01-01");
+        assert_eq!(chrono_date_from_days(18628), "2021-01-01");
+    }
+
+    #[test]
+    fn test_format_epoch_secs() {
+        assert_eq!(format_epoch_secs(0), "1970-01-01T00:00:00");
+        assert_eq!(format_epoch_secs(86400), "1970-01-02T00:00:00");
+    }
+
+    #[test]
+    fn test_nested_struct_parquet() {
+        let inner_fields = vec![
+            Field::new("city", DataType::Utf8, false),
+            Field::new("zip", DataType::Int32, false),
+        ];
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("address", DataType::Struct(inner_fields.into()), true),
+        ]));
+
+        let names: ArrayRef = Arc::new(StringArray::from(vec!["Alice"]));
+        let cities: ArrayRef = Arc::new(StringArray::from(vec!["Seoul"]));
+        let zips: ArrayRef = Arc::new(arrow::array::Int32Array::from(vec![12345]));
+        let address: ArrayRef = Arc::new(arrow::array::StructArray::from(vec![
+            (
+                Arc::new(Field::new("city", DataType::Utf8, false)),
+                cities as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("zip", DataType::Int32, false)),
+                zips as ArrayRef,
+            ),
+        ]));
+
+        let batch = RecordBatch::try_new(schema.clone(), vec![names, address]).unwrap();
+
+        let mut buf = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let reader = ParquetReader::new(ParquetOptions::default());
+        let value = reader.read_from_bytes(&buf).unwrap();
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+
+        let row = arr[0].as_object().unwrap();
+        let addr = row["address"].as_object().unwrap();
+        assert_eq!(addr["city"], Value::String("Seoul".to_string()));
+        assert_eq!(addr["zip"], Value::Integer(12345));
+    }
+
+    #[test]
+    fn test_list_parquet() {
+        let list_field = Field::new("item", DataType::Int32, true);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "values",
+            DataType::List(Arc::new(list_field)),
+            true,
+        )]));
+
+        let values_builder = arrow::array::ListBuilder::new(arrow::array::Int32Builder::new());
+        let mut builder = values_builder;
+        builder.values().append_value(1);
+        builder.values().append_value(2);
+        builder.values().append_value(3);
+        builder.append(true);
+        builder.values().append_value(4);
+        builder.values().append_value(5);
+        builder.append(true);
+
+        let list_array: ArrayRef = Arc::new(builder.finish());
+        let batch = RecordBatch::try_new(schema.clone(), vec![list_array]).unwrap();
+
+        let mut buf = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let reader = ParquetReader::new(ParquetOptions::default());
+        let value = reader.read_from_bytes(&buf).unwrap();
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+
+        let row0 = arr[0].as_object().unwrap();
+        let vals = row0["values"].as_array().unwrap();
+        assert_eq!(vals.len(), 3);
+        assert_eq!(vals[0], Value::Integer(1));
+    }
+}

--- a/tests/parquet_test.rs
+++ b/tests/parquet_test.rs
@@ -1,0 +1,224 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+/// 테스트용 Parquet 파일을 생성한다.
+fn create_test_parquet(path: &std::path::Path) {
+    use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use std::sync::Arc;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int64, false),
+        Field::new("score", DataType::Float64, true),
+        Field::new("active", DataType::Boolean, false),
+    ]));
+
+    let names: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie"]));
+    let ages: ArrayRef = Arc::new(Int64Array::from(vec![30, 25, 35]));
+    let scores: ArrayRef = Arc::new(Float64Array::from(vec![Some(95.5), None, Some(87.3)]));
+    let actives: ArrayRef = Arc::new(BooleanArray::from(vec![true, false, true]));
+
+    let batch = RecordBatch::try_new(schema.clone(), vec![names, ages, scores, actives]).unwrap();
+
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+// --- convert ---
+
+#[test]
+fn convert_parquet_to_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    dkit()
+        .args([
+            "convert",
+            pq_path.to_str().unwrap(),
+            "-f",
+            "json",
+            "--compact",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"))
+        .stdout(predicate::str::contains("Charlie"));
+}
+
+#[test]
+fn convert_parquet_to_csv() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    dkit()
+        .args(["convert", pq_path.to_str().unwrap(), "-f", "csv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name,age,score,active"))
+        .stdout(predicate::str::contains("Alice,30,95.5,true"));
+}
+
+#[test]
+fn convert_parquet_to_yaml() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    dkit()
+        .args(["convert", pq_path.to_str().unwrap(), "-f", "yaml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name: Alice"))
+        .stdout(predicate::str::contains("age: 30"));
+}
+
+// --- view ---
+
+#[test]
+fn view_parquet() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    dkit()
+        .args(["view", pq_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"))
+        .stdout(predicate::str::contains("Charlie"));
+}
+
+#[test]
+fn view_parquet_with_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    dkit()
+        .args(["view", pq_path.to_str().unwrap(), "--limit", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Charlie").not());
+}
+
+// --- stats ---
+
+#[test]
+fn stats_parquet() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    dkit()
+        .args(["stats", pq_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rows: 3"))
+        .stdout(predicate::str::contains("name"));
+}
+
+// --- schema ---
+
+#[test]
+fn schema_parquet() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    dkit()
+        .args(["schema", pq_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("age"));
+}
+
+// --- query ---
+
+#[test]
+fn query_parquet() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    dkit()
+        .args(["query", pq_path.to_str().unwrap(), ".[0].name"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+}
+
+// --- format detection ---
+
+#[test]
+fn parquet_format_auto_detected() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    // No --from needed, should auto-detect from .parquet extension
+    dkit()
+        .args([
+            "convert",
+            pq_path.to_str().unwrap(),
+            "-f",
+            "json",
+            "--compact",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+}
+
+// --- parquet as output should fail ---
+
+#[test]
+fn convert_json_to_parquet_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let json_path = dir.path().join("data.json");
+    std::fs::write(&json_path, r#"[{"id":1}]"#).unwrap();
+
+    dkit()
+        .args(["convert", json_path.to_str().unwrap(), "-f", "parquet"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("input-only"));
+}
+
+// --- null handling ---
+
+#[test]
+fn parquet_null_values_to_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let pq_path = dir.path().join("data.parquet");
+    create_test_parquet(&pq_path);
+
+    let output = dkit()
+        .args([
+            "convert",
+            pq_path.to_str().unwrap(),
+            "-f",
+            "json",
+            "--compact",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Bob's score is null
+    assert!(stdout.contains("null"));
+}


### PR DESCRIPTION
## Summary
- Apache Parquet 파일 읽기 지원 추가 (`arrow` + `parquet` 크레이트 활용)
- 컬럼 기반 데이터를 행 기반 Value 배열로 변환 (모든 Arrow 타입 지원)
- 모든 서브커맨드에서 Parquet 입력 지원 (convert, view, query, stats, schema, merge, diff)
- 중첩 스키마 (Struct, List, Map) 지원
- Row Group 단위 읽기 및 메타데이터 조회 기능

## Test plan
- [x] 9 unit tests: basic read, null handling, nested struct, list, empty, metadata, row group filter
- [x] 11 integration tests: convert (json/csv/yaml), view, stats, schema, query, format detection, output-only error
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과
- [x] 기존 전체 테스트 542개 + 새 테스트 20개 = 모두 통과

Closes #92

https://claude.ai/code/session_01NLET2mf1PYmEepgkZEM8x1