### PR TITLE
feat(query): GROUP BY 절 구현 - 그룹별 집계 지원

### DIFF
--- a/docs/query-syntax.md
+++ b/docs/query-syntax.md
@@ -147,6 +147,67 @@ dkit query data.json '.users[] | where age > 30 | count'
 dkit query data.json '.users[] | where active == true | avg score'
 ```
 
+## group_by — Grouping and Aggregation
+
+배열 데이터를 지정된 필드 기준으로 그룹화하고, 각 그룹에 대해 집계를 수행한다.
+
+### 기본 사용법
+
+```bash
+# 단일 필드 그룹화 (기본: count 포함)
+dkit query data.csv '.[] | group_by category'
+
+# 다중 필드 그룹화
+dkit query data.csv '.[] | group_by region, category'
+```
+
+### 집계 함수 조합
+
+`group_by` 뒤에 집계 함수를 지정한다. 함수 형식: `func()` 또는 `func(field)`.
+
+```bash
+# 카테고리별 개수, 합계, 평균
+dkit query data.csv '.[] | group_by category count(), sum(price), avg(price)'
+
+# 지역별 최솟값, 최댓값
+dkit query data.csv '.[] | group_by region min(price), max(price)'
+```
+
+지원되는 집계 함수:
+
+| 함수 | 설명 | 예시 |
+|------|------|------|
+| `count()` | 그룹 내 요소 수 | `count()` |
+| `count(field)` | 비null 필드 수 | `count(email)` |
+| `sum(field)` | 숫자 필드 합계 | `sum(price)` |
+| `avg(field)` | 숫자 필드 평균 | `avg(score)` |
+| `min(field)` | 최솟값 | `min(price)` |
+| `max(field)` | 최댓값 | `max(price)` |
+
+### HAVING — 그룹 필터링
+
+집계 결과를 기준으로 그룹을 필터링한다.
+
+```bash
+# 2개 이상인 그룹만 표시
+dkit query data.csv '.[] | group_by category count() having count > 1'
+
+# 평균 가격이 100 이상인 그룹만
+dkit query data.csv '.[] | group_by category count(), avg(price) having avg_price >= 100'
+```
+
+### 후속 파이프라인 조합
+
+GROUP BY 결과에 sort, limit 등을 추가로 적용할 수 있다.
+
+```bash
+# 카테고리별 개수를 내림차순 정렬, 상위 5개
+dkit query data.csv '.[] | group_by category count() | sort count desc | limit 5'
+
+# 그룹 결과에서 특정 필드만 선택
+dkit query data.csv '.[] | group_by category count(), sum(price) | select category, count'
+```
+
 ## Combined Examples
 
 ```bash
@@ -175,6 +236,7 @@ iterate     = "[" "]"
 
 operation   = where_op | select_op | sort_op | limit_op
             | count_op | sum_op | avg_op | min_op | max_op | distinct_op
+            | group_by_op
 where_op    = "where" condition
 select_op   = "select" IDENTIFIER ( "," IDENTIFIER )*
 sort_op     = "sort" IDENTIFIER [ "desc" ]
@@ -185,6 +247,9 @@ avg_op      = "avg" IDENTIFIER
 min_op      = "min" IDENTIFIER
 max_op      = "max" IDENTIFIER
 distinct_op = "distinct" IDENTIFIER
+group_by_op = "group_by" IDENTIFIER ( "," IDENTIFIER )* aggregate* [ "having" condition ]
+aggregate   = agg_func "(" [ IDENTIFIER ] ")"
+agg_func    = "count" | "sum" | "avg" | "min" | "max"
 
 condition   = comparison ( logic_op comparison )*
 comparison  = IDENTIFIER compare_op value

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -1,6 +1,9 @@
 use crate::error::DkitError;
-use crate::query::parser::{CompareOp, Comparison, Condition, LiteralValue, Operation};
+use crate::query::parser::{
+    AggregateFunc, CompareOp, Comparison, Condition, GroupAggregate, LiteralValue, Operation,
+};
 use crate::value::Value;
+use indexmap::IndexMap;
 
 /// 연산 목록을 순차적으로 적용
 pub fn apply_operations(value: Value, operations: &[Operation]) -> Result<Value, DkitError> {
@@ -24,6 +27,11 @@ fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitErr
         Operation::Min { field } => apply_min(value, field),
         Operation::Max { field } => apply_max(value, field),
         Operation::Distinct { field } => apply_distinct(value, field),
+        Operation::GroupBy {
+            fields,
+            having,
+            aggregates,
+        } => apply_group_by(value, fields, having.as_ref(), aggregates),
     }
 }
 
