### PR TITLE
feat: implement Parquet Writer with compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -887,6 +889,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,8 +1190,11 @@ dependencies = [
  "num-bigint",
  "paste",
  "seq-macro",
+ "snap",
  "thrift",
  "twox-hash",
+ "zstd",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -1488,6 +1503,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "static_assertions"
@@ -2115,4 +2136,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chardetng = "0.1"
 calamine = "0.26"
 rusqlite = { version = "0.31", features = ["bundled"] }
 arrow = { version = "53", default-features = false, features = ["prettyprint"] }
-parquet = { version = "53", default-features = false, features = ["arrow"] }
+parquet = { version = "53", default-features = false, features = ["arrow", "snap", "zstd"] }
 bytes = "1"
 glob = "0.3"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,6 +129,14 @@ pub enum Commands {
         /// Filter expression (e.g. 'age > 30 and city == "Seoul"')
         #[arg(long, value_name = "EXPR", alias = "where")]
         filter: Option<String>,
+
+        /// Parquet compression codec (none, snappy, gzip, zstd)
+        #[arg(long, value_name = "CODEC", default_value = "none")]
+        compression: String,
+
+        /// Parquet row group size (number of rows per row group)
+        #[arg(long, value_name = "N")]
+        row_group_size: Option<usize>,
     },
 
     /// Query data using path expressions

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -6,7 +6,8 @@ use anyhow::{bail, Context, Result};
 
 use super::{
     read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
-    read_xlsx_from_bytes, EncodingOptions, ExcelOptions, SqliteOptions,
+    read_xlsx_from_bytes, write_parquet_to_bytes, EncodingOptions, ExcelOptions,
+    ParquetWriteOptions, SqliteOptions,
 };
 use crate::format::csv::{CsvReader, CsvWriter};
 use crate::format::html::HtmlWriter;
@@ -49,6 +50,7 @@ pub struct ConvertArgs<'a> {
     pub rename: Option<&'a str>,
     pub continue_on_error: bool,
     pub data_filter: super::DataFilterOptions,
+    pub parquet_opts: ParquetWriteOptions,
 }
 
 /// convert 서브커맨드 실행
@@ -120,7 +122,13 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         };
 
         let value = super::apply_data_filters(value, &args.data_filter)?;
-        write_output(&value, target_format, &write_options, args.output)?;
+        write_output(
+            &value,
+            target_format,
+            &write_options,
+            args.output,
+            &args.parquet_opts,
+        )?;
         return Ok(());
     }
 
@@ -222,7 +230,13 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
             }
         }
     }
-    write_output(&value, target_format, &write_options, out_path)?;
+    write_output(
+        &value,
+        target_format,
+        &write_options,
+        out_path,
+        &args.parquet_opts,
+    )?;
 
     Ok(())
 }
@@ -259,7 +273,13 @@ fn convert_single_file(
 
     let out_name = make_output_name(path, args.to, args.rename);
     let out_path = outdir.join(out_name);
-    write_output(&value, target_format, write_options, Some(&out_path))
+    write_output(
+        &value,
+        target_format,
+        write_options,
+        Some(&out_path),
+        &args.parquet_opts,
+    )
 }
 
 /// 입력 경로를 확장한다: 글롭 패턴, 디렉토리, 일반 파일을 처리
@@ -418,6 +438,7 @@ fn write_output(
     format: Format,
     options: &FormatOptions,
     output: Option<&Path>,
+    parquet_opts: &ParquetWriteOptions,
 ) -> Result<()> {
     if format == Format::Msgpack {
         let bytes = MsgpackWriter.write_bytes(value)?;
@@ -428,6 +449,16 @@ fn write_output(
             io::stdout()
                 .write_all(&bytes)
                 .context("Failed to write to stdout")?;
+        }
+    } else if format == Format::Parquet {
+        let bytes = write_parquet_to_bytes(value, parquet_opts)?;
+        if let Some(out_path) = output {
+            fs::write(out_path, &bytes)
+                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        } else {
+            io::stdout()
+                .write_all(&bytes)
+                .context("Failed to write Parquet to stdout")?;
         }
     } else {
         let result = write_value(value, format, options)?;
@@ -452,7 +483,9 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),
-        Format::Parquet => bail!("Parquet is an input-only format and cannot be used as output\n  Hint: Parquet Writer will be available in a future version"),
+        Format::Parquet => {
+            bail!("Internal error: Parquet output should be handled via write_output")
+        }
         Format::Markdown => MarkdownWriter.write(value),
         Format::Html => HtmlWriter::new(options.styled, options.full_html).write(value),
         Format::Table => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -126,6 +126,31 @@ pub fn read_parquet_from_bytes(bytes: &[u8]) -> anyhow::Result<crate::value::Val
     ParquetReader::new(ParquetOptions::default()).read_from_bytes(bytes)
 }
 
