### PR TITLE
test(v0.7.0): 통합 테스트 추가 및 README 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ cargo install --path .
 | TOML        | `.toml`                | O    | O     |
 | XML         | `.xml`                 | O    | O     |
 | MessagePack | `.msgpack`             | O    | O     |
+| Parquet     | `.parquet`             | O    | O     |
 | Excel       | `.xlsx`                | O    | -     |
 | SQLite      | `.db`, `.sqlite`       | O    | -     |
 | Markdown    | `.md`                  | -    | O     |
@@ -115,6 +116,17 @@ dkit view data.db --list-tables                          # List available tables
 dkit convert data.csv --to json --encoding euc-kr       # EUC-KR input
 dkit convert data.csv --to json --encoding shift_jis     # Shift-JIS input
 dkit convert data.csv --to json --detect-encoding        # Auto-detect encoding
+
+# Parquet (.parquet) input/output
+dkit convert data.parquet --to json                      # Parquet → JSON
+dkit convert data.parquet --to csv                       # Parquet → CSV
+dkit convert data.json --to parquet -o out.parquet       # JSON → Parquet
+dkit convert data.csv --to parquet --compression snappy  # Parquet with Snappy compression
+dkit convert data.csv --to parquet --compression zstd    # Parquet with Zstd compression
+
+# Streaming mode for large files (chunk-based processing)
+dkit convert large.jsonl --from jsonl -f csv --chunk-size 1000 -o out.csv
+dkit convert large.csv --from csv -f jsonl --chunk-size 500 -o out.jsonl
 ```
 
 ### `query` — Data querying
@@ -152,12 +164,56 @@ dkit query data.json '.items[-1]'
 
 ```bash
 # Advanced query examples
-dkit query data.json '.users[] | where .age > 20 | select .name, .email'
-dkit query data.json '.items[] | sort .price desc | limit 5'
-dkit query data.json '.users[] | where .name contains "Kim"'
+dkit query data.json '.users[] | where age > 20 | select name, email'
+dkit query data.json '.items[] | sort price desc | limit 5'
+dkit query data.json '.users[] | where name contains "Kim"'
 
 # Output query results in different formats
 dkit query data.json '.users[]' --to csv -o users.csv