@@ -380,6 +388,230 @@ fn apply_distinct(value: Value, field: &str) -> Result<Value, DkitError> {
         _ => Err(DkitError::QueryError(
             "distinct requires an array input".to_string(),
         )),
+    }
+}
+
+/// group_by: 배열을 지정된 필드 기준으로 그룹화하고 집계
+fn apply_group_by(
+    value: Value,
+    fields: &[String],
+    having: Option<&Condition>,
+    aggregates: &[GroupAggregate],
+) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            // Group items by key fields
+            let mut groups: Vec<(IndexMap<String, Value>, Vec<Value>)> = Vec::new();
+
+            for item in arr {
+                let key = extract_group_key(&item, fields);
+                if let Some(pos) = groups.iter().position(|(k, _)| *k == key) {
+                    groups[pos].1.push(item);
+                } else {
+                    groups.push((key, vec![item]));
+                }
+            }
+
+            // Build result objects for each group
+            let mut results = Vec::new();
+            for (key, group_items) in groups {
+                let mut obj = IndexMap::new();
+
+                // Add group key fields
+                for (field_name, field_value) in &key {
+                    obj.insert(field_name.clone(), field_value.clone());
+                }
+
+                // If no explicit aggregates, add default count
+                if aggregates.is_empty() {
+                    obj.insert(
+                        "count".to_string(),
+                        Value::Integer(group_items.len() as i64),
+                    );
+                } else {
+                    // Compute each aggregate
+                    for agg in aggregates {
+                        let agg_value =
+                            compute_group_aggregate(&agg.func, agg.field.as_deref(), &group_items)?;
+                        obj.insert(agg.alias.clone(), agg_value);
+                    }
+                }
+
+                let result_obj = Value::Object(obj);
+
+                // Apply HAVING filter
+                if let Some(having_cond) = having {
+                    if !evaluate_condition(&result_obj, having_cond).unwrap_or(false) {
+                        continue;
+                    }
+                }
+
+                results.push(result_obj);
+            }
+
+            Ok(Value::Array(results))
+        }
+        _ => Err(DkitError::QueryError(
+            "group_by requires an array input".to_string(),
+        )),
+    }
+}
+
+/// 그룹 키 추출: 지정된 필드들의 값을 IndexMap으로 반환
+fn extract_group_key(value: &Value, fields: &[String]) -> IndexMap<String, Value> {
+    let mut key = IndexMap::new();
+    if let Value::Object(map) = value {
+        for field in fields {
+            let v = map.get(field).cloned().unwrap_or(Value::Null);
+            key.insert(field.clone(), v);
+        }
+    } else {
+        for field in fields {
+            key.insert(field.clone(), Value::Null);
+        }
+    }
+    key
+}
+
+/// 그룹 내 집계 함수 계산
+fn compute_group_aggregate(
+    func: &AggregateFunc,
+    field: Option<&str>,
+    items: &[Value],
+) -> Result<Value, DkitError> {
+    match func {
+        AggregateFunc::Count => {
+            let count = match field {
+                None => items.len() as i64,
+                Some(f) => items
+                    .iter()
+                    .filter(|item| match item {
+                        Value::Object(map) => map.get(f).is_some_and(|v| !matches!(v, Value::Null)),
+                        _ => false,
+                    })
+                    .count() as i64,
+            };
+            Ok(Value::Integer(count))
+        }
+        AggregateFunc::Sum => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("sum() requires a field argument".to_string())
+            })?;
+            let mut sum_int: i64 = 0;
+            let mut sum_float: f64 = 0.0;
+            let mut has_float = false;
+
+            for item in items {
+                if let Value::Object(map) = item {
+                    match map.get(f) {
+                        Some(Value::Integer(n)) => {
+                            if has_float {
+                                sum_float += *n as f64;
+                            } else {
+                                sum_int = sum_int.saturating_add(*n);
+                            }
+                        }
+                        Some(Value::Float(fv)) => {
+                            if !has_float {
+                                sum_float = sum_int as f64;
+                                has_float = true;
+                            }
+                            sum_float += fv;
+                        }
+                        Some(Value::Null) | None => {}
+                        _ => {}
+                    }
+                }
+            }
+            if has_float {
+                Ok(Value::Float(sum_float))
+            } else {
+                Ok(Value::Integer(sum_int))
+            }
+        }
+        AggregateFunc::Avg => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("avg() requires a field argument".to_string())
+            })?;
+            let mut sum: f64 = 0.0;
+            let mut count: usize = 0;
+
+            for item in items {
+                if let Value::Object(map) = item {
+                    match map.get(f) {
+                        Some(Value::Integer(n)) => {
+                            sum += *n as f64;
+                            count += 1;
+                        }
+                        Some(Value::Float(fv)) => {
+                            sum += fv;
+                            count += 1;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if count == 0 {
+                Ok(Value::Null)
+            } else {
+                Ok(Value::Float(sum / count as f64))
+            }
+        }
+        AggregateFunc::Min => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("min() requires a field argument".to_string())
+            })?;
+            let mut min_val: Option<Value> = None;
+
+            for item in items {
+                if let Value::Object(map) = item {
+                    if let Some(v) = map.get(f) {
+                        if matches!(v, Value::Null) {
+                            continue;
+                        }
+                        min_val = Some(match &min_val {
+                            None => v.clone(),
+                            Some(current) => {
+                                if compare_value_ordering(v, current) == std::cmp::Ordering::Less {
+                                    v.clone()
+                                } else {
+                                    current.clone()
+                                }
+                            }
+                        });
+                    }
+                }
+            }
+            Ok(min_val.unwrap_or(Value::Null))
+        }
+        AggregateFunc::Max => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("max() requires a field argument".to_string())
+            })?;
+            let mut max_val: Option<Value> = None;
+
+            for item in items {
+                if let Value::Object(map) = item {
+                    if let Some(v) = map.get(f) {
+                        if matches!(v, Value::Null) {
+                            continue;
+                        }
+                        max_val = Some(match &max_val {
+                            None => v.clone(),
+                            Some(current) => {
+                                if compare_value_ordering(v, current) == std::cmp::Ordering::Greater
+                                {
+                                    v.clone()
+                                } else {
+                                    current.clone()
+                                }
+                            }
+                        });
+                    }
+                }
+            }
+            Ok(max_val.unwrap_or(Value::Null))
+        }
     }
 }
 
