### PR TITLE
feat(query): 쿼리 함수 확장 (문자열, 날짜, 수학 함수, 타입 변환)

### DIFF
--- a/docs/query-syntax.md
+++ b/docs/query-syntax.md
@@ -208,6 +208,95 @@ dkit query data.csv '.[] | group_by category count() | sort count desc | limit 5
 dkit query data.csv '.[] | group_by category count(), sum(price) | select category, count'
 ```
 
+## Built-in Functions
+
+`select` 절에서 내장 함수를 사용하여 데이터를 변환할 수 있다. 함수는 중첩 호출이 가능하다.
+
+```bash
+dkit query data.csv '.[] | select upper(name), round(price, 2)'
+dkit query data.json '.users[] | select upper(trim(name)), to_string(age)'
+```
+
+### 별칭 (as)
+
+`as` 키워드로 출력 필드명을 지정한다.
+
+```bash
+dkit query data.csv '.[] | select upper(name) as NAME, round(price, 2) as price_rounded'
+```
+
+### 문자열 함수
+
+| 함수 | 설명 | 예시 |
+|------|------|------|
+| `upper(s)` | 대문자 변환 | `upper(name)` |
+| `lower(s)` | 소문자 변환 | `lower(email)` |
+| `trim(s)` | 앞뒤 공백 제거 | `trim(name)` |
+| `ltrim(s)` | 앞쪽 공백 제거 | `ltrim(name)` |
+| `rtrim(s)` | 뒤쪽 공백 제거 | `rtrim(name)` |
+| `length(s)` | 문자열 길이 | `length(name)` |
+| `substr(s, start)` | 부분 문자열 (시작 위치~끝) | `substr(name, 2)` |
+| `substr(s, start, len)` | 부분 문자열 (시작 위치, 길이) | `substr(name, 0, 5)` |
+| `concat(a, b, ...)` | 문자열 합치기 | `concat(first, " ", last)` |
+| `replace(s, from, to)` | 문자열 치환 | `replace(name, "old", "new")` |
+| `split(s, sep)` | 문자열 분리 (배열 반환) | `split(tags, ",")` |
+
+### 수학 함수
+
+| 함수 | 설명 | 예시 |
+|------|------|------|
+| `round(n)` | 반올림 (정수 반환) | `round(price)` |
+| `round(n, d)` | d자리까지 반올림 | `round(price, 2)` |
+| `ceil(n)` | 올림 | `ceil(price)` |
+| `floor(n)` | 내림 | `floor(price)` |
+| `abs(n)` | 절댓값 | `abs(diff)` |
+| `sqrt(n)` | 제곱근 | `sqrt(area)` |
+| `pow(base, exp)` | 거듭제곱 | `pow(x, 2)` |
+
+### 날짜 함수
+
+날짜 문자열은 ISO 8601 형식(`yyyy-MM-dd` 또는 `yyyy-MM-ddTHH:mm:ssZ`)을 기대한다.
+
+| 함수 | 설명 | 예시 |
+|------|------|------|
+| `now()` | 현재 UTC 시각 (ISO 8601) | `now()` |
+| `date(s)` | 날짜 정규화 (yyyy-MM-dd) | `date(created_at)` |
+| `year(s)` | 연도 추출 | `year(created_at)` |
+| `month(s)` | 월 추출 (1-12) | `month(created_at)` |
+| `day(s)` | 일 추출 (1-31) | `day(created_at)` |
+
+### 타입 변환
+
+| 함수 | 설명 | 예시 |
+|------|------|------|
+| `to_int(v)` / `int(v)` | 정수 변환 | `to_int(score)` |
+| `to_float(v)` / `float(v)` | 부동소수점 변환 | `to_float(price)` |
+| `to_string(v)` / `str(v)` | 문자열 변환 | `to_string(id)` |
+| `to_bool(v)` / `bool(v)` | 불리언 변환 | `to_bool(active)` |
+
+### 유틸 함수
+
+| 함수 | 설명 | 예시 |
+|------|------|------|
+| `coalesce(a, b, ...)` | 첫 번째 non-null 값 반환 | `coalesce(name, "unknown")` |
+| `if_null(v, default)` | null이면 기본값 반환 | `if_null(email, "N/A")` |
+
+### 함수 조합 예시
+
+```bash
+# 이름 대문자 변환 + 공백 제거
+dkit query data.csv '.[] | select upper(trim(name))'
+
+# 가격 소수점 2자리 반올림, 별칭 사용
+dkit query data.csv '.[] | select name, round(price, 2) as price'
+
+# 날짜에서 연도 추출
+dkit query data.json '.[] | select upper(name), year(created_at) as year'
+
+# 타입 변환 + where 필터 후 함수 적용
+dkit query data.csv '.[] | where score > 80 | select name, to_string(score) as score_str'
+```
+
 ## Combined Examples
 
 ```bash
@@ -238,7 +327,10 @@ operation   = where_op | select_op | sort_op | limit_op
             | count_op | sum_op | avg_op | min_op | max_op | distinct_op
             | group_by_op
 where_op    = "where" condition
-select_op   = "select" IDENTIFIER ( "," IDENTIFIER )*
+select_op   = "select" select_expr ( "," select_expr )*
+select_expr = expr [ "as" IDENTIFIER ]
+expr        = IDENTIFIER | literal | func_call
+func_call   = IDENTIFIER "(" [ expr ( "," expr )* ] ")"
 sort_op     = "sort" IDENTIFIER [ "desc" ]
 limit_op    = "limit" INTEGER
 count_op    = "count" [ IDENTIFIER ]

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -1,6 +1,8 @@
 use crate::error::DkitError;
+use crate::query::functions::{evaluate_expr, expr_default_key};
 use crate::query::parser::{
     AggregateFunc, CompareOp, Comparison, Condition, GroupAggregate, LiteralValue, Operation,
+    SelectExpr,
 };
 use crate::value::Value;
 use indexmap::IndexMap;
@@ -51,17 +53,17 @@ fn apply_where(value: Value, condition: &Condition) -> Result<Value, DkitError> 
     }
 }
 