+```
+
+**Aggregate functions:**
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `count` | Count elements | `.[] \| count` |
+| `count field` | Count non-null values | `.[] \| count email` |
+| `sum field` | Sum numeric field | `.[] \| sum price` |
+| `avg field` | Average of numeric field | `.[] \| avg score` |
+| `min field` | Minimum value | `.[] \| min price` |
+| `max field` | Maximum value | `.[] \| max price` |
+| `distinct field` | Unique values | `.[] \| distinct category` |
+
+```bash
+# Aggregate examples
+dkit query data.csv '.[] | count'
+dkit query data.csv '.[] | sum price'
+dkit query data.json '.users[] | where age > 30 | avg score'
+dkit query data.csv '.[] | distinct category'
+
+# GROUP BY examples
+dkit query data.csv '.[] | group_by category count(), sum(price)'
+dkit query data.csv '.[] | group_by region min(price), max(price)'
+dkit query data.csv '.[] | group_by category count() having count > 1'
+dkit query data.csv '.[] | group_by category count() | sort count desc | limit 5'
+```
+
+**Built-in functions (usable in `select`):**
+
+| Category | Functions |
+|----------|-----------|
+| String | `upper()`, `lower()`, `trim()`, `ltrim()`, `rtrim()`, `length()`, `substr()`, `concat()`, `replace()`, `split()` |
+| Math | `round()`, `ceil()`, `floor()`, `abs()`, `sqrt()`, `pow()` |
+| Date | `now()`, `date()`, `year()`, `month()`, `day()` |
+| Type | `to_int()`, `to_float()`, `to_string()`, `to_bool()` |
+| Util | `coalesce()`, `if_null()` |
+
+```bash
+# Function examples
+dkit query data.csv '.[] | select upper(name), round(price, 2)'
+dkit query data.json '.users[] | select upper(trim(name)) as NAME, year(created_at)'
+dkit query data.csv '.[] | where score > 80 | select name, to_string(score)'
+dkit query data.json '.[] | select name, coalesce(email, "N/A")'
 ```
 
 ### `view` — Table preview
@@ -251,13 +307,18 @@ dkit merge config1.yaml config2.yaml --to yaml
 | TOML | O | X | X | X |
 | XML | O | X | X | O |
 | MessagePack | O | X | X | X |
+| Parquet | O | X | X | X |
 | Excel (.xlsx) input | O | X | X | X |
 | SQLite input | O | X | X | X |
 | Markdown/HTML output | O | X | X | X |
 | Cross-format convert | O | X | Partial | Partial |
 | Table output | O | X | O | X |
 | Query (where/select/sort) | O | O | O | O |
+| Aggregate functions | O | O | O | X |
+| GROUP BY | O | Partial | O | X |
+| Built-in functions | O | O | O | X |
 | Pipeline chaining | O | O | O | X |
+| Streaming (large files) | O | X | O | X |
 | Statistics | O | X | O | X |
 | Schema inspection | O | X | X | X |
 | File merging | O | X | O | X |

--- a/tests/v070_integration_test.rs
+++ b/tests/v070_integration_test.rs
@@ -30,7 +30,9 @@ fn create_typed_parquet(path: &std::path::Path) {
     ]));
 
     let ids: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5]));
-    let names: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "Diana", "Eve"]));
+    let names: ArrayRef = Arc::new(StringArray::from(vec![
+        "Alice", "Bob", "Charlie", "Diana", "Eve",
+    ]));
     let scores: ArrayRef = Arc::new(Float64Array::from(vec![
         Some(85.0),
         Some(92.5),
@@ -188,15 +190,22 @@ fn json_to_parquet_with_snappy_compression() {
     let json_path = dir.path().join("data.json");
     let pq_path = dir.path().join("out.parquet");
 
-    fs::write(&json_path, r#"[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]"#).unwrap();
+    fs::write(
+        &json_path,
+        r#"[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]"#,
+    )
+    .unwrap();
 
     dkit()
         .args([
             "convert",
             json_path.to_str().unwrap(),
-            "-f", "parquet",
-            "-o", pq_path.to_str().unwrap(),
-            "--compression", "snappy",
+            "-f",
+            "parquet",
+            "-o",
+            pq_path.to_str().unwrap(),
+            "--compression",
+            "snappy",
         ])
         .assert()
         .success();
@@ -217,9 +226,12 @@ fn json_to_parquet_with_zstd_compression() {
         .args([
             "convert",
             json_path.to_str().unwrap(),
-            "-f", "parquet",
-            "-o", pq_path.to_str().unwrap(),
-            "--compression", "zstd",
+            "-f",
+            "parquet",
+            "-o",
+            pq_path.to_str().unwrap(),
+            "--compression",
+            "zstd",
         ])
         .assert()
         .success();
@@ -298,7 +310,10 @@ fn aggregate_sum_field() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     // 85 + 92 + 78 + 95 + 88 = 438
-    assert!(stdout.contains("438"), "sum of scores should be 438, got: {stdout}");
+    assert!(
+        stdout.contains("438"),
+        "sum of scores should be 438, got: {stdout}"
+    );
 }
 
 #[test]
@@ -310,7 +325,10 @@ fn aggregate_avg_field() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     // avg = 438 / 5 = 87.6
-    assert!(stdout.contains("87.6"), "avg score should be 87.6, got: {stdout}");
+    assert!(
+        stdout.contains("87.6"),
+        "avg score should be 87.6, got: {stdout}"
+    );
 }
 
 #[test]
@@ -352,7 +370,11 @@ fn aggregate_max_string() {
 #[test]
 fn aggregate_distinct_field() {
     let output = dkit()
-        .args(["query", "tests/fixtures/employees.json", ".[] | distinct city"])
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | distinct city",
+        ])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -388,7 +410,10 @@ fn aggregate_sum_after_filter() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     // Alice(85) + Diana(95) + Eve(88) = 268
-    assert!(stdout.contains("268"), "sum of engineer scores should be 268, got: {stdout}");
+    assert!(
+        stdout.contains("268"),
+        "sum of engineer scores should be 268, got: {stdout}"
+    );
 }
 
 #[test]
@@ -404,7 +429,10 @@ fn aggregate_avg_after_filter() {
     assert!(output.status.success());
     // Charlie(78) + Eve(88) = 166 / 2 = 83.0
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("83"), "avg score for age>30 should be 83, got: {stdout}");
+    assert!(
+        stdout.contains("83"),
+        "avg score for age>30 should be 83, got: {stdout}"
+    );
 }
 
 // ============================================================
@@ -493,7 +521,10 @@ fn group_by_result_sortable() {
     // Seoul(3) 이 먼저 나와야 함
     let seoul_pos = stdout.find("Seoul").unwrap();
     let busan_pos = stdout.find("Busan").unwrap();
-    assert!(seoul_pos < busan_pos, "Seoul (count=3) should come before Busan (count=1)");
+    assert!(
+        seoul_pos < busan_pos,
+        "Seoul (count=3) should come before Busan (count=1)"
+    );
 }
 
 #[test]
@@ -508,9 +539,18 @@ fn group_by_having_filter() {
         .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("Seoul"), "Seoul (count=3) should pass having count>1");
-    assert!(!stdout.contains("Busan"), "Busan (count=1) should be filtered out");
-    assert!(!stdout.contains("Incheon"), "Incheon (count=1) should be filtered out");
+    assert!(
+        stdout.contains("Seoul"),
+        "Seoul (count=3) should pass having count>1"
+    );
+    assert!(
+        !stdout.contains("Busan"),
+        "Busan (count=1) should be filtered out"
+    );
+    assert!(
+        !stdout.contains("Incheon"),
+        "Incheon (count=1) should be filtered out"
+    );
 }
 
 // ============================================================
@@ -549,16 +589,23 @@ fn streaming_jsonl_to_csv_chunk_size() {
         .args([
             "convert",
             jsonl.to_str().unwrap(),
-            "--from", "jsonl",
-            "-f", "csv",
-            "--chunk-size", "100",
-            "-o", out.to_str().unwrap(),
+            "--from",
+            "jsonl",
+            "-f",
+            "csv",
+            "--chunk-size",
+            "100",
+            "-o",
+            out.to_str().unwrap(),
         ])
         .assert()
         .success();
 
     let content = fs::read_to_string(&out).unwrap();
-    assert!(content.contains("id,name,value"), "CSV header should be present");
+    assert!(
+        content.contains("id,name,value"),
+        "CSV header should be present"
+    );
     assert!(content.contains("user0"), "first record should be present");
     assert!(content.contains("user499"), "last record should be present");
 }
@@ -574,10 +621,14 @@ fn streaming_csv_to_jsonl_chunk_size() {
         .args([
             "convert",
             csv.to_str().unwrap(),
-            "--from", "csv",
-            "-f", "jsonl",
-            "--chunk-size", "50",
-            "-o", out.to_str().unwrap(),
+            "--from",
+            "csv",
+            "-f",
+            "jsonl",
+            "--chunk-size",
+            "50",
+            "-o",
+            out.to_str().unwrap(),
         ])
         .assert()
         .success();
@@ -598,10 +649,14 @@ fn streaming_large_csv_to_csv() {
         .args([
             "convert",
             csv.to_str().unwrap(),
-            "--from", "csv",
-            "-f", "csv",
-            "--chunk-size", "200",
-            "-o", out.to_str().unwrap(),
+            "--from",
+            "csv",
+            "-f",
+            "csv",
+            "--chunk-size",
+            "200",
+            "-o",
+            out.to_str().unwrap(),
         ])
         .assert()
         .success();
@@ -622,10 +677,14 @@ fn streaming_parquet_to_csv_chunk_size() {
         .args([
             "convert",
             pq.to_str().unwrap(),
-            "--from", "parquet",
-            "-f", "csv",
-            "--chunk-size", "2",
-            "-o", out.to_str().unwrap(),
+            "--from",
+            "parquet",
+            "-f",
+            "csv",
+            "--chunk-size",
+            "2",
+            "-o",
+            out.to_str().unwrap(),
         ])
         .assert()
         .success();
@@ -677,7 +736,10 @@ fn query_func_length_string() {
         .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("5"), "length of 'Alice' should be 5, got: {stdout}");
+    assert!(
+        stdout.contains("5"),
+        "length of 'Alice' should be 5, got: {stdout}"
+    );
 }
 
 #[test]
@@ -707,7 +769,10 @@ fn query_func_round() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     // Bob's score is 92, round(92) = 92
-    assert!(stdout.contains("92"), "round(92) should be 92, got: {stdout}");
+    assert!(
+        stdout.contains("92"),
+        "round(92) should be 92, got: {stdout}"
+    );
 }
 
 #[test]
@@ -802,8 +867,11 @@ fn query_func_nested_upper_trim() {
 fn query_func_coalesce() {
     let dir = TempDir::new().unwrap();
     let json = dir.path().join("data.json");
-    fs::write(&json, r#"[{"name":"Alice","email":null},{"name":"Bob","email":"bob@example.com"}]"#)
-        .unwrap();
+    fs::write(
+        &json,
+        r#"[{"name":"Alice","email":null},{"name":"Bob","email":"bob@example.com"}]"#,
+    )
+    .unwrap();
 
     dkit()
         .args([
@@ -896,13 +964,27 @@ fn parquet_roundtrip_via_csv() {
 
     // parquet → csv
     dkit()
-        .args(["convert", pq1.to_str().unwrap(), "-f", "csv", "-o", csv.to_str().unwrap()])
+        .args([
+            "convert",
+            pq1.to_str().unwrap(),
+            "-f",
+            "csv",
+            "-o",
+            csv.to_str().unwrap(),
+        ])
         .assert()
         .success();
 
     // csv → parquet
     dkit()
-        .args(["convert", csv.to_str().unwrap(), "-f", "parquet", "-o", pq2.to_str().unwrap()])
+        .args([
+            "convert",
+            csv.to_str().unwrap(),
+            "-f",
+            "parquet",
+            "-o",
+            pq2.to_str().unwrap(),
+        ])
         .assert()
         .success();
 

--- a/tests/v070_integration_test.rs
+++ b/tests/v070_integration_test.rs
@@ -1,0 +1,916 @@
+//! v0.7.0 통합 테스트: Parquet 읽기/쓰기, 집계 함수, GROUP BY, 스트리밍, 쿼리 함수
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// ============================================================
+// Parquet 다양한 스키마 및 압축 테스트
+// ============================================================
+
+/// 다양한 타입(int, float, string, bool, null 포함)의 Parquet 파일 생성
+fn create_typed_parquet(path: &std::path::Path) {
+    use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use std::sync::Arc;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("score", DataType::Float64, true),
+        Field::new("active", DataType::Boolean, false),
+        Field::new("category", DataType::Utf8, true),
+    ]));
+
+    let ids: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5]));
+    let names: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "Diana", "Eve"]));
+    let scores: ArrayRef = Arc::new(Float64Array::from(vec![
+        Some(85.0),
+        Some(92.5),
+        Some(78.3),
+        None,
+        Some(91.0),
+    ]));
+    let actives: ArrayRef = Arc::new(BooleanArray::from(vec![true, false, true, true, false]));
+    let categories: ArrayRef = Arc::new(StringArray::from(vec![
+        Some("A"),
+        Some("B"),
+        Some("A"),
+        Some("B"),
+        None,
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![ids, names, scores, actives, categories],
+    )
+    .unwrap();
+
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+/// SNAPPY 압축으로 Parquet 파일 생성
+fn create_snappy_parquet(path: &std::path::Path) {
+    use arrow::array::{ArrayRef, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use parquet::basic::Compression;
+    use parquet::file::properties::WriterProperties;
+    use std::sync::Arc;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Utf8, false),
+    ]));
+
+    let ids: ArrayRef = Arc::new(Int64Array::from(vec![10, 20, 30]));
+    let values: ArrayRef = Arc::new(StringArray::from(vec!["x", "y", "z"]));
+
+    let batch = RecordBatch::try_new(schema.clone(), vec![ids, values]).unwrap();
+
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, Some(props)).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+/// ZSTD 압축으로 Parquet 파일 생성
+fn create_zstd_parquet(path: &std::path::Path) {
+    use arrow::array::{ArrayRef, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use parquet::basic::{Compression, ZstdLevel};
+    use parquet::file::properties::WriterProperties;
+    use std::sync::Arc;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Utf8, false),
+    ]));
+
+    let ids: ArrayRef = Arc::new(Int64Array::from(vec![100, 200, 300]));
+    let values: ArrayRef = Arc::new(StringArray::from(vec!["foo", "bar", "baz"]));
+
+    let batch = RecordBatch::try_new(schema.clone(), vec![ids, values]).unwrap();
+
+    let props = WriterProperties::builder()
+        .set_compression(Compression::ZSTD(ZstdLevel::default()))
+        .build();
+
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, Some(props)).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+#[test]
+fn parquet_various_types_to_json() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    create_typed_parquet(&pq);
+
+    dkit()
+        .args(["convert", pq.to_str().unwrap(), "-f", "json", "--compact"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("92.5"))
+        .stdout(predicate::str::contains("null"))
+        .stdout(predicate::str::contains("true"))
+        .stdout(predicate::str::contains("false"));
+}
+
+#[test]
+fn parquet_various_types_to_csv() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    create_typed_parquet(&pq);
+
+    dkit()
+        .args(["convert", pq.to_str().unwrap(), "-f", "csv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("id,name,score,active,category"))
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("85"));
+}
+
+#[test]
+fn parquet_snappy_compression_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("snappy.parquet");
+    create_snappy_parquet(&pq);
+
+    dkit()
+        .args(["convert", pq.to_str().unwrap(), "-f", "json", "--compact"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("10"))
+        .stdout(predicate::str::contains("x"))
+        .stdout(predicate::str::contains("y"))
+        .stdout(predicate::str::contains("z"));
+}
+
+#[test]
+fn parquet_zstd_compression_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("zstd.parquet");
+    create_zstd_parquet(&pq);
+
+    dkit()
+        .args(["convert", pq.to_str().unwrap(), "-f", "json", "--compact"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("100"))
+        .stdout(predicate::str::contains("foo"))
+        .stdout(predicate::str::contains("bar"));
+}
+
+#[test]
+fn json_to_parquet_with_snappy_compression() {
+    let dir = TempDir::new().unwrap();
+    let json_path = dir.path().join("data.json");
+    let pq_path = dir.path().join("out.parquet");
+
+    fs::write(&json_path, r#"[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]"#).unwrap();
+
+    dkit()
+        .args([
+            "convert",
+            json_path.to_str().unwrap(),
+            "-f", "parquet",
+            "-o", pq_path.to_str().unwrap(),
+            "--compression", "snappy",
+        ])
+        .assert()
+        .success();
+
+    let bytes = fs::read(&pq_path).unwrap();
+    assert!(bytes.starts_with(b"PAR1"), "output should be Parquet");
+}
+
+#[test]
+fn json_to_parquet_with_zstd_compression() {
+    let dir = TempDir::new().unwrap();
+    let json_path = dir.path().join("data.json");
+    let pq_path = dir.path().join("out.parquet");
+
+    fs::write(&json_path, r#"[{"id":1,"val":10.5},{"id":2,"val":20.0}]"#).unwrap();
+
+    dkit()
+        .args([
+            "convert",
+            json_path.to_str().unwrap(),
+            "-f", "parquet",
+            "-o", pq_path.to_str().unwrap(),
+            "--compression", "zstd",
+        ])
+        .assert()
+        .success();
+
+    let bytes = fs::read(&pq_path).unwrap();
+    assert!(bytes.starts_with(b"PAR1"), "output should be Parquet");
+}
+
+#[test]
+fn parquet_null_values_preserved_in_csv() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    create_typed_parquet(&pq);
+
+    // Diana's score is null → should appear as empty in CSV
+    let output = dkit()
+        .args(["convert", pq.to_str().unwrap(), "-f", "csv"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Diana"), "Diana should be present");
+}
+
+#[test]
+fn parquet_schema_detection() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    create_typed_parquet(&pq);
+
+    dkit()
+        .args(["schema", pq.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("id"))
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("score"))
+        .stdout(predicate::str::contains("active"))
+        .stdout(predicate::str::contains("category"));
+}
+
+#[test]
+fn parquet_stats_output() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    create_typed_parquet(&pq);
+
+    dkit()
+        .args(["stats", pq.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rows: 5"))
+        .stdout(predicate::str::contains("name"));
+}
+
+// ============================================================
+// 집계 함수 테스트 (count, sum, avg, min, max, distinct)
+// ============================================================
+
+#[test]
+fn aggregate_count_all() {
+    dkit()
+        .args(["query", "tests/fixtures/employees.json", ".[] | count"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("5"));
+}
+
+#[test]
+fn aggregate_sum_field() {
+    let output = dkit()
+        .args(["query", "tests/fixtures/employees.json", ".[] | sum score"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // 85 + 92 + 78 + 95 + 88 = 438
+    assert!(stdout.contains("438"), "sum of scores should be 438, got: {stdout}");
+}
+
+#[test]
+fn aggregate_avg_field() {
+    let output = dkit()
+        .args(["query", "tests/fixtures/employees.json", ".[] | avg score"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // avg = 438 / 5 = 87.6
+    assert!(stdout.contains("87.6"), "avg score should be 87.6, got: {stdout}");
+}
+
+#[test]
+fn aggregate_min_numeric() {
+    dkit()
+        .args(["query", "tests/fixtures/employees.json", ".[] | min score"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("78"));
+}
+
+#[test]
+fn aggregate_max_numeric() {
+    dkit()
+        .args(["query", "tests/fixtures/employees.json", ".[] | max score"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("95"));
+}
+
+#[test]
+fn aggregate_min_string() {
+    dkit()
+        .args(["query", "tests/fixtures/employees.json", ".[] | min name"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+}
+
+#[test]
+fn aggregate_max_string() {
+    dkit()
+        .args(["query", "tests/fixtures/employees.json", ".[] | max name"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Eve"));
+}
+
+#[test]
+fn aggregate_distinct_field() {
+    let output = dkit()
+        .args(["query", "tests/fixtures/employees.json", ".[] | distinct city"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Seoul"));
+    assert!(stdout.contains("Busan"));
+    assert!(stdout.contains("Incheon"));
+}
+
+#[test]
+fn aggregate_count_after_filter() {
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where city == \"Seoul\" | count",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("3"));
+}
+
+#[test]
+fn aggregate_sum_after_filter() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where role == \"engineer\" | sum score",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Alice(85) + Diana(95) + Eve(88) = 268
+    assert!(stdout.contains("268"), "sum of engineer scores should be 268, got: {stdout}");
+}
+
+#[test]
+fn aggregate_avg_after_filter() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where age > 30 | avg score",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    // Charlie(78) + Eve(88) = 166 / 2 = 83.0
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("83"), "avg score for age>30 should be 83, got: {stdout}");
+}
+
+// ============================================================
+// GROUP BY 테스트
+// ============================================================
+
+#[test]
+fn group_by_single_field_count() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | group_by city count()",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Seoul: 3, Busan: 1, Incheon: 1
+    assert!(stdout.contains("Seoul"), "Seoul group should appear");
+    assert!(stdout.contains("3"), "Seoul count should be 3");
+    assert!(stdout.contains("Busan"), "Busan group should appear");
+}
+
+#[test]
+fn group_by_with_sum() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | group_by role count(), sum(score)",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("engineer"), "engineer group should appear");
+    assert!(stdout.contains("manager"), "manager group should appear");
+    assert!(stdout.contains("designer"), "designer group should appear");
+}
+
+#[test]
+fn group_by_with_avg() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | group_by role avg(score)",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("engineer"));
+}
+
+#[test]
+fn group_by_with_min_max() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | group_by city min(score), max(score)",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Seoul"));
+    assert!(stdout.contains("Busan"));
+}
+
+#[test]
+fn group_by_result_sortable() {
+    // GROUP BY 후 sort 적용
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | group_by city count() | sort count desc",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Seoul(3) 이 먼저 나와야 함
+    let seoul_pos = stdout.find("Seoul").unwrap();
+    let busan_pos = stdout.find("Busan").unwrap();
+    assert!(seoul_pos < busan_pos, "Seoul (count=3) should come before Busan (count=1)");
+}
+
+#[test]
+fn group_by_having_filter() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | group_by city count() having count > 1",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Seoul"), "Seoul (count=3) should pass having count>1");
+    assert!(!stdout.contains("Busan"), "Busan (count=1) should be filtered out");
+    assert!(!stdout.contains("Incheon"), "Incheon (count=1) should be filtered out");
+}
+
+// ============================================================
+// 스트리밍 처리 테스트 (--chunk-size)
+// ============================================================
+
+fn create_large_jsonl(path: &std::path::Path, n: usize) {
+    let mut content = String::new();
+    for i in 0..n {
+        content.push_str(&format!(
+            "{{\"id\":{},\"name\":\"user{}\",\"value\":{}}}\n",
+            i,
+            i,
+            i * 10
+        ));
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn create_large_csv(path: &std::path::Path, n: usize) {
+    let mut content = String::from("id,name,value\n");
+    for i in 0..n {
+        content.push_str(&format!("{},user{},{}\n", i, i, i * 10));
+    }
+    fs::write(path, content).unwrap();
+}
+
+#[test]
+fn streaming_jsonl_to_csv_chunk_size() {
+    let dir = TempDir::new().unwrap();
+    let jsonl = dir.path().join("large.jsonl");
+    let out = dir.path().join("out.csv");
+    create_large_jsonl(&jsonl, 500);
+
+    dkit()
+        .args([
+            "convert",
+            jsonl.to_str().unwrap(),
+            "--from", "jsonl",
+            "-f", "csv",
+            "--chunk-size", "100",
+            "-o", out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out).unwrap();
+    assert!(content.contains("id,name,value"), "CSV header should be present");
+    assert!(content.contains("user0"), "first record should be present");
+    assert!(content.contains("user499"), "last record should be present");
+}
+
+#[test]
+fn streaming_csv_to_jsonl_chunk_size() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("large.csv");
+    let out = dir.path().join("out.jsonl");
+    create_large_csv(&csv, 300);
+
+    dkit()
+        .args([
+            "convert",
+            csv.to_str().unwrap(),
+            "--from", "csv",
+            "-f", "jsonl",
+            "--chunk-size", "50",
+            "-o", out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out).unwrap();
+    let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 300, "should have 300 JSONL records");
+}
+
+#[test]
+fn streaming_large_csv_to_csv() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("large.csv");
+    let out = dir.path().join("out.csv");
+    create_large_csv(&csv, 1000);
+
+    dkit()
+        .args([
+            "convert",
+            csv.to_str().unwrap(),
+            "--from", "csv",
+            "-f", "csv",
+            "--chunk-size", "200",
+            "-o", out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out).unwrap();
+    let data_lines: Vec<&str> = content.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert_eq!(data_lines.len(), 1000, "should have 1000 data rows");
+}
+
+#[test]
+fn streaming_parquet_to_csv_chunk_size() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    let out = dir.path().join("out.csv");
+    create_typed_parquet(&pq);
+
+    dkit()
+        .args([
+            "convert",
+            pq.to_str().unwrap(),
+            "--from", "parquet",
+            "-f", "csv",
+            "--chunk-size", "2",
+            "-o", out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&out).unwrap();
+    assert!(content.contains("Alice"));
+    assert!(content.contains("Eve"));
+}
+
+// ============================================================
+// 쿼리 내장 함수 테스트
+// ============================================================
+
+#[test]
+fn query_func_upper() {
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Alice\" | select upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"));
+}
+
+#[test]
+fn query_func_lower() {
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Bob\" | select lower(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("bob"));
+}
+
+#[test]
+fn query_func_length_string() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Alice\" | select length(name)",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("5"), "length of 'Alice' should be 5, got: {stdout}");
+}
+
+#[test]
+fn query_func_upper_with_alias() {
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Alice\" | select upper(name) as NAME",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("NAME"))
+        .stdout(predicate::str::contains("ALICE"));
+}
+
+#[test]
+fn query_func_round() {
+    let output = dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Bob\" | select round(score)",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Bob's score is 92, round(92) = 92
+    assert!(stdout.contains("92"), "round(92) should be 92, got: {stdout}");
+}
+
+#[test]
+fn query_func_to_string() {
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Alice\" | select to_string(age)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("30"));
+}
+
+#[test]
+fn query_func_to_int() {
+    // CSV 에서 문자열로 읽힌 숫자를 정수 변환
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("data.csv");
+    fs::write(&csv, "name,score\nAlice,85\nBob,92\n").unwrap();
+
+    dkit()
+        .args([
+            "query",
+            csv.to_str().unwrap(),
+            ".[] | where name == \"Alice\" | select to_int(score)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("85"));
+}
+
+#[test]
+fn query_func_concat() {
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Alice\" | select concat(name, \"-\", city)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice-Seoul"));
+}
+
+#[test]
+fn query_func_substr() {
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Charlie\" | select substr(name, 0, 4)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Char"));
+}
+
+#[test]
+fn query_func_multiple_funcs_in_select() {
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name == \"Alice\" | select upper(name), to_string(age)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("30"));
+}
+
+#[test]
+fn query_func_nested_upper_trim() {
+    let dir = TempDir::new().unwrap();
+    let json = dir.path().join("data.json");
+    fs::write(&json, r#"[{"name":"  alice  "}]"#).unwrap();
+
+    dkit()
+        .args([
+            "query",
+            json.to_str().unwrap(),
+            ".[] | select upper(trim(name))",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"));
+}
+
+#[test]
+fn query_func_coalesce() {
+    let dir = TempDir::new().unwrap();
+    let json = dir.path().join("data.json");
+    fs::write(&json, r#"[{"name":"Alice","email":null},{"name":"Bob","email":"bob@example.com"}]"#)
+        .unwrap();
+
+    dkit()
+        .args([
+            "query",
+            json.to_str().unwrap(),
+            ".[] | select name, coalesce(email, \"N/A\")",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("N/A"))
+        .stdout(predicate::str::contains("bob@example.com"));
+}
+
+#[test]
+fn query_func_with_where_filter() {
+    // 함수 결과가 where 절과 조합하여 올바르게 동작하는지 검증
+    dkit()
+        .args([
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where role == \"engineer\" | select upper(name), score | sort score desc",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DIANA"))
+        .stdout(predicate::str::contains("EVE"))
+        .stdout(predicate::str::contains("ALICE"));
+}
+
+// ============================================================
+// Parquet + 쿼리 통합 테스트
+// ============================================================
+
+#[test]
+fn parquet_query_with_aggregate() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    create_typed_parquet(&pq);
+
+    dkit()
+        .args(["query", pq.to_str().unwrap(), ".[] | count"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("5"));
+}
+
+#[test]
+fn parquet_query_with_filter_and_aggregate() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    create_typed_parquet(&pq);
+
+    dkit()
+        .args([
+            "query",
+            pq.to_str().unwrap(),
+            ".[] | where active == true | count",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("3"));
+}
+
+#[test]
+fn parquet_query_func_upper() {
+    let dir = TempDir::new().unwrap();
+    let pq = dir.path().join("typed.parquet");
+    create_typed_parquet(&pq);
+
+    dkit()
+        .args([
+            "query",
+            pq.to_str().unwrap(),
+            ".[] | where name == \"Alice\" | select upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"));
+}
+
+#[test]
+fn parquet_roundtrip_via_csv() {
+    // parquet → csv → parquet → json 라운드트립
+    let dir = TempDir::new().unwrap();
+    let pq1 = dir.path().join("orig.parquet");
+    let csv = dir.path().join("mid.csv");
+    let pq2 = dir.path().join("out.parquet");
+
+    create_typed_parquet(&pq1);
+
+    // parquet → csv
+    dkit()
+        .args(["convert", pq1.to_str().unwrap(), "-f", "csv", "-o", csv.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // csv → parquet
+    dkit()
+        .args(["convert", csv.to_str().unwrap(), "-f", "parquet", "-o", pq2.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // parquet → json (verify round-trip)
+    dkit()
+        .args(["convert", pq2.to_str().unwrap(), "-f", "json", "--compact"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}


### PR DESCRIPTION
## Summary

- v0.7.0 신규 기능에 대한 통합 테스트 47개 추가 (`tests/v070_integration_test.rs`)
- README.md에 v0.7.0 기능 문서 추가

## 변경 내용

### 테스트 (`tests/v070_integration_test.rs`)

- **Parquet 읽기/쓰기**: 다양한 스키마(int/float/string/bool/null), Snappy·Zstd 압축, 라운드트립 검증
- **집계 함수**: count, sum, avg, min, max, distinct — 필터(`where`) 조합 포함
- **GROUP BY**: count/sum/avg/min/max 집계, `having` 필터, 후속 sort/limit 조합
- **스트리밍 처리**: `--chunk-size` 옵션으로 JSONL→CSV, CSV→JSONL, 대용량 CSV 변환
- **쿼리 내장 함수**: upper, lower, length, concat, substr, coalesce, to_int, nested 함수 호출
- **Parquet + 쿼리 통합**: 집계, 필터, 함수 조합, Parquet 라운드트립

### 문서 (`README.md`)

- Parquet 포맷 지원 표에 추가
- `convert` 섹션: Parquet 변환 예제, 스트리밍(`--chunk-size`) 예제 추가
- `query` 섹션: 집계 함수 표, GROUP BY 예제, 내장 함수 표 추가
- 비교 테이블: Parquet, 집계 함수, GROUP BY, 스트리밍 항목 추가

## Test plan

- [ ] `cargo test --test v070_integration_test` — 47개 모두 통과 확인
- [ ] `cargo test` — 전체 테스트 통과 확인

Closes #98

https://claude.ai/code/session_012eArNigY6czjuCCLocAWqm