@@ -1504,5 +1736,237 @@ mod tests {
         let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
         let result = apply_operations(path_result, &query.operations).unwrap();
         assert_eq!(result, Value::Integer(65)); // 30+35
+    }
+
+    // --- GROUP BY tests ---
+
+    fn sample_sales() -> Value {
+        Value::Array(vec![
+            Value::Object(indexmap::indexmap! {
+                "category".to_string() => Value::String("electronics".to_string()),
+                "product".to_string() => Value::String("phone".to_string()),
+                "price".to_string() => Value::Integer(1000),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "category".to_string() => Value::String("electronics".to_string()),
+                "product".to_string() => Value::String("laptop".to_string()),
+                "price".to_string() => Value::Integer(2000),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "category".to_string() => Value::String("clothing".to_string()),
+                "product".to_string() => Value::String("shirt".to_string()),
+                "price".to_string() => Value::Integer(50),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "category".to_string() => Value::String("clothing".to_string()),
+                "product".to_string() => Value::String("pants".to_string()),
+                "price".to_string() => Value::Integer(80),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "category".to_string() => Value::String("food".to_string()),
+                "product".to_string() => Value::String("apple".to_string()),
+                "price".to_string() => Value::Integer(5),
+            }),
+        ])
+    }
+
+    #[test]
+    fn test_group_by_basic() {
+        let data = sample_sales();
+        let query = parse_query(".[] | group_by category").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+
+        if let Value::Array(arr) = &result {
+            assert_eq!(arr.len(), 3);
+            // Default count aggregate
+            if let Value::Object(map) = &arr[0] {
+                assert_eq!(
+                    map.get("category"),
+                    Some(&Value::String("electronics".to_string()))
+                );
+                assert_eq!(map.get("count"), Some(&Value::Integer(2)));
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_group_by_with_aggregates() {
+        let data = sample_sales();
+        let query = parse_query(".[] | group_by category count(), sum(price), avg(price)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+
+        if let Value::Array(arr) = &result {
+            assert_eq!(arr.len(), 3);
+            // electronics: count=2, sum=3000, avg=1500.0
+            if let Value::Object(map) = &arr[0] {
+                assert_eq!(map.get("count"), Some(&Value::Integer(2)));
+                assert_eq!(map.get("sum_price"), Some(&Value::Integer(3000)));
+                assert_eq!(map.get("avg_price"), Some(&Value::Float(1500.0)));
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_group_by_having() {
+        let data = sample_sales();
+        let query = parse_query(".[] | group_by category count() having count > 1").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+
+        if let Value::Array(arr) = &result {
+            assert_eq!(arr.len(), 2); // electronics(2) and clothing(2), food(1) filtered out
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_group_by_multiple_keys() {
+        let data = Value::Array(vec![
+            Value::Object(indexmap::indexmap! {
+                "region".to_string() => Value::String("east".to_string()),
+                "category".to_string() => Value::String("A".to_string()),
+                "amount".to_string() => Value::Integer(100),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "region".to_string() => Value::String("east".to_string()),
+                "category".to_string() => Value::String("A".to_string()),
+                "amount".to_string() => Value::Integer(200),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "region".to_string() => Value::String("east".to_string()),
+                "category".to_string() => Value::String("B".to_string()),
+                "amount".to_string() => Value::Integer(150),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "region".to_string() => Value::String("west".to_string()),
+                "category".to_string() => Value::String("A".to_string()),
+                "amount".to_string() => Value::Integer(300),
+            }),
+        ]);
+
+        let query = parse_query(".[] | group_by region, category count(), sum(amount)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+
+        if let Value::Array(arr) = &result {
+            assert_eq!(arr.len(), 3); // east-A, east-B, west-A
+            if let Value::Object(map) = &arr[0] {
+                assert_eq!(map.get("region"), Some(&Value::String("east".to_string())));
+                assert_eq!(map.get("category"), Some(&Value::String("A".to_string())));
+                assert_eq!(map.get("count"), Some(&Value::Integer(2)));
+                assert_eq!(map.get("sum_amount"), Some(&Value::Integer(300)));
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_group_by_min_max() {
+        let data = sample_sales();
+        let query = parse_query(".[] | group_by category min(price), max(price)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+
+        if let Value::Array(arr) = &result {
+            // electronics: min=1000, max=2000
+            if let Value::Object(map) = &arr[0] {
+                assert_eq!(map.get("min_price"), Some(&Value::Integer(1000)));
+                assert_eq!(map.get("max_price"), Some(&Value::Integer(2000)));
+            } else {
+                panic!("expected object");
+            }
+            // clothing: min=50, max=80
+            if let Value::Object(map) = &arr[1] {
+                assert_eq!(map.get("min_price"), Some(&Value::Integer(50)));
+                assert_eq!(map.get("max_price"), Some(&Value::Integer(80)));
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_group_by_empty_array() {
+        let data = Value::Array(vec![]);
+        let query = parse_query(".[] | group_by category").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+
+        assert_eq!(result, Value::Array(vec![]));
+    }
+
+    #[test]
+    fn test_group_by_non_array_error() {
+        let data = Value::Object(indexmap::indexmap! {
+            "name".to_string() => Value::String("test".to_string()),
+        });
+        let result = apply_group_by(data, &["name".to_string()], None, &[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_group_by_with_sort() {
+        let data = sample_sales();
+        let query = parse_query(".[] | group_by category count() | sort count desc").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+
+        if let Value::Array(arr) = &result {
+            // electronics(2), clothing(2) come first, food(1) last
+            if let Value::Object(map) = &arr[2] {
+                assert_eq!(map.get("count"), Some(&Value::Integer(1)));
+                assert_eq!(
+                    map.get("category"),
+                    Some(&Value::String("food".to_string()))
+                );
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_group_by_with_null_keys() {
+        let data = Value::Array(vec![
+            Value::Object(indexmap::indexmap! {
+                "category".to_string() => Value::String("A".to_string()),
+                "val".to_string() => Value::Integer(1),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "category".to_string() => Value::Null,
+                "val".to_string() => Value::Integer(2),
+            }),
+            Value::Object(indexmap::indexmap! {
+                "val".to_string() => Value::Integer(3),
+            }),
+        ]);
+
+        let query = parse_query(".[] | group_by category count()").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+
+        if let Value::Array(arr) = &result {
+            assert_eq!(arr.len(), 2); // "A" group and null group (null + missing)
+        } else {
+            panic!("expected array");
+        }
     }
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -49,6 +49,31 @@ pub enum Operation {
     Max { field: String },
     /// `distinct field` 고유값 목록
     Distinct { field: String },
+    /// `group_by field1, field2` 그룹별 집계
+    /// 집계 연산: `group_by category | select category, count, sum_price`
+    GroupBy {
+        fields: Vec<String>,
+        having: Option<Condition>,
+        aggregates: Vec<GroupAggregate>,
+    },
+}
+
+/// GROUP BY 집계 연산 정의
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupAggregate {
+    pub func: AggregateFunc,
+    pub field: Option<String>,
+    pub alias: String,
+}
+
+/// 집계 함수 종류
+#[derive(Debug, Clone, PartialEq)]
+pub enum AggregateFunc {
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
 }
 
 /// 조건식 (where 절)
@@ -302,12 +327,118 @@ impl Parser {
                 let field = self.parse_identifier()?;
                 Ok(Operation::Distinct { field })
             }
+            "group_by" => {
+                self.skip_whitespace();
+                let fields = self.parse_identifier_list()?;
+                self.skip_whitespace();
+
+                // Parse optional aggregate functions
+                let aggregates = self.parse_group_aggregates()?;
+
+                // Parse optional HAVING clause
+                let having = if self.try_consume_keyword("having") {
+                    self.skip_whitespace();
+                    Some(self.parse_condition()?)
+                } else {
+                    None
+                };
+
+                Ok(Operation::GroupBy {
+                    fields,
+                    having,
+                    aggregates,
+                })
+            }
             _ => Err(DkitError::QueryError(format!(
                 "unknown operation '{}' at position {}",
                 keyword,
                 self.pos - keyword.len()
             ))),
         }
+    }
+
+    /// GROUP BY 집계 함수 목록 파싱: `count(), sum(field), avg(field), ...`
+    fn parse_group_aggregates(&mut self) -> Result<Vec<GroupAggregate>, DkitError> {
+        let mut aggregates = Vec::new();
+
+        loop {
+            let saved_pos = self.pos;
+            if let Some(agg) = self.try_parse_single_aggregate()? {
+                aggregates.push(agg);
+                self.skip_whitespace();
+                if !self.consume_char(',') {
+                    // No comma, check if next is "having" or end
+                    break;
+                }
+                self.skip_whitespace();
+            } else {
+                self.pos = saved_pos;
+                break;
+            }
+        }
+
+        Ok(aggregates)
+    }
+
+    /// 단일 집계 함수 파싱: `count()`, `sum(field)`, `avg(field)` 등
+    fn try_parse_single_aggregate(&mut self) -> Result<Option<GroupAggregate>, DkitError> {
+        let saved_pos = self.pos;
+
+        // Try to read a keyword
+        let func_name = match self.parse_keyword() {
+            Ok(name) => name,
+            Err(_) => {
+                self.pos = saved_pos;
+                return Ok(None);
+            }
+        };
+
+        let func = match func_name.as_str() {
+            "count" => AggregateFunc::Count,
+            "sum" => AggregateFunc::Sum,
+            "avg" => AggregateFunc::Avg,
+            "min" => AggregateFunc::Min,
+            "max" => AggregateFunc::Max,
+            _ => {
+                // Not an aggregate function, restore position
+                self.pos = saved_pos;
+                return Ok(None);
+            }
+        };
+
+        self.skip_whitespace();
+
+        // Must have '('
+        if !self.consume_char('(') {
+            self.pos = saved_pos;
+            return Ok(None);
+        }
+
+        self.skip_whitespace();
+
+        // Parse optional field name
+        let field = if self.peek() == Some(')') {
+            None
+        } else {
+            Some(self.parse_identifier()?)
+        };
+
+        self.skip_whitespace();
+
+        if !self.consume_char(')') {
+            return Err(DkitError::QueryError(format!(
+                "expected ')' at position {}",
+                self.pos
+            )));
+        }
+
+        // Generate alias
+        let alias = match &field {
+            Some(f) => format!("{}_{}", func_name, f),
+            None => func_name.clone(),
+        };
+
+        Ok(Some(GroupAggregate { func, field, alias }))
     }
 
     /// 쉼표로 구분된 식별자 목록 파싱: `IDENTIFIER ( "," IDENTIFIER )*`
@@ -1387,5 +1518,99 @@ mod tests {
                 descending: false,
             }
         );
+    }
+
+    #[test]
+    fn test_group_by_single_field() {
+        let q = parse_query(".[] | group_by category").unwrap();
+        assert_eq!(q.operations.len(), 1);
+        match &q.operations[0] {
+            Operation::GroupBy {
+                fields,
+                having,
+                aggregates,
+            } => {
+                assert_eq!(fields, &vec!["category".to_string()]);
+                assert!(having.is_none());
+                assert!(aggregates.is_empty());
+            }
+            _ => panic!("expected GroupBy"),
+        }
+    }
+
+    #[test]
+    fn test_group_by_multiple_fields() {
+        let q = parse_query(".[] | group_by region, category").unwrap();
+        match &q.operations[0] {
+            Operation::GroupBy { fields, .. } => {
+                assert_eq!(fields, &vec!["region".to_string(), "category".to_string()]);
+            }
+            _ => panic!("expected GroupBy"),
+        }
+    }
+
+    #[test]
+    fn test_group_by_with_aggregates() {
+        let q = parse_query(".[] | group_by category count(), sum(price), avg(score)").unwrap();
+        match &q.operations[0] {
+            Operation::GroupBy { aggregates, .. } => {
+                assert_eq!(aggregates.len(), 3);
+                assert_eq!(aggregates[0].func, AggregateFunc::Count);
+                assert_eq!(aggregates[0].field, None);
+                assert_eq!(aggregates[0].alias, "count");
+                assert_eq!(aggregates[1].func, AggregateFunc::Sum);
+                assert_eq!(aggregates[1].field, Some("price".to_string()));
+                assert_eq!(aggregates[1].alias, "sum_price");
+                assert_eq!(aggregates[2].func, AggregateFunc::Avg);
+                assert_eq!(aggregates[2].field, Some("score".to_string()));
+                assert_eq!(aggregates[2].alias, "avg_score");
+            }
+            _ => panic!("expected GroupBy"),
+        }
+    }
+
+    #[test]
+    fn test_group_by_with_having() {
+        let q = parse_query(".[] | group_by category count() having count > 5").unwrap();
+        match &q.operations[0] {
+            Operation::GroupBy {
+                fields,
+                having,
+                aggregates,
+            } => {
+                assert_eq!(fields, &vec!["category".to_string()]);
+                assert!(having.is_some());
+                assert_eq!(aggregates.len(), 1);
+            }
+            _ => panic!("expected GroupBy"),
+        }
+    }
+
+    #[test]
+    fn test_group_by_with_min_max() {
+        let q = parse_query(".[] | group_by category min(price), max(price)").unwrap();
+        match &q.operations[0] {
+            Operation::GroupBy { aggregates, .. } => {
+                assert_eq!(aggregates.len(), 2);
+                assert_eq!(aggregates[0].func, AggregateFunc::Min);
+                assert_eq!(aggregates[1].func, AggregateFunc::Max);
+            }
+            _ => panic!("expected GroupBy"),
+        }
+    }
+
+    #[test]
+    fn test_group_by_pipeline() {
+        let q = parse_query(".[] | group_by category count() | sort count desc | limit 5").unwrap();
+        assert_eq!(q.operations.len(), 3);
+        assert!(matches!(&q.operations[0], Operation::GroupBy { .. }));
+        assert!(matches!(
+            &q.operations[1],
+            Operation::Sort {
+                descending: true,
+                ..
+            }
+        ));
+        assert_eq!(q.operations[2], Operation::Limit(5));
     }
 }


### PR DESCRIPTION
## Summary
- 쿼리 엔진에 `group_by` 연산 추가: 단일/다중 필드 기준 그룹화
- 집계 함수 조합 지원: `count()`, `sum(field)`, `avg(field)`, `min(field)`, `max(field)`
- `HAVING` 절로 집계 결과 기반 그룹 필터링
- 후속 파이프라인(`sort`, `limit`, `select`)과의 조합 지원
- 단위 테스트 15개 추가 (파서 6개 + 필터 9개)
- `docs/query-syntax.md` 문서 및 EBNF 문법 업데이트

## 사용 예시
```bash
# 기본 그룹화
dkit query data.csv '.[] | group_by category'

# 집계 함수 조합
dkit query data.csv '.[] | group_by category count(), sum(price), avg(price)'

# HAVING 필터링
dkit query data.csv '.[] | group_by category count() having count > 1'

# 파이프라인 조합
dkit query data.csv '.[] | group_by category count() | sort count desc | limit 5'
```

## Test plan
- [x] 단일 필드 group_by 기본 동작
- [x] 다중 필드 group_by
- [x] 집계 함수 (count, sum, avg, min, max) 조합
- [x] HAVING 절 필터링
- [x] 빈 배열, 비배열 입력 에러 처리
- [x] null 키 값 처리
- [x] 후속 파이프라인 (sort, limit) 조합
- [x] 전체 기존 테스트 통과 확인 (572+ tests)

Closes #95

https://claude.ai/code/session_012H2utgLZUbGNLHii7msoUK