+/// Parquet 쓰기 옵션
+#[derive(Debug, Clone, Default)]
+pub struct ParquetWriteOptions {
+    /// 압축 방식 문자열 (none, snappy, gzip, zstd)
+    pub compression: String,
+    /// Row Group 최대 크기
+    pub row_group_size: Option<usize>,
+}
+
+/// Value를 Parquet 바이트로 직렬화한다.
+pub fn write_parquet_to_bytes(
+    value: &crate::value::Value,
+    opts: &ParquetWriteOptions,
+) -> anyhow::Result<Vec<u8>> {
+    use crate::format::parquet::{
+        ParquetCompression, ParquetWriteOptions as FmtOpts, ParquetWriter,
+    };
+    let compression: ParquetCompression = opts.compression.parse()?;
+    let write_opts = FmtOpts {
+        compression,
+        row_group_size: opts.row_group_size,
+    };
+    ParquetWriter::new(write_opts).write_to_bytes(value)
+}
+
 /// 인코딩을 고려하여 파일을 읽는다.
 ///
 /// 동작 우선순위:

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -68,7 +68,7 @@ impl Format {
             ("msgpack", "MessagePack binary format"),
             ("xlsx", "Excel spreadsheet (input only)"),
             ("sqlite", "SQLite database (input only)"),
-            ("parquet", "Apache Parquet columnar format (input only)"),
+            ("parquet", "Apache Parquet columnar format"),
             ("md", "Markdown table"),
             ("html", "HTML table"),
             ("table", "Terminal table (default for view)"),

--- a/src/format/parquet.rs
+++ b/src/format/parquet.rs
@@ -1,13 +1,20 @@
+use std::sync::Arc;
+
 use anyhow::bail;
 use arrow::array::{
-    Array, AsArray, BinaryArray, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
-    Int64Array, Int8Array, LargeBinaryArray, LargeStringArray, StringArray, StructArray,
-    UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    Array, ArrayRef, AsArray, BinaryArray, BooleanArray, BooleanBuilder, Float32Array,
+    Float64Array, Float64Builder, Int16Array, Int32Array, Int64Array, Int64Builder, Int8Array,
+    LargeBinaryArray, LargeStringArray, StringArray, StringBuilder, StructArray, UInt16Array,
+    UInt32Array, UInt64Array, UInt8Array,
 };
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
 use bytes::Bytes;
 use indexmap::IndexMap;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use parquet::basic::{Compression, GzipLevel, ZstdLevel};
+use parquet::file::properties::WriterProperties;
 
 use crate::error::DkitError;
 use crate::value::Value;
@@ -122,6 +129,264 @@ pub struct ParquetMetadata {
     pub num_row_groups: usize,
     pub columns: Vec<String>,
     pub column_types: Vec<String>,
+}
+
+/// Parquet 압축 방식
+#[derive(Debug, Clone, Default)]
+pub enum ParquetCompression {
+    #[default]
+    None,
+    Snappy,
+    Gzip,
+    Zstd,
+}
+
+impl std::str::FromStr for ParquetCompression {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        match s.to_lowercase().as_str() {
+            "none" | "uncompressed" => Ok(ParquetCompression::None),
+            "snappy" => Ok(ParquetCompression::Snappy),
+            "gzip" => Ok(ParquetCompression::Gzip),
+            "zstd" => Ok(ParquetCompression::Zstd),
+            _ => anyhow::bail!(
+                "Unknown Parquet compression '{}'. Valid options: none, snappy, gzip, zstd",
+                s
+            ),
+        }
+    }
+}
+
+/// Parquet Writer 옵션
+#[derive(Debug, Clone, Default)]
+pub struct ParquetWriteOptions {
+    /// 압축 방식 (기본: none)
+    pub compression: ParquetCompression,
+    /// Row Group 최대 크기 (기본: parquet 라이브러리 기본값)
+    pub row_group_size: Option<usize>,
+}
+
+/// Parquet Writer - Value 배열을 Parquet 바이트로 직렬화한다.
+pub struct ParquetWriter {
+    options: ParquetWriteOptions,
+}
+
+impl ParquetWriter {
+    pub fn new(options: ParquetWriteOptions) -> Self {
+        Self { options }
+    }
+
+    /// Value를 Parquet 바이트로 변환한다.
+    ///
+    /// Value는 반드시 Object의 Array이어야 한다.
+    pub fn write_to_bytes(&self, value: &Value) -> anyhow::Result<Vec<u8>> {
+        let rows = match value {
+            Value::Array(rows) => rows,
+            _ => anyhow::bail!(
+                "Parquet output requires an array of records (got {})\n  Hint: input data must be a JSON array of objects",
+                value_type_name(value)
+            ),
+        };
+
+        if rows.is_empty() {
+            let schema = Arc::new(Schema::empty());
+            let batch = RecordBatch::new_empty(schema.clone());
+            return write_batch_to_bytes(&batch, schema, &self.options);
+        }
+
+        // Infer schema from all rows
+        let schema = infer_schema(rows);
+
+        // Build Arrow columns
+        let columns = build_columns(rows, &schema)?;
+
+        let batch = RecordBatch::try_new(schema.clone(), columns)
+            .map_err(|e| anyhow::anyhow!("Failed to create Parquet record batch: {e}"))?;
+
+        write_batch_to_bytes(&batch, schema, &self.options)
+    }
+}
+
+/// RecordBatch를 Parquet 바이트로 기록한다.
+fn write_batch_to_bytes(
+    batch: &RecordBatch,
+    schema: Arc<Schema>,
+    options: &ParquetWriteOptions,
+) -> anyhow::Result<Vec<u8>> {
+    let compression = match options.compression {
+        ParquetCompression::None => Compression::UNCOMPRESSED,
+        ParquetCompression::Snappy => Compression::SNAPPY,
+        ParquetCompression::Gzip => Compression::GZIP(GzipLevel::default()),
+        ParquetCompression::Zstd => Compression::ZSTD(ZstdLevel::default()),
+    };
+
+    let mut props_builder = WriterProperties::builder().set_compression(compression);
+
+    if let Some(rg_size) = options.row_group_size {
+        props_builder = props_builder.set_max_row_group_size(rg_size);
+    }
+
+    let props = props_builder.build();
+
+    let mut buf = Vec::new();
+    let mut writer = ArrowWriter::try_new(&mut buf, schema, Some(props))
+        .map_err(|e| anyhow::anyhow!("Failed to create Parquet writer: {e}"))?;
+
+    writer
+        .write(batch)
+        .map_err(|e| anyhow::anyhow!("Failed to write Parquet data: {e}"))?;
+
+    writer
+        .close()
+        .map_err(|e| anyhow::anyhow!("Failed to finalize Parquet file: {e}"))?;
+
+    Ok(buf)
+}
+
+/// Value 타입 이름을 반환한다 (에러 메시지용)
+fn value_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Integer(_) => "integer",
+        Value::Float(_) => "float",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// 행 배열에서 Arrow Schema를 추론한다.
+fn infer_schema(rows: &[Value]) -> Arc<Schema> {
+    // 모든 행에서 필드 이름을 순서대로 수집한다.
+    let mut field_names: IndexMap<String, ()> = IndexMap::new();
+    for row in rows {
+        if let Value::Object(obj) = row {
+            for key in obj.keys() {
+                field_names.entry(key.clone()).or_insert(());
+            }
+        }
+    }
+
+    let fields: Vec<Field> = field_names
+        .keys()
+        .map(|name| {
+            let (data_type, nullable) = infer_field_type(rows, name);
+            Field::new(name, data_type, nullable)
+        })
+        .collect();
+
+    Arc::new(Schema::new(fields))
+}
+
+/// 특정 필드의 Arrow DataType과 nullable 여부를 추론한다.
+fn infer_field_type(rows: &[Value], field: &str) -> (DataType, bool) {
+    let mut has_null = false;
+    let mut seen_bool = false;
+    let mut seen_int = false;
+    let mut seen_float = false;
+    let mut seen_string = false;
+
+    for row in rows {
+        match row {
+            Value::Object(obj) => match obj.get(field) {
+                None | Some(Value::Null) => has_null = true,
+                Some(Value::Bool(_)) => seen_bool = true,
+                Some(Value::Integer(_)) => seen_int = true,
+                Some(Value::Float(_)) => seen_float = true,
+                Some(Value::String(_)) => seen_string = true,
+                // 중첩 배열/객체는 문자열로 직렬화
+                Some(_) => seen_string = true,
+            },
+            _ => has_null = true,
+        }
+    }
+
+    let data_type = if seen_string {
+        DataType::Utf8
+    } else if seen_float {
+        // Integer 값도 Float64로 업캐스트한다.
+        DataType::Float64
+    } else if seen_int && seen_bool {
+        // 혼합 타입은 문자열로 직렬화
+        DataType::Utf8
+    } else if seen_int {
+        DataType::Int64
+    } else if seen_bool {
+        DataType::Boolean
+    } else {
+        // 모두 null이거나 미지정 → Utf8
+        DataType::Utf8
+    };
+
+    (data_type, has_null)
+}
+
+/// 행 배열에서 Arrow 컬럼 배열을 생성한다.
+fn build_columns(rows: &[Value], schema: &Schema) -> anyhow::Result<Vec<ArrayRef>> {
+    schema
+        .fields()
+        .iter()
+        .map(|field| Ok(build_column(rows, field.name(), field.data_type())))
+        .collect()
+}
+
+/// 특정 필드에 대한 Arrow 배열을 생성한다.
+fn build_column(rows: &[Value], field_name: &str, data_type: &DataType) -> ArrayRef {
+    match data_type {
+        DataType::Boolean => {
+            let mut builder = BooleanBuilder::new();
+            for row in rows {
+                match get_field_value(row, field_name) {
+                    Some(Value::Bool(b)) => builder.append_value(*b),
+                    _ => builder.append_null(),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        DataType::Int64 => {
+            let mut builder = Int64Builder::new();
+            for row in rows {
+                match get_field_value(row, field_name) {
+                    Some(Value::Integer(i)) => builder.append_value(*i),
+                    _ => builder.append_null(),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        DataType::Float64 => {
+            let mut builder = Float64Builder::new();
+            for row in rows {
+                match get_field_value(row, field_name) {
+                    Some(Value::Float(f)) => builder.append_value(*f),
+                    Some(Value::Integer(i)) => builder.append_value(*i as f64),
+                    _ => builder.append_null(),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        _ => {
+            let mut builder = StringBuilder::new();
+            for row in rows {
+                match get_field_value(row, field_name) {
+                    Some(Value::String(s)) => builder.append_value(s),
+                    Some(Value::Null) | None => builder.append_null(),
+                    Some(other) => builder.append_value(other.to_string()),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+    }
+}
+
+/// 행에서 특정 필드 값을 가져온다.
+fn get_field_value<'a>(row: &'a Value, field_name: &str) -> Option<&'a Value> {
+    if let Value::Object(obj) = row {
+        obj.get(field_name)
+    } else {
+        None
+    }
 }
 
 /// Arrow 배열의 특정 행 값을 Value로 변환한다.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use colored::Colorize;
 
 use cli::{Cli, Commands};
-use commands::{EncodingOptions, ExcelOptions, SqliteOptions};
+use commands::{EncodingOptions, ExcelOptions, ParquetWriteOptions, SqliteOptions};
 
 fn main() {
     let cli = Cli::parse();
@@ -98,6 +98,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             head,
             tail,
             filter,
+            compression,
+            row_group_size,
         } => {
             commands::convert::run(&commands::convert::ConvertArgs {
                 input: &input,
@@ -127,6 +129,10 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                     head,
                     tail,
                     filter,
+                },
+                parquet_opts: ParquetWriteOptions {
+                    compression,
+                    row_group_size,
                 },
             })?;
         }

--- a/tests/parquet_test.rs
+++ b/tests/parquet_test.rs
@@ -184,19 +184,33 @@ fn parquet_format_auto_detected() {
         .stdout(predicate::str::contains("Alice"));
 }
 
-// --- parquet as output should fail ---
+// --- parquet as output (write) ---
 
 #[test]
-fn convert_json_to_parquet_fails() {
+fn convert_json_to_parquet_succeeds() {
     let dir = tempfile::tempdir().unwrap();
     let json_path = dir.path().join("data.json");
-    std::fs::write(&json_path, r#"[{"id":1}]"#).unwrap();
+    let out_path = dir.path().join("output.parquet");
+    std::fs::write(&json_path, r#"[{"id":1,"name":"Alice"}]"#).unwrap();
 
     dkit()
-        .args(["convert", json_path.to_str().unwrap(), "-f", "parquet"])
+        .args([
+            "convert",
+            json_path.to_str().unwrap(),
+            "-f",
+            "parquet",
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
         .assert()
-        .failure()
-        .stderr(predicate::str::contains("input-only"));
+        .success();
+
+    // The output file should be a valid Parquet file (starts with PAR1)
+    let bytes = std::fs::read(&out_path).unwrap();
+    assert!(
+        bytes.starts_with(b"PAR1"),
+        "Output should be a valid Parquet file"
+    );
 }
 
 // --- null handling ---


### PR DESCRIPTION
## Summary

- `ParquetWriter` 구현: Value 배열 → Arrow RecordBatch → Parquet 파일 변환
- 자동 스키마 추론 (Value 타입 → Arrow DataType: Bool/Int/Float/String)
- 압축 옵션 지원: `--compression none|snappy|gzip|zstd`
- Row Group 크기 설정: `--row-group-size N`
- `dkit convert data.csv -f parquet -o output.parquet` 형태로 사용 가능

## Test plan

- [ ] `dkit convert data.json -f parquet -o out.parquet` 동작 확인
- [ ] `--compression snappy/gzip/zstd` 옵션 동작 확인
- [ ] `--row-group-size` 옵션 동작 확인
- [ ] 기존 Parquet 읽기 테스트 통과 확인
- [ ] 전체 테스트 통과: `cargo test`

Closes #93

https://claude.ai/code/session_018cYgKAaHAzrWTJthFmcQNN