### PR TITLE
feat(query): 집계 함수 구현 (count, sum, avg, min, max, distinct)

### DIFF
--- a/docs/query-syntax.md
+++ b/docs/query-syntax.md
@@ -92,6 +92,61 @@ dkit query data.json '.users[] | limit 10'
 dkit query data.json '.users[] | sort age desc | limit 5'
 ```
 
+## Aggregate Functions
+
+배열 데이터에서 집계 값을 계산한다. 결과는 단일 값으로 반환된다.
+
+### count — 요소 개수
+
+```bash
+# 전체 요소 수
+dkit query data.csv '.[] | count'
+
+# 특정 필드의 비null 요소 수
+dkit query data.csv '.[] | count email'
+```
+
+### sum — 합계
+
+```bash
+dkit query data.csv '.[] | sum price'
+dkit query data.json '.users[] | sum age'
+```
+
+### avg — 평균
+
+```bash
+dkit query data.csv '.[] | avg price'
+dkit query data.json '.users[] | avg score'
+```
+
+### min / max — 최솟값 / 최댓값
+
+숫자 및 문자열 필드 모두 지원한다.
+
+```bash
+dkit query data.csv '.[] | min price'
+dkit query data.csv '.[] | max price'
+dkit query data.json '.users[] | min name'
+dkit query data.json '.users[] | max name'
+```
+
+### distinct — 고유값 목록
+
+```bash
+dkit query data.csv '.[] | distinct category'
+dkit query data.json '.users[] | distinct country'
+```
+
+### 집계 + 필터 조합
+
+```bash
+# 특정 조건 후 집계
+dkit query data.csv '.[] | where region == "KR" | sum revenue'
+dkit query data.json '.users[] | where age > 30 | count'
+dkit query data.json '.users[] | where active == true | avg score'
+```
+
 ## Combined Examples
 
 ```bash
@@ -119,10 +174,17 @@ index_access = "[" INTEGER "]"
 iterate     = "[" "]"
 
 operation   = where_op | select_op | sort_op | limit_op
+            | count_op | sum_op | avg_op | min_op | max_op | distinct_op
 where_op    = "where" condition
 select_op   = "select" IDENTIFIER ( "," IDENTIFIER )*
 sort_op     = "sort" IDENTIFIER [ "desc" ]
 limit_op    = "limit" INTEGER
+count_op    = "count" [ IDENTIFIER ]
+sum_op      = "sum" IDENTIFIER
+avg_op      = "avg" IDENTIFIER
+min_op      = "min" IDENTIFIER
+max_op      = "max" IDENTIFIER
+distinct_op = "distinct" IDENTIFIER
 
 condition   = comparison ( logic_op comparison )*
 comparison  = IDENTIFIER compare_op value

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -156,9 +156,7 @@ fn apply_count(value: Value, field: Option<&str>) -> Result<Value, DkitError> {
                 Some(f) => arr
                     .iter()
                     .filter(|item| match item {
-                        Value::Object(map) => {
-                            map.get(f).is_some_and(|v| !matches!(v, Value::Null))
-                        }
+                        Value::Object(map) => map.get(f).is_some_and(|v| !matches!(v, Value::Null)),
                         _ => false,
                     })
                     .count() as i64,

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -18,6 +18,12 @@ fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitErr
         Operation::Select(fields) => apply_select(value, fields),
         Operation::Sort { field, descending } => apply_sort(value, field, *descending),
         Operation::Limit(n) => apply_limit(value, *n),
+        Operation::Count { field } => apply_count(value, field.as_deref()),
+        Operation::Sum { field } => apply_sum(value, field),
+        Operation::Avg { field } => apply_avg(value, field),
+        Operation::Min { field } => apply_min(value, field),
+        Operation::Max { field } => apply_max(value, field),
+        Operation::Distinct { field } => apply_distinct(value, field),
     }
 }
 