-/// select 절: 배열의 각 요소에서 지정된 필드만 추출
-fn apply_select(value: Value, fields: &[String]) -> Result<Value, DkitError> {
+/// select 절: 배열의 각 요소에 표현식을 적용하여 새 객체를 생성
+fn apply_select(value: Value, exprs: &[SelectExpr]) -> Result<Value, DkitError> {
     match value {
         Value::Array(arr) => {
-            let projected: Vec<Value> = arr
+            let projected: Result<Vec<Value>, DkitError> = arr
                 .into_iter()
-                .map(|item| select_fields(item, fields))
+                .map(|item| select_exprs(&item, exprs))
                 .collect();
-            Ok(Value::Array(projected))
+            Ok(Value::Array(projected?))
         }
-        Value::Object(_) => Ok(select_fields(value, fields)),
+        Value::Object(_) => select_exprs(&value, exprs),
         _ => Err(DkitError::QueryError(
             "select clause requires an array or object input".to_string(),
         )),
@@ -616,18 +618,29 @@ fn compute_group_aggregate(
 }
 
 /// 오브젝트에서 지정된 필드만 추출
-fn select_fields(value: Value, fields: &[String]) -> Value {
+/// 단일 레코드에 SelectExpr 목록을 적용하여 새 객체를 반환
+fn select_exprs(value: &Value, exprs: &[SelectExpr]) -> Result<Value, DkitError> {
+    use crate::query::parser::Expr;
     match value {
         Value::Object(map) => {
-            let mut new_map = indexmap::IndexMap::new();
-            for field in fields {
-                if let Some(v) = map.get(field) {
-                    new_map.insert(field.clone(), v.clone());
+            let mut new_map = IndexMap::new();
+            for se in exprs {
+                // 단순 필드 참조이고 필드가 없으면 기존 동작대로 스킵
+                if let Expr::Field(fname) = &se.expr {
+                    if se.alias.is_none() && !map.contains_key(fname) {
+                        continue;
+                    }
                 }
+                let val = evaluate_expr(value, &se.expr)?;
+                let key = se
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| expr_default_key(&se.expr));
+                new_map.insert(key, val);
             }
-            Value::Object(new_map)
+            Ok(Value::Object(new_map))
         }
-        _ => value,
+        _ => Ok(value.clone()),
     }
 }
 
@@ -1185,10 +1198,21 @@ mod tests {
 
     // --- select 절 ---
 
+    fn sel_fields(names: &[&str]) -> Vec<SelectExpr> {
+        use crate::query::parser::Expr;
+        names
+            .iter()
+            .map(|n| SelectExpr {
+                expr: Expr::Field(n.to_string()),
+                alias: None,
+            })
+            .collect()
+    }
+
     #[test]
     fn test_select_single_field() {
         let data = sample_users();
-        let result = apply_select(data, &["name".to_string()]).unwrap();
+        let result = apply_select(data, &sel_fields(&["name"])).unwrap();
         let arr = result.as_array().unwrap();
         assert_eq!(arr.len(), 3);
         // 각 요소에 name만 있어야 함
@@ -1202,7 +1226,7 @@ mod tests {
     #[test]
     fn test_select_multiple_fields() {
         let data = sample_users();
-        let result = apply_select(data, &["name".to_string(), "age".to_string()]).unwrap();
+        let result = apply_select(data, &sel_fields(&["name", "age"])).unwrap();
         let arr = result.as_array().unwrap();
         assert_eq!(arr.len(), 3);
         for item in arr {
@@ -1216,7 +1240,7 @@ mod tests {
     #[test]
     fn test_select_preserves_order() {
         let data = sample_users();
-        let result = apply_select(data, &["city".to_string(), "name".to_string()]).unwrap();
+        let result = apply_select(data, &sel_fields(&["city", "name"])).unwrap();
         let arr = result.as_array().unwrap();
         let obj = arr[0].as_object().unwrap();
         let keys: Vec<&String> = obj.keys().collect();
@@ -1226,7 +1250,7 @@ mod tests {
     #[test]
     fn test_select_missing_field_skipped() {
         let data = sample_users();
-        let result = apply_select(data, &["name".to_string(), "nonexistent".to_string()]).unwrap();
+        let result = apply_select(data, &sel_fields(&["name", "nonexistent"])).unwrap();
         let arr = result.as_array().unwrap();
         for item in arr {
             let obj = item.as_object().unwrap();
@@ -1243,7 +1267,7 @@ mod tests {
         m.insert("city".to_string(), Value::String("Seoul".to_string()));
         let data = Value::Object(m);
 
-        let result = apply_select(data, &["name".to_string(), "city".to_string()]).unwrap();
+        let result = apply_select(data, &sel_fields(&["name", "city"])).unwrap();
         let obj = result.as_object().unwrap();
         assert_eq!(obj.len(), 2);
         assert!(obj.contains_key("name"));
@@ -1254,7 +1278,7 @@ mod tests {
     fn test_select_on_non_object_array() {
         // 배열 안에 비-오브젝트 요소는 그대로 반환
         let data = Value::Array(vec![Value::Integer(1), Value::Integer(2)]);
-        let result = apply_select(data, &["name".to_string()]).unwrap();
+        let result = apply_select(data, &sel_fields(&["name"])).unwrap();
         let arr = result.as_array().unwrap();
         assert_eq!(arr[0], Value::Integer(1));
     }
@@ -1262,15 +1286,51 @@ mod tests {
     #[test]
     fn test_select_on_non_array_non_object_error() {
         let data = Value::Integer(42);
-        let result = apply_select(data, &["name".to_string()]);
+        let result = apply_select(data, &sel_fields(&["name"]));
         assert!(result.is_err());
     }
 
     #[test]
     fn test_select_empty_array() {
         let data = Value::Array(vec![]);
-        let result = apply_select(data, &["name".to_string()]).unwrap();
+        let result = apply_select(data, &sel_fields(&["name"])).unwrap();
         assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_select_with_function() {
+        use crate::query::parser::Expr;
+        let data = sample_users();
+        let exprs = vec![SelectExpr {
+            expr: Expr::FuncCall {
+                name: "upper".to_string(),
+                args: vec![Expr::Field("name".to_string())],
+            },
+            alias: None,
+        }];
+        let result = apply_select(data, &exprs).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        let obj = arr[0].as_object().unwrap();
+        assert!(obj.contains_key("upper_name"));
+        assert_eq!(obj["upper_name"], Value::String("ALICE".to_string()));
+    }
+
+    #[test]
+    fn test_select_with_alias() {
+        use crate::query::parser::Expr;
+        let data = sample_users();
+        let exprs = vec![SelectExpr {
+            expr: Expr::FuncCall {
+                name: "upper".to_string(),
+                args: vec![Expr::Field("name".to_string())],
+            },
+            alias: Some("NAME".to_string()),
+        }];
+        let result = apply_select(data, &exprs).unwrap();
+        let arr = result.as_array().unwrap();
+        let obj = arr[0].as_object().unwrap();
+        assert!(obj.contains_key("NAME"));
     }
 
     // --- 통합: where + select ---

--- a/src/query/functions.rs
+++ b/src/query/functions.rs
@@ -1,0 +1,820 @@
+use crate::error::DkitError;
+use crate::query::parser::{Expr, LiteralValue};
+use crate::value::Value;
+
+/// 표현식을 주어진 레코드(행)에 대해 평가하여 Value를 반환
+pub fn evaluate_expr(row: &Value, expr: &Expr) -> Result<Value, DkitError> {
+    match expr {
+        Expr::Field(name) => match row {
+            Value::Object(map) => Ok(map.get(name).cloned().unwrap_or(Value::Null)),
+            _ => Err(DkitError::QueryError(format!(
+                "cannot access field '{}' on non-object value",
+                name
+            ))),
+        },
+        Expr::Literal(lit) => Ok(literal_to_value(lit)),
+        Expr::FuncCall { name, args } => {
+            let evaluated: Result<Vec<Value>, DkitError> =
+                args.iter().map(|a| evaluate_expr(row, a)).collect();
+            call_function(name, evaluated?)
+        }
+    }
+}
+
+/// 표현식에서 출력 키(필드명)를 자동으로 결정
+pub fn expr_default_key(expr: &Expr) -> String {
+    match expr {
+        Expr::Field(f) => f.clone(),
+        Expr::Literal(_) => "value".to_string(),
+        Expr::FuncCall { name, args } => {
+            if let Some(first) = args.first() {
+                format!("{}_{}", name, expr_default_key(first))
+            } else {
+                name.clone()
+            }
+        }
+    }
+}
+
+fn literal_to_value(lit: &LiteralValue) -> Value {
+    match lit {
+        LiteralValue::String(s) => Value::String(s.clone()),
+        LiteralValue::Integer(n) => Value::Integer(*n),
+        LiteralValue::Float(f) => Value::Float(*f),
+        LiteralValue::Bool(b) => Value::Bool(*b),
+        LiteralValue::Null => Value::Null,
+    }
+}
+
+/// 내장 함수 호출
+fn call_function(name: &str, args: Vec<Value>) -> Result<Value, DkitError> {
+    match name {
+        // --- 문자열 함수 ---
+        "upper" => {
+            let s = require_one_string(name, &args)?;
+            Ok(Value::String(s.to_uppercase()))
+        }
+        "lower" => {
+            let s = require_one_string(name, &args)?;
+            Ok(Value::String(s.to_lowercase()))
+        }
+        "trim" => {
+            let s = require_one_string(name, &args)?;
+            Ok(Value::String(s.trim().to_string()))
+        }
+        "ltrim" => {
+            let s = require_one_string(name, &args)?;
+            Ok(Value::String(s.trim_start().to_string()))
+        }
+        "rtrim" => {
+            let s = require_one_string(name, &args)?;
+            Ok(Value::String(s.trim_end().to_string()))
+        }
+        "length" => match args.as_slice() {
+            [Value::String(s)] => Ok(Value::Integer(s.chars().count() as i64)),
+            [Value::Array(a)] => Ok(Value::Integer(a.len() as i64)),
+            [Value::Null] => Ok(Value::Integer(0)),
+            [v] => Err(DkitError::QueryError(format!(
+                "length() requires a string or array argument, got {}",
+                value_type_name(v)
+            ))),
+            _ => Err(DkitError::QueryError(format!(
+                "length() takes 1 argument, got {}",
+                args.len()
+            ))),
+        },
+        "substr" => {
+            if args.len() < 2 || args.len() > 3 {
+                return Err(DkitError::QueryError(format!(
+                    "substr() takes 2 or 3 arguments, got {}",
+                    args.len()
+                )));
+            }
+            let s = match &args[0] {
+                Value::String(s) => s.clone(),
+                Value::Null => return Ok(Value::Null),
+                v => {
+                    return Err(DkitError::QueryError(format!(
+                        "substr() first argument must be a string, got {}",
+                        value_type_name(v)
+                    )))
+                }
+            };
+            let start = require_integer_arg("substr", &args[1], "start")? as usize;
+            let chars: Vec<char> = s.chars().collect();
+            let start = start.min(chars.len());
+            if args.len() == 3 {
+                let len = require_integer_arg("substr", &args[2], "length")? as usize;
+                let end = (start + len).min(chars.len());
+                Ok(Value::String(chars[start..end].iter().collect()))
+            } else {
+                Ok(Value::String(chars[start..].iter().collect()))
+            }
+        }
+        "concat" => {
+            if args.is_empty() {
+                return Ok(Value::String(String::new()));
+            }
+            let mut result = String::new();
+            for arg in &args {
+                match arg {
+                    Value::String(s) => result.push_str(s),
+                    Value::Null => {}
+                    v => result.push_str(&v.to_string()),
+                }
+            }
+            Ok(Value::String(result))
+        }
+        "replace" => {
+            if args.len() != 3 {
+                return Err(DkitError::QueryError(format!(
+                    "replace() takes 3 arguments (string, from, to), got {}",
+                    args.len()
+                )));
+            }
+            let s = match &args[0] {
+                Value::String(s) => s.clone(),
+                Value::Null => return Ok(Value::Null),
+                v => {
+                    return Err(DkitError::QueryError(format!(
+                        "replace() first argument must be a string, got {}",
+                        value_type_name(v)
+                    )))
+                }
+            };
+            let from = match &args[1] {
+                Value::String(s) => s.clone(),
+                v => {
+                    return Err(DkitError::QueryError(format!(
+                        "replace() second argument must be a string, got {}",
+                        value_type_name(v)
+                    )))
+                }
+            };
+            let to = match &args[2] {
+                Value::String(s) => s.clone(),
+                v => {
+                    return Err(DkitError::QueryError(format!(
+                        "replace() third argument must be a string, got {}",
+                        value_type_name(v)
+                    )))
+                }
+            };
+            Ok(Value::String(s.replace(&*from, &to)))
+        }
+        "split" => {
+            if args.len() != 2 {
+                return Err(DkitError::QueryError(format!(
+                    "split() takes 2 arguments (string, separator), got {}",
+                    args.len()
+                )));
+            }
+            let s = match &args[0] {
+                Value::String(s) => s.clone(),
+                Value::Null => return Ok(Value::Array(vec![])),
+                v => {
+                    return Err(DkitError::QueryError(format!(
+                        "split() first argument must be a string, got {}",
+                        value_type_name(v)
+                    )))
+                }
+            };
+            let sep = match &args[1] {
+                Value::String(s) => s.clone(),
+                v => {
+                    return Err(DkitError::QueryError(format!(
+                        "split() second argument must be a string, got {}",
+                        value_type_name(v)
+                    )))
+                }
+            };
+            Ok(Value::Array(
+                s.split(&*sep)
+                    .map(|p| Value::String(p.to_string()))
+                    .collect(),
+            ))
+        }
+
+        // --- 수학 함수 ---
+        "round" => {
+            let n = require_numeric_arg(name, &args)?;
+            if args.len() == 2 {
+                let decimals = require_integer_arg("round", &args[1], "decimals")?;
+                let factor = 10_f64.powi(decimals as i32);
+                Ok(Value::Float((n * factor).round() / factor))
+            } else if args.len() == 1 {
+                Ok(Value::Integer(n.round() as i64))
+            } else {
+                Err(DkitError::QueryError(format!(
+                    "round() takes 1 or 2 arguments, got {}",
+                    args.len()
+                )))
+            }
+        }
+        "ceil" => {
+            let n = require_numeric_arg(name, &args)?;
+            Ok(Value::Integer(n.ceil() as i64))
+        }
+        "floor" => {
+            let n = require_numeric_arg(name, &args)?;
+            Ok(Value::Integer(n.floor() as i64))
+        }
+        "abs" => match args.as_slice() {
+            [Value::Integer(n)] => Ok(Value::Integer(n.abs())),
+            [Value::Float(f)] => Ok(Value::Float(f.abs())),
+            [Value::Null] => Ok(Value::Null),
+            [v] => Err(DkitError::QueryError(format!(
+                "abs() requires a numeric argument, got {}",
+                value_type_name(v)
+            ))),
+            _ => Err(DkitError::QueryError(format!(
+                "abs() takes 1 argument, got {}",
+                args.len()
+            ))),
+        },
+        "sqrt" => {
+            let n = require_numeric_arg(name, &args)?;
+            if n < 0.0 {
+                return Err(DkitError::QueryError(
+                    "sqrt() requires a non-negative argument".to_string(),
+                ));
+            }
+            Ok(Value::Float(n.sqrt()))
+        }
+        "pow" => {
+            if args.len() != 2 {
+                return Err(DkitError::QueryError(format!(
+                    "pow() takes 2 arguments, got {}",
+                    args.len()
+                )));
+            }
+            let base = require_numeric_arg("pow base", &args[..1])?;
+            let exp = require_numeric_arg("pow exp", &args[1..])?;
+            Ok(Value::Float(base.powf(exp)))
+        }
+
+        // --- 날짜 함수 ---
+        "now" => {
+            if !args.is_empty() {
+                return Err(DkitError::QueryError(
+                    "now() takes no arguments".to_string(),
+                ));
+            }
+            Ok(Value::String(current_datetime_utc()))
+        }
+        "date" => {
+            let s = require_one_string(name, &args)?;
+            // 날짜 파싱 검증 (ISO 8601 형식 기대)
+            let normalized = normalize_date_str(&s)?;
+            Ok(Value::String(normalized))
+        }
+        "year" => {
+            let s = require_one_string(name, &args)?;
+            let y = extract_year(&s)?;
+            Ok(Value::Integer(y))
+        }
+        "month" => {
+            let s = require_one_string(name, &args)?;
+            let m = extract_month(&s)?;
+            Ok(Value::Integer(m))
+        }
+        "day" => {
+            let s = require_one_string(name, &args)?;
+            let d = extract_day(&s)?;
+            Ok(Value::Integer(d))
+        }
+
+        // --- 타입 변환 ---
+        "to_int" | "int" => match args.as_slice() {
+            [Value::Integer(n)] => Ok(Value::Integer(*n)),
+            [Value::Float(f)] => Ok(Value::Integer(*f as i64)),
+            [Value::String(s)] => s.trim().parse::<i64>().map(Value::Integer).map_err(|_| {
+                DkitError::QueryError(format!("to_int(): cannot parse '{}' as integer", s))
+            }),
+            [Value::Bool(b)] => Ok(Value::Integer(if *b { 1 } else { 0 })),
+            [Value::Null] => Ok(Value::Null),
+            [v] => Err(DkitError::QueryError(format!(
+                "to_int() cannot convert {}",
+                value_type_name(v)
+            ))),
+            _ => Err(DkitError::QueryError(format!(
+                "to_int() takes 1 argument, got {}",
+                args.len()
+            ))),
+        },
+        "to_float" | "float" => match args.as_slice() {
+            [Value::Float(f)] => Ok(Value::Float(*f)),
+            [Value::Integer(n)] => Ok(Value::Float(*n as f64)),
+            [Value::String(s)] => s.trim().parse::<f64>().map(Value::Float).map_err(|_| {
+                DkitError::QueryError(format!("to_float(): cannot parse '{}' as float", s))
+            }),
+            [Value::Bool(b)] => Ok(Value::Float(if *b { 1.0 } else { 0.0 })),
+            [Value::Null] => Ok(Value::Null),
+            [v] => Err(DkitError::QueryError(format!(
+                "to_float() cannot convert {}",
+                value_type_name(v)
+            ))),
+            _ => Err(DkitError::QueryError(format!(
+                "to_float() takes 1 argument, got {}",
+                args.len()
+            ))),
+        },
+        "to_string" | "str" => match args.as_slice() {
+            [Value::String(s)] => Ok(Value::String(s.clone())),
+            [Value::Integer(n)] => Ok(Value::String(n.to_string())),
+            [Value::Float(f)] => Ok(Value::String(f.to_string())),
+            [Value::Bool(b)] => Ok(Value::String(b.to_string())),
+            [Value::Null] => Ok(Value::String("null".to_string())),
+            [v] => Ok(Value::String(v.to_string())),
+            _ => Err(DkitError::QueryError(format!(
+                "to_string() takes 1 argument, got {}",
+                args.len()
+            ))),
+        },
+        "to_bool" | "bool" => match args.as_slice() {
+            [Value::Bool(b)] => Ok(Value::Bool(*b)),
+            [Value::Integer(n)] => Ok(Value::Bool(*n != 0)),
+            [Value::Float(f)] => Ok(Value::Bool(*f != 0.0)),
+            [Value::String(s)] => match s.trim().to_lowercase().as_str() {
+                "true" | "yes" | "1" | "on" => Ok(Value::Bool(true)),
+                "false" | "no" | "0" | "off" | "" => Ok(Value::Bool(false)),
+                _ => Err(DkitError::QueryError(format!(
+                    "to_bool(): cannot parse '{}' as boolean",
+                    s
+                ))),
+            },
+            [Value::Null] => Ok(Value::Bool(false)),
+            [v] => Err(DkitError::QueryError(format!(
+                "to_bool() cannot convert {}",
+                value_type_name(v)
+            ))),
+            _ => Err(DkitError::QueryError(format!(
+                "to_bool() takes 1 argument, got {}",
+                args.len()
+            ))),
+        },
+
+        // --- 기타 유틸 ---
+        "coalesce" => {
+            for arg in &args {
+                if !matches!(arg, Value::Null) {
+                    return Ok(arg.clone());
+                }
+            }
+            Ok(Value::Null)
+        }
+        "if_null" => match args.as_slice() {
+            [Value::Null, default] => Ok(default.clone()),
+            [v, _] => Ok(v.clone()),
+            _ => Err(DkitError::QueryError(format!(
+                "if_null() takes 2 arguments, got {}",
+                args.len()
+            ))),
+        },
+
+        _ => Err(DkitError::QueryError(format!(
+            "unknown function '{}'",
+            name
+        ))),
+    }
+}
+
+// --- 헬퍼 함수 ---
+
+fn require_one_string(func: &str, args: &[Value]) -> Result<String, DkitError> {
+    match args {
+        [Value::String(s)] => Ok(s.clone()),
+        [Value::Null] => Err(DkitError::QueryError(format!(
+            "{}() argument is null",
+            func
+        ))),
+        [v] => Err(DkitError::QueryError(format!(
+            "{}() requires a string argument, got {}",
+            func,
+            value_type_name(v)
+        ))),
+        _ => Err(DkitError::QueryError(format!(
+            "{}() takes 1 argument, got {}",
+            func,
+            args.len()
+        ))),
+    }
+}
+
+fn require_numeric_arg(func: &str, args: &[Value]) -> Result<f64, DkitError> {
+    match args.first() {
+        Some(Value::Float(f)) => Ok(*f),
+        Some(Value::Integer(n)) => Ok(*n as f64),
+        Some(Value::Null) => Err(DkitError::QueryError(format!(
+            "{}() argument is null",
+            func
+        ))),
+        Some(v) => Err(DkitError::QueryError(format!(
+            "{}() requires a numeric argument, got {}",
+            func,
+            value_type_name(v)
+        ))),
+        None => Err(DkitError::QueryError(format!(
+            "{}() takes at least 1 argument",
+            func
+        ))),
+    }
+}
+
+fn require_integer_arg(func: &str, val: &Value, param: &str) -> Result<i64, DkitError> {
+    match val {
+        Value::Integer(n) => Ok(*n),
+        Value::Float(f) => Ok(*f as i64),
+        v => Err(DkitError::QueryError(format!(
+            "{}() '{}' argument must be an integer, got {}",
+            func,
+            param,
+            value_type_name(v)
+        ))),
+    }
+}
+
+fn value_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Integer(_) => "integer",
+        Value::Float(_) => "float",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+// --- 날짜 헬퍼 ---
+
+/// ISO 8601 날짜 문자열에서 연도 추출 (예: "2024-03-15" → 2024)
+fn extract_year(s: &str) -> Result<i64, DkitError> {
+    let date_part = s.split('T').next().unwrap_or(s);
+    let parts: Vec<&str> = date_part.split('-').collect();
+    if parts.is_empty() {
+        return Err(DkitError::QueryError(format!(
+            "year(): cannot parse date from '{}'",
+            s
+        )));
+    }
+    parts[0]
+        .parse::<i64>()
+        .map_err(|_| DkitError::QueryError(format!("year(): cannot parse year from '{}'", s)))
+}
+
+/// ISO 8601 날짜 문자열에서 월 추출 (1-12)
+fn extract_month(s: &str) -> Result<i64, DkitError> {
+    let date_part = s.split('T').next().unwrap_or(s);
+    let parts: Vec<&str> = date_part.split('-').collect();
+    if parts.len() < 2 {
+        return Err(DkitError::QueryError(format!(
+            "month(): cannot parse month from '{}'",
+            s
+        )));
+    }
+    parts[1]
+        .parse::<i64>()
+        .map_err(|_| DkitError::QueryError(format!("month(): cannot parse month from '{}'", s)))
+}
+
+/// ISO 8601 날짜 문자열에서 일 추출 (1-31)
+fn extract_day(s: &str) -> Result<i64, DkitError> {
+    let date_part = s.split('T').next().unwrap_or(s);
+    let parts: Vec<&str> = date_part.split('-').collect();
+    if parts.len() < 3 {
+        return Err(DkitError::QueryError(format!(
+            "day(): cannot parse day from '{}'",
+            s
+        )));
+    }
+    // Day part may have trailing time info
+    let day_str = parts[2].split(&['T', ' '][..]).next().unwrap_or(parts[2]);
+    day_str
+        .parse::<i64>()
+        .map_err(|_| DkitError::QueryError(format!("day(): cannot parse day from '{}'", s)))
+}
+
+/// 날짜 문자열 정규화 (yyyy-MM-dd 형식 확인)
+fn normalize_date_str(s: &str) -> Result<String, DkitError> {
+    let date_part = s.split('T').next().unwrap_or(s).trim();
+    let parts: Vec<&str> = date_part.split('-').collect();
+    if parts.len() != 3 {
+        return Err(DkitError::QueryError(format!(
+            "date(): expected yyyy-MM-dd format, got '{}'",
+            s
+        )));
+    }
+    let year = parts[0]
+        .parse::<i32>()
+        .map_err(|_| DkitError::QueryError(format!("date(): invalid year in '{}'", s)))?;
+    let month = parts[1]
+        .parse::<u32>()
+        .map_err(|_| DkitError::QueryError(format!("date(): invalid month in '{}'", s)))?;
+    let day = parts[2]
+        .split(&[' ', 'T'][..])
+        .next()
+        .unwrap_or(parts[2])
+        .parse::<u32>()
+        .map_err(|_| DkitError::QueryError(format!("date(): invalid day in '{}'", s)))?;
+    if !(1..=12).contains(&month) {
+        return Err(DkitError::QueryError(format!(
+            "date(): month {} out of range in '{}'",
+            month, s
+        )));
+    }
+    if !(1..=31).contains(&day) {
+        return Err(DkitError::QueryError(format!(
+            "date(): day {} out of range in '{}'",
+            day, s
+        )));
+    }
+    Ok(format!("{:04}-{:02}-{:02}", year, month, day))
+}
+
+/// 현재 UTC 시각을 ISO 8601 문자열로 반환
+fn current_datetime_utc() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // 간단한 UTC 변환 (초 → 날짜/시간)
+    let days_since_epoch = secs / 86400;
+    let time_of_day = secs % 86400;
+    let (year, month, day) = days_to_ymd(days_since_epoch);
+    let hour = time_of_day / 3600;
+    let minute = (time_of_day % 3600) / 60;
+    let second = time_of_day % 60;
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hour, minute, second
+    )
+}
+
+/// Unix epoch 일수를 (year, month, day)로 변환
+fn days_to_ymd(days: u64) -> (i64, u64, u64) {
+    // Gregorian calendar algorithm
+    let z = days as i64 + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m as u64, d as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::parser::Expr;
+    use indexmap::IndexMap;
+
+    fn obj(fields: &[(&str, Value)]) -> Value {
+        let mut map = IndexMap::new();
+        for (k, v) in fields {
+            map.insert(k.to_string(), v.clone());
+        }
+        Value::Object(map)
+    }
+
+    fn eval(row: &Value, expr: &Expr) -> Result<Value, DkitError> {
+        evaluate_expr(row, expr)
+    }
+
+    fn func(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::FuncCall {
+            name: name.to_string(),
+            args,
+        }
+    }
+
+    fn field(name: &str) -> Expr {
+        Expr::Field(name.to_string())
+    }
+
+    fn lit_str(s: &str) -> Expr {
+        Expr::Literal(LiteralValue::String(s.to_string()))
+    }
+
+    fn lit_int(n: i64) -> Expr {
+        Expr::Literal(LiteralValue::Integer(n))
+    }
+
+    // --- 문자열 함수 ---
+
+    #[test]
+    fn test_upper() {
+        let row = obj(&[("name", Value::String("hello".to_string()))]);
+        let result = eval(&row, &func("upper", vec![field("name")])).unwrap();
+        assert_eq!(result, Value::String("HELLO".to_string()));
+    }
+
+    #[test]
+    fn test_lower() {
+        let row = obj(&[("name", Value::String("WORLD".to_string()))]);
+        let result = eval(&row, &func("lower", vec![field("name")])).unwrap();
+        assert_eq!(result, Value::String("world".to_string()));
+    }
+
+    #[test]
+    fn test_trim() {
+        let row = obj(&[("name", Value::String("  hello  ".to_string()))]);
+        let result = eval(&row, &func("trim", vec![field("name")])).unwrap();
+        assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn test_length_string() {
+        let row = obj(&[("name", Value::String("hello".to_string()))]);
+        let result = eval(&row, &func("length", vec![field("name")])).unwrap();
+        assert_eq!(result, Value::Integer(5));
+    }
+
+    #[test]
+    fn test_substr() {
+        let row = obj(&[("name", Value::String("hello world".to_string()))]);
+        let result = eval(
+            &row,
+            &func("substr", vec![field("name"), lit_int(0), lit_int(5)]),
+        )
+        .unwrap();
+        assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn test_concat() {
+        let row = obj(&[
+            ("first", Value::String("hello".to_string())),
+            ("last", Value::String(" world".to_string())),
+        ]);
+        let result = eval(&row, &func("concat", vec![field("first"), field("last")])).unwrap();
+        assert_eq!(result, Value::String("hello world".to_string()));
+    }
+
+    #[test]
+    fn test_replace() {
+        let row = obj(&[("name", Value::String("hello world".to_string()))]);
+        let result = eval(
+            &row,
+            &func(
+                "replace",
+                vec![field("name"), lit_str("world"), lit_str("dkit")],
+            ),
+        )
+        .unwrap();
+        assert_eq!(result, Value::String("hello dkit".to_string()));
+    }
+
+    // --- 수학 함수 ---
+
+    #[test]
+    fn test_round_no_decimals() {
+        let row = obj(&[("price", Value::Float(3.7))]);
+        let result = eval(&row, &func("round", vec![field("price")])).unwrap();
+        assert_eq!(result, Value::Integer(4));
+    }
+
+    #[test]
+    fn test_round_with_decimals() {
+        let row = obj(&[("price", Value::Float(3.14159))]);
+        let result = eval(&row, &func("round", vec![field("price"), lit_int(2)])).unwrap();
+        assert_eq!(result, Value::Float(3.14));
+    }
+
+    #[test]
+    fn test_ceil() {
+        let row = obj(&[("price", Value::Float(3.2))]);
+        let result = eval(&row, &func("ceil", vec![field("price")])).unwrap();
+        assert_eq!(result, Value::Integer(4));
+    }
+
+    #[test]
+    fn test_floor() {
+        let row = obj(&[("price", Value::Float(3.9))]);
+        let result = eval(&row, &func("floor", vec![field("price")])).unwrap();
+        assert_eq!(result, Value::Integer(3));
+    }
+
+    #[test]
+    fn test_abs_negative() {
+        let row = obj(&[("score", Value::Integer(-5))]);
+        let result = eval(&row, &func("abs", vec![field("score")])).unwrap();
+        assert_eq!(result, Value::Integer(5));
+    }
+
+    // --- 날짜 함수 ---
+
+    #[test]
+    fn test_year() {
+        let row = obj(&[("date", Value::String("2024-03-15".to_string()))]);
+        let result = eval(&row, &func("year", vec![field("date")])).unwrap();
+        assert_eq!(result, Value::Integer(2024));
+    }
+
+    #[test]
+    fn test_month() {
+        let row = obj(&[("date", Value::String("2024-03-15".to_string()))]);
+        let result = eval(&row, &func("month", vec![field("date")])).unwrap();
+        assert_eq!(result, Value::Integer(3));
+    }
+
+    #[test]
+    fn test_day() {
+        let row = obj(&[("date", Value::String("2024-03-15".to_string()))]);
+        let result = eval(&row, &func("day", vec![field("date")])).unwrap();
+        assert_eq!(result, Value::Integer(15));
+    }
+
+    #[test]
+    fn test_date_normalize() {
+        let row = obj(&[("d", Value::String("2024-3-5".to_string()))]);
+        let result = eval(&row, &func("date", vec![field("d")])).unwrap();
+        assert_eq!(result, Value::String("2024-03-05".to_string()));
+    }
+
+    #[test]
+    fn test_now_returns_string() {
+        let row = obj(&[]);
+        let result = eval(&row, &func("now", vec![])).unwrap();
+        assert!(matches!(result, Value::String(_)));
+        if let Value::String(s) = result {
+            assert!(s.contains('T'), "now() should return ISO 8601 format");
+        }
+    }
+
+    // --- 타입 변환 ---
+
+    #[test]
+    fn test_to_int_from_string() {
+        let row = obj(&[("n", Value::String("42".to_string()))]);
+        let result = eval(&row, &func("to_int", vec![field("n")])).unwrap();
+        assert_eq!(result, Value::Integer(42));
+    }
+
+    #[test]
+    fn test_to_float_from_int() {
+        let row = obj(&[("n", Value::Integer(5))]);
+        let result = eval(&row, &func("to_float", vec![field("n")])).unwrap();
+        assert_eq!(result, Value::Float(5.0));
+    }
+
+    #[test]
+    fn test_to_string_from_int() {
+        let row = obj(&[("n", Value::Integer(42))]);
+        let result = eval(&row, &func("to_string", vec![field("n")])).unwrap();
+        assert_eq!(result, Value::String("42".to_string()));
+    }
+
+    #[test]
+    fn test_to_bool_from_string() {
+        let row = obj(&[("flag", Value::String("true".to_string()))]);
+        let result = eval(&row, &func("to_bool", vec![field("flag")])).unwrap();
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    // --- 중첩 함수 호출 ---
+
+    #[test]
+    fn test_nested_upper_trim() {
+        let row = obj(&[("name", Value::String("  hello  ".to_string()))]);
+        let result = eval(
+            &row,
+            &func("upper", vec![func("trim", vec![field("name")])]),
+        )
+        .unwrap();
+        assert_eq!(result, Value::String("HELLO".to_string()));
+    }
+
+    // --- expr_default_key ---
+
+    #[test]
+    fn test_default_key_field() {
+        assert_eq!(expr_default_key(&Expr::Field("name".to_string())), "name");
+    }
+
+    #[test]
+    fn test_default_key_func() {
+        let expr = Expr::FuncCall {
+            name: "upper".to_string(),
+            args: vec![Expr::Field("name".to_string())],
+        };
+        assert_eq!(expr_default_key(&expr), "upper_name");
+    }
+
+    #[test]
+    fn test_default_key_nested_func() {
+        let expr = Expr::FuncCall {
+            name: "upper".to_string(),
+            args: vec![Expr::FuncCall {
+                name: "trim".to_string(),
+                args: vec![Expr::Field("name".to_string())],
+            }],
+        };
+        assert_eq!(expr_default_key(&expr), "upper_trim_name");
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,3 +1,4 @@
 pub mod evaluator;
 pub mod filter;
+pub mod functions;
 pub mod parser;

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -31,8 +31,8 @@ pub enum Segment {
 pub enum Operation {
     /// `where` 필터링
     Where(Condition),
-    /// `select` 컬럼 선택: `select name, email`
-    Select(Vec<String>),
+    /// `select` 컬럼 선택: `select name, upper(name), round(price, 2)`
+    Select(Vec<SelectExpr>),
     /// `sort` 정렬: `sort age` (오름차순) / `sort age desc` (내림차순)
     Sort { field: String, descending: bool },
     /// `limit` 결과 제한: `limit 10`
@@ -117,6 +117,25 @@ pub enum LiteralValue {
     Float(f64),
     Bool(bool),
     Null,
+}
+
+/// 표현식 (select 절 등에서 사용)
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    /// 필드 참조: `name`
+    Field(String),
+    /// 리터럴 값: `42`, `"hello"`, `true`
+    Literal(LiteralValue),
+    /// 함수 호출: `upper(name)`, `round(price, 2)`, `upper(trim(name))`
+    FuncCall { name: String, args: Vec<Expr> },
+}
+
+/// SELECT 절의 컬럼 표현식
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectExpr {
+    pub expr: Expr,
+    /// 출력 키 별칭 (`upper(name) as name_upper` 에서 `name_upper`)
+    pub alias: Option<String>,
 }
 
 /// 쿼리 문자열을 파싱하는 파서
@@ -282,8 +301,8 @@ impl Parser {
             }
             "select" => {
                 self.skip_whitespace();
-                let fields = self.parse_identifier_list()?;
-                Ok(Operation::Select(fields))
+                let exprs = self.parse_select_expr_list()?;
+                Ok(Operation::Select(exprs))
             }
             "sort" => {
                 self.skip_whitespace();
@@ -439,6 +458,104 @@ impl Parser {
         };
 
         Ok(Some(GroupAggregate { func, field, alias }))
+    }
+
+    /// SELECT 절의 표현식 목록 파싱: `expr [as alias] ( "," expr [as alias] )*`
+    fn parse_select_expr_list(&mut self) -> Result<Vec<SelectExpr>, DkitError> {
+        let mut exprs = vec![self.parse_select_expr()?];
+        loop {
+            self.skip_whitespace();
+            if self.consume_char(',') {
+                self.skip_whitespace();
+                exprs.push(self.parse_select_expr()?);
+            } else {
+                break;
+            }
+        }
+        Ok(exprs)
+    }
+
+    /// 단일 SELECT 표현식 파싱: `expr [as alias]`
+    fn parse_select_expr(&mut self) -> Result<SelectExpr, DkitError> {
+        let expr = self.parse_expr()?;
+        self.skip_whitespace();
+        // Optional alias: `as alias_name`
+        let alias = {
+            let saved = self.pos;
+            if let Ok(keyword) = self.parse_keyword() {
+                if keyword == "as" {
+                    self.skip_whitespace();
+                    Some(self.parse_identifier()?)
+                } else {
+                    self.pos = saved;
+                    None
+                }
+            } else {
+                self.pos = saved;
+                None
+            }
+        };
+        Ok(SelectExpr { expr, alias })
+    }
+
+    /// 표현식 파싱: 필드 참조, 리터럴, 함수 호출
+    fn parse_expr(&mut self) -> Result<Expr, DkitError> {
+        match self.peek() {
+            Some('"') => {
+                let lit = self.parse_string_literal()?;
+                Ok(Expr::Literal(lit))
+            }
+            Some(c) if c.is_ascii_digit() => {
+                let lit = self.parse_number_literal()?;
+                Ok(Expr::Literal(lit))
+            }
+            Some(c) if c.is_alphabetic() || c == '_' => {
+                let name = self.parse_identifier()?;
+                // Check for bool/null literals
+                match name.as_str() {
+                    "true" => return Ok(Expr::Literal(LiteralValue::Bool(true))),
+                    "false" => return Ok(Expr::Literal(LiteralValue::Bool(false))),
+                    "null" => return Ok(Expr::Literal(LiteralValue::Null)),
+                    _ => {}
+                }
+                // Check for function call: name(...)
+                if self.peek() == Some('(') {
+                    self.advance(); // consume '('
+                    self.skip_whitespace();
+                    let mut args = Vec::new();
+                    if self.peek() != Some(')') {
+                        args.push(self.parse_expr()?);
+                        loop {
+                            self.skip_whitespace();
+                            if self.consume_char(',') {
+                                self.skip_whitespace();
+                                args.push(self.parse_expr()?);
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                    self.skip_whitespace();
+                    if !self.consume_char(')') {
+                        return Err(DkitError::QueryError(format!(
+                            "expected ')' at position {}",
+                            self.pos
+                        )));
+                    }
+                    Ok(Expr::FuncCall { name, args })
+                } else {
+                    Ok(Expr::Field(name))
+                }
+            }
+            Some(c) => Err(DkitError::QueryError(format!(
+                "expected expression at position {}, found '{}'",
+                self.pos, c
+            ))),
+            None => Err(DkitError::QueryError(format!(
+                "expected expression at position {}",
+                self.pos
+            ))),
+        }
     }
 
     /// 쉼표로 구분된 식별자 목록 파싱: `IDENTIFIER ( "," IDENTIFIER )*`
@@ -1309,60 +1426,52 @@ mod tests {
 
     // --- select 절 파싱 ---
 
+    fn field(name: &str) -> SelectExpr {
+        SelectExpr {
+            expr: Expr::Field(name.to_string()),
+            alias: None,
+        }
+    }
+
+    fn fields(names: &[&str]) -> Operation {
+        Operation::Select(names.iter().map(|n| field(n)).collect())
+    }
+
     #[test]
     fn test_select_single_field() {
         let q = parse_query(".users[] | select name").unwrap();
         assert_eq!(q.operations.len(), 1);
-        assert_eq!(q.operations[0], Operation::Select(vec!["name".to_string()]));
+        assert_eq!(q.operations[0], fields(&["name"]));
     }
 
     #[test]
     fn test_select_multiple_fields() {
         let q = parse_query(".users[] | select name, email").unwrap();
-        assert_eq!(
-            q.operations[0],
-            Operation::Select(vec!["name".to_string(), "email".to_string()])
-        );
+        assert_eq!(q.operations[0], fields(&["name", "email"]));
     }
 
     #[test]
     fn test_select_three_fields() {
         let q = parse_query(".users[] | select name, age, email").unwrap();
-        assert_eq!(
-            q.operations[0],
-            Operation::Select(vec![
-                "name".to_string(),
-                "age".to_string(),
-                "email".to_string(),
-            ])
-        );
+        assert_eq!(q.operations[0], fields(&["name", "age", "email"]));
     }
 
     #[test]
     fn test_select_with_extra_whitespace() {
         let q = parse_query(".[]  |  select  name ,  email  ").unwrap();
-        assert_eq!(
-            q.operations[0],
-            Operation::Select(vec!["name".to_string(), "email".to_string()])
-        );
+        assert_eq!(q.operations[0], fields(&["name", "email"]));
     }
 
     #[test]
     fn test_select_field_with_underscore() {
         let q = parse_query(".[] | select user_name, created_at").unwrap();
-        assert_eq!(
-            q.operations[0],
-            Operation::Select(vec!["user_name".to_string(), "created_at".to_string()])
-        );
+        assert_eq!(q.operations[0], fields(&["user_name", "created_at"]));
     }
 
     #[test]
     fn test_select_field_with_hyphen() {
         let q = parse_query(".[] | select content-type").unwrap();
-        assert_eq!(
-            q.operations[0],
-            Operation::Select(vec!["content-type".to_string()])
-        );
+        assert_eq!(q.operations[0], fields(&["content-type"]));
     }
 
     #[test]
@@ -1370,16 +1479,97 @@ mod tests {
         let q = parse_query(".users[] | where age > 30 | select name, email").unwrap();
         assert_eq!(q.operations.len(), 2);
         assert!(matches!(&q.operations[0], Operation::Where(_)));
-        assert_eq!(
-            q.operations[1],
-            Operation::Select(vec!["name".to_string(), "email".to_string()])
-        );
+        assert_eq!(q.operations[1], fields(&["name", "email"]));
     }
 
     #[test]
     fn test_error_select_missing_fields() {
         let err = parse_query(".[] | select").unwrap_err();
         assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    #[test]
+    fn test_select_func_single() {
+        let q = parse_query(".[] | select upper(name)").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec![SelectExpr {
+                expr: Expr::FuncCall {
+                    name: "upper".to_string(),
+                    args: vec![Expr::Field("name".to_string())],
+                },
+                alias: None,
+            }])
+        );
+    }
+
+    #[test]
+    fn test_select_func_with_alias() {
+        let q = parse_query(".[] | select upper(name) as NAME").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec![SelectExpr {
+                expr: Expr::FuncCall {
+                    name: "upper".to_string(),
+                    args: vec![Expr::Field("name".to_string())],
+                },
+                alias: Some("NAME".to_string()),
+            }])
+        );
+    }
+
+    #[test]
+    fn test_select_func_nested() {
+        let q = parse_query(".[] | select upper(trim(name))").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec![SelectExpr {
+                expr: Expr::FuncCall {
+                    name: "upper".to_string(),
+                    args: vec![Expr::FuncCall {
+                        name: "trim".to_string(),
+                        args: vec![Expr::Field("name".to_string())],
+                    }],
+                },
+                alias: None,
+            }])
+        );
+    }
+
+    #[test]
+    fn test_select_func_with_literal_arg() {
+        let q = parse_query(".[] | select round(price, 2)").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec![SelectExpr {
+                expr: Expr::FuncCall {
+                    name: "round".to_string(),
+                    args: vec![
+                        Expr::Field("price".to_string()),
+                        Expr::Literal(LiteralValue::Integer(2)),
+                    ],
+                },
+                alias: None,
+            }])
+        );
+    }
+
+    #[test]
+    fn test_select_mixed_fields_and_funcs() {
+        let q = parse_query(".[] | select name, upper(city)").unwrap();
+        assert_eq!(
+            q.operations[0],
+            Operation::Select(vec![
+                field("name"),
+                SelectExpr {
+                    expr: Expr::FuncCall {
+                        name: "upper".to_string(),
+                        args: vec![Expr::Field("city".to_string())],
+                    },
+                    alias: None,
+                }
+            ])
+        );
     }
 
     // --- sort 절 파싱 ---
@@ -1507,10 +1697,7 @@ mod tests {
         let q = parse_query(".users[] | where age > 30 | select name, email | sort name").unwrap();
         assert_eq!(q.operations.len(), 3);
         assert!(matches!(&q.operations[0], Operation::Where(_)));
-        assert_eq!(
-            q.operations[1],
-            Operation::Select(vec!["name".to_string(), "email".to_string()])
-        );
+        assert_eq!(q.operations[1], fields(&["name", "email"]));
         assert_eq!(
             q.operations[2],
             Operation::Sort {


### PR DESCRIPTION
## Summary

- `select` 절에서 내장 함수 호출 지원: `upper(name)`, `round(price, 2)`, `upper(trim(name))`
- 함수 별칭(as) 지원: `select upper(name) as NAME`
- 20개 이상의 내장 함수 추가 (문자열, 수학, 날짜, 타입 변환, 유틸)

## 추가된 함수

| 카테고리 | 함수 |
|---------|------|
| 문자열 | `upper`, `lower`, `trim`, `ltrim`, `rtrim`, `length`, `substr`, `concat`, `replace`, `split` |
| 수학 | `round`, `ceil`, `floor`, `abs`, `sqrt`, `pow` |
| 날짜 | `now`, `date`, `year`, `month`, `day` |
| 타입 변환 | `to_int`/`int`, `to_float`/`float`, `to_string`/`str`, `to_bool`/`bool` |
| 유틸 | `coalesce`, `if_null` |

## 사용 예시

```bash
# 문자열 변환
dkit query data.csv '.[] | select upper(name), lower(email)'

# 수학 함수
dkit query data.csv '.[] | select name, round(price, 2) as price'

# 함수 중첩
dkit query data.csv '.[] | select upper(trim(name))'

# 날짜 추출
dkit query data.json '.[] | select name, year(created_at) as year'

# 타입 변환
dkit query data.csv '.[] | select name, to_int(score) as score'
```

## Test plan

- [ ] 모든 기존 테스트 통과 확인 (614개)
- [ ] 새 파서 테스트: 함수 호출, 별칭, 중첩 함수 파싱
- [ ] 새 functions.rs 단위 테스트: 각 함수 정확성 검증
- [ ] 새 filter.rs 테스트: select with function, select with alias

Closes #97

https://claude.ai/code/session_01NaraixP5n2QociUHbxjNBV