@@ -135,6 +141,246 @@ fn apply_limit(value: Value, n: usize) -> Result<Value, DkitError> {
         }
         _ => Err(DkitError::QueryError(
             "limit clause requires an array input".to_string(),
+        )),
+    }
+}
+
+// --- 집계 함수 ---
+
+/// count: 배열의 전체 요소 수 또는 특정 필드의 비null 요소 수를 반환
+fn apply_count(value: Value, field: Option<&str>) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let count = match field {
+                None => arr.len() as i64,
+                Some(f) => arr
+                    .iter()
+                    .filter(|item| match item {
+                        Value::Object(map) => {
+                            map.get(f).is_some_and(|v| !matches!(v, Value::Null))
+                        }
+                        _ => false,
+                    })
+                    .count() as i64,
+            };
+            Ok(Value::Integer(count))
+        }
+        _ => Err(DkitError::QueryError(
+            "count requires an array input".to_string(),
+        )),
+    }
+}
+
+/// sum: 배열에서 지정된 숫자 필드의 합계를 반환
+fn apply_sum(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut sum_int: i64 = 0;
+            let mut sum_float: f64 = 0.0;
+            let mut has_float = false;
+
+            for item in &arr {
+                match item {
+                    Value::Object(map) => match map.get(field) {
+                        Some(Value::Integer(n)) => {
+                            if has_float {
+                                sum_float += *n as f64;
+                            } else {
+                                sum_int = sum_int.saturating_add(*n);
+                            }
+                        }
+                        Some(Value::Float(f)) => {
+                            if !has_float {
+                                sum_float = sum_int as f64;
+                                has_float = true;
+                            }
+                            sum_float += f;
+                        }
+                        Some(Value::Null) | None => {}
+                        Some(v) => {
+                            return Err(DkitError::QueryError(format!(
+                                "sum: field '{}' is not numeric (got {})",
+                                field, v
+                            )));
+                        }
+                    },
+                    _ => {
+                        return Err(DkitError::QueryError(
+                            "sum requires an array of objects".to_string(),
+                        ));
+                    }
+                }
+            }
+            if has_float {
+                Ok(Value::Float(sum_float))
+            } else {
+                Ok(Value::Integer(sum_int))
+            }
+        }
+        _ => Err(DkitError::QueryError(
+            "sum requires an array input".to_string(),
+        )),
+    }
+}
+
+/// avg: 배열에서 지정된 숫자 필드의 평균을 반환
+fn apply_avg(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut sum: f64 = 0.0;
+            let mut count: usize = 0;
+
+            for item in &arr {
+                match item {
+                    Value::Object(map) => match map.get(field) {
+                        Some(Value::Integer(n)) => {
+                            sum += *n as f64;
+                            count += 1;
+                        }
+                        Some(Value::Float(f)) => {
+                            sum += f;
+                            count += 1;
+                        }
+                        Some(Value::Null) | None => {}
+                        Some(v) => {
+                            return Err(DkitError::QueryError(format!(
+                                "avg: field '{}' is not numeric (got {})",
+                                field, v
+                            )));
+                        }
+                    },
+                    _ => {
+                        return Err(DkitError::QueryError(
+                            "avg requires an array of objects".to_string(),
+                        ));
+                    }
+                }
+            }
+            if count == 0 {
+                Ok(Value::Null)
+            } else {
+                Ok(Value::Float(sum / count as f64))
+            }
+        }
+        _ => Err(DkitError::QueryError(
+            "avg requires an array input".to_string(),
+        )),
+    }
+}
+
+/// min: 배열에서 지정된 필드의 최솟값을 반환
+fn apply_min(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut min_val: Option<Value> = None;
+
+            for item in &arr {
+                match item {
+                    Value::Object(map) => {
+                        if let Some(v) = map.get(field) {
+                            if matches!(v, Value::Null) {
+                                continue;
+                            }
+                            min_val = Some(match &min_val {
+                                None => v.clone(),
+                                Some(current) => {
+                                    if compare_value_ordering(v, current)
+                                        == std::cmp::Ordering::Less
+                                    {
+                                        v.clone()
+                                    } else {
+                                        current.clone()
+                                    }
+                                }
+                            });
+                        }
+                    }
+                    _ => {
+                        return Err(DkitError::QueryError(
+                            "min requires an array of objects".to_string(),
+                        ));
+                    }
+                }
+            }
+            Ok(min_val.unwrap_or(Value::Null))
+        }
+        _ => Err(DkitError::QueryError(
+            "min requires an array input".to_string(),
+        )),
+    }
+}
+
+/// max: 배열에서 지정된 필드의 최댓값을 반환
+fn apply_max(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut max_val: Option<Value> = None;
+
+            for item in &arr {
+                match item {
+                    Value::Object(map) => {
+                        if let Some(v) = map.get(field) {
+                            if matches!(v, Value::Null) {
+                                continue;
+                            }
+                            max_val = Some(match &max_val {
+                                None => v.clone(),
+                                Some(current) => {
+                                    if compare_value_ordering(v, current)
+                                        == std::cmp::Ordering::Greater
+                                    {
+                                        v.clone()
+                                    } else {
+                                        current.clone()
+                                    }
+                                }
+                            });
+                        }
+                    }
+                    _ => {
+                        return Err(DkitError::QueryError(
+                            "max requires an array of objects".to_string(),
+                        ));
+                    }
+                }
+            }
+            Ok(max_val.unwrap_or(Value::Null))
+        }
+        _ => Err(DkitError::QueryError(
+            "max requires an array input".to_string(),
+        )),
+    }
+}
+
+/// distinct: 배열에서 지정된 필드의 고유값 목록을 반환
+fn apply_distinct(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut seen: Vec<Value> = Vec::new();
+
+            for item in &arr {
+                match item {
+                    Value::Object(map) => {
+                        if let Some(v) = map.get(field) {
+                            if matches!(v, Value::Null) {
+                                continue;
+                            }
+                            if !seen.contains(v) {
+                                seen.push(v.clone());
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(DkitError::QueryError(
+                            "distinct requires an array of objects".to_string(),
+                        ));
+                    }
+                }
+            }
+            Ok(Value::Array(seen))
+        }
+        _ => Err(DkitError::QueryError(
+            "distinct requires an array input".to_string(),
         )),
     }
 }
@@ -1099,5 +1345,166 @@ mod tests {
             arr[1].as_object().unwrap().get("name"),
             Some(&Value::String("Charlie".to_string()))
         );
+    }
+
+    // --- 집계 함수 테스트 ---
+
+    #[test]
+    fn test_count_all() {
+        let data = sample_users();
+        let query = parse_query(".[] | count").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Integer(3));
+    }
+
+    #[test]
+    fn test_count_field() {
+        // name 필드가 있는 요소 수 (모두 있음)
+        let data = sample_users();
+        let query = parse_query(".[] | count name").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Integer(3));
+    }
+
+    #[test]
+    fn test_count_field_with_nulls() {
+        // null이 포함된 경우
+        let arr = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("email".to_string(), Value::String("a@b.com".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("email".to_string(), Value::Null);
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("email".to_string(), Value::String("c@d.com".to_string()));
+                Value::Object(m)
+            },
+        ]);
+        let query = parse_query(".[] | count email").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&arr, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Integer(2));
+    }
+
+    #[test]
+    fn test_sum_integer() {
+        let data = sample_users();
+        let query = parse_query(".[] | sum age").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Integer(90)); // 30+25+35
+    }
+
+    #[test]
+    fn test_sum_float() {
+        let arr = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("price".to_string(), Value::Float(1.5));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("price".to_string(), Value::Float(2.5));
+                Value::Object(m)
+            },
+        ]);
+        let query = parse_query(".[] | sum price").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&arr, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Float(4.0));
+    }
+
+    #[test]
+    fn test_avg_integer() {
+        let data = sample_users();
+        let query = parse_query(".[] | avg age").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Float(30.0)); // (30+25+35)/3
+    }
+
+    #[test]
+    fn test_avg_empty() {
+        let arr = Value::Array(vec![]);
+        let result = apply_avg(arr, "age").unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_min_integer() {
+        let data = sample_users();
+        let query = parse_query(".[] | min age").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Integer(25));
+    }
+
+    #[test]
+    fn test_max_integer() {
+        let data = sample_users();
+        let query = parse_query(".[] | max age").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Integer(35));
+    }
+
+    #[test]
+    fn test_min_string() {
+        let data = sample_users();
+        let result = apply_min(data, "name").unwrap();
+        assert_eq!(result, Value::String("Alice".to_string()));
+    }
+
+    #[test]
+    fn test_max_string() {
+        let data = sample_users();
+        let result = apply_max(data, "name").unwrap();
+        assert_eq!(result, Value::String("Charlie".to_string()));
+    }
+
+    #[test]
+    fn test_min_empty() {
+        let arr = Value::Array(vec![]);
+        let result = apply_min(arr, "age").unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_distinct() {
+        let data = sample_users();
+        let query = parse_query(".[] | distinct city").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert!(arr.contains(&Value::String("Seoul".to_string())));
+        assert!(arr.contains(&Value::String("Busan".to_string())));
+    }
+
+    #[test]
+    fn test_count_after_filter() {
+        let data = sample_users();
+        let query = parse_query(".[] | where age > 28 | count").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Integer(2)); // Alice(30), Charlie(35)
+    }
+
+    #[test]
+    fn test_sum_after_filter() {
+        let data = sample_users();
+        let query = parse_query(".[] | where age > 28 | sum age").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::Integer(65)); // 30+35
     }
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -37,6 +37,18 @@ pub enum Operation {
     Sort { field: String, descending: bool },
     /// `limit` 결과 제한: `limit 10`
     Limit(usize),
+    /// `count` 전체 카운트 / `count field` 비null 카운트
+    Count { field: Option<String> },
+    /// `sum field` 숫자 필드 합계
+    Sum { field: String },
+    /// `avg field` 숫자 필드 평균
+    Avg { field: String },
+    /// `min field` 최솟값
+    Min { field: String },
+    /// `max field` 최댓값
+    Max { field: String },
+    /// `distinct field` 고유값 목록
+    Distinct { field: String },
 }
 
 /// 조건식 (where 절)
@@ -259,6 +271,36 @@ impl Parser {
                 self.skip_whitespace();
                 let n = self.parse_positive_integer()?;
                 Ok(Operation::Limit(n))
+            }
+            "count" => {
+                self.skip_whitespace();
+                let field = self.try_parse_identifier();
+                Ok(Operation::Count { field })
+            }
+            "sum" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Sum { field })
+            }
+            "avg" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Avg { field })
+            }
+            "min" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Min { field })
+            }
+            "max" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Max { field })
+            }
+            "distinct" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Distinct { field })
             }
             _ => Err(DkitError::QueryError(format!(
                 "unknown operation '{}' at position {}",
@@ -569,6 +611,21 @@ impl Parser {
 
     fn is_at_end(&self) -> bool {
         self.pos >= self.input.len()
+    }
+
+    /// 식별자를 시도적으로 파싱: 식별자가 없으면 None 반환 (위치 복원)
+    fn try_parse_identifier(&mut self) -> Option<String> {
+        if !self.peek_is_identifier_start() {
+            return None;
+        }
+        let saved_pos = self.pos;
+        match self.parse_identifier() {
+            Ok(id) => Some(id),
+            Err(_) => {
+                self.pos = saved_pos;
+                None
+            }
+        }
     }
 
     /// 키워드를 시도적으로 소비: 매치하면 true, 아니면 위치를 복원하고 false


### PR DESCRIPTION
## Summary

- 쿼리 파이프라인에 6가지 집계 연산 추가
- `count` / `count field`: 전체 요소 수 또는 비null 필드 카운트
- `sum field`: 숫자 필드 합계 (정수/부동소수점 모두 지원)
- `avg field`: 숫자 필드 평균 (빈 배열이면 null 반환)
- `min field` / `max field`: 숫자 및 문자열 최솟값/최댓값
- `distinct field`: 필드 고유값 목록 반환

## 사용 예시

```bash
dkit query data.csv '.[] | count'
dkit query data.csv '.[] | count email'
dkit query data.csv '.[] | sum price'
dkit query data.csv '.[] | avg score'
dkit query data.csv '.[] | min age'
dkit query data.csv '.[] | max age'
dkit query data.csv '.[] | distinct category'

# 필터와 조합
dkit query data.csv '.[] | where region == "KR" | sum revenue'
dkit query data.json '.users[] | where age > 30 | count'
```

## Test plan

- [x] `cargo test` — 신규 집계 함수 단위 테스트 포함 전체 통과
- [x] `cargo clippy -- -D warnings` — 경고 없음
- [x] `docs/query-syntax.md` 집계 문법 섹션 및 EBNF 업데이트

Closes #94

https://claude.ai/code/session_01QAryg1yiQeBqv6GTGSU1i8