### PR TITLE
feat(diff): diff 서브커맨드 고도화 - 비교 모드, 출력 포맷, 배열 전략

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -467,7 +467,7 @@ pub enum Commands {
 
     /// Compare two data files and show differences
     #[command(
-        after_help = "Examples:\n  dkit diff old.json new.json\n  dkit diff config_dev.yaml config_prod.yaml\n  dkit diff data.json data.yaml\n  dkit diff old.json new.json --path '.database'\n  dkit diff a.json b.json --quiet && echo 'same' || echo 'different'"
+        after_help = "Examples:\n  dkit diff old.json new.json\n  dkit diff config_dev.yaml config_prod.yaml\n  dkit diff data.json data.yaml\n  dkit diff old.json new.json --path '.database'\n  dkit diff a.json b.json --quiet && echo 'same' || echo 'different'\n  dkit diff a.json b.json --mode value --diff-format json\n  dkit diff a.json b.json --array-diff key=id --ignore-order"
     )]
     Diff {
         /// First input file
@@ -485,6 +485,26 @@ pub enum Commands {
         /// Only report whether files differ (exit code: 0=same, 1=different)
         #[arg(long)]
         quiet: bool,
+
+        /// Comparison mode: structural (added/removed/changed), value (value changes only), key (key existence only)
+        #[arg(long, value_name = "MODE", default_value = "structural")]
+        mode: String,
+
+        /// Diff output format: unified, side-by-side, json, summary
+        #[arg(long, value_name = "FORMAT", default_value = "unified")]
+        diff_format: String,
+
+        /// Array comparison strategy: index (by position), value (by value), key=<field> (by key field)
+        #[arg(long, value_name = "STRATEGY", default_value = "index")]
+        array_diff: String,
+
+        /// Ignore array element order when comparing
+        #[arg(long)]
+        ignore_order: bool,
+
+        /// Ignore string case when comparing
+        #[arg(long)]
+        ignore_case: bool,
 
         /// Input file encoding (e.g. euc-kr, shift_jis, latin1)
         #[arg(long, value_name = "ENCODING")]

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -17,14 +17,91 @@ use crate::format::yaml::YamlReader;
 use crate::format::{default_delimiter, detect_format, Format, FormatOptions, FormatReader};
 use crate::value::Value;
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum DiffMode {
+    Structural,
+    Value,
+    Key,
+}
+
+impl DiffMode {
+    pub fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "structural" => Ok(DiffMode::Structural),
+            "value" => Ok(DiffMode::Value),
+            "key" => Ok(DiffMode::Key),
+            other => bail!("Unknown diff mode: '{other}'. Valid modes: structural, value, key"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DiffOutputFormat {
+    Unified,
+    SideBySide,
+    Json,
+    Summary,
+}
+
+impl DiffOutputFormat {
+    pub fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "unified" => Ok(DiffOutputFormat::Unified),
+            "side-by-side" | "sidebyside" => Ok(DiffOutputFormat::SideBySide),
+            "json" => Ok(DiffOutputFormat::Json),
+            "summary" => Ok(DiffOutputFormat::Summary),
+            other => bail!(
+                "Unknown diff format: '{other}'. Valid formats: unified, side-by-side, json, summary"
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ArrayDiffStrategy {
+    Index,
+    Value,
+    Key(String),
+}
+
+impl ArrayDiffStrategy {
+    pub fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "index" => Ok(ArrayDiffStrategy::Index),
+            "value" => Ok(ArrayDiffStrategy::Value),
+            _ if s.starts_with("key=") => {
+                let field = s.strip_prefix("key=").unwrap();
+                if field.is_empty() {
+                    bail!("key= strategy requires a field name, e.g. --array-diff key=id");
+                }
+                Ok(ArrayDiffStrategy::Key(field.to_string()))
+            }
+            other => bail!(
+                "Unknown array-diff strategy: '{other}'. Valid options: index, value, key=<field>"
+            ),
+        }
+    }
+}
+
 pub struct DiffArgs<'a> {
     pub file1: &'a Path,
     pub file2: &'a Path,
     pub path: Option<&'a str>,
     pub quiet: bool,
+    pub mode: DiffMode,
+    pub diff_format: DiffOutputFormat,
+    pub array_diff: ArrayDiffStrategy,
+    pub ignore_order: bool,
+    pub ignore_case: bool,
     pub encoding_opts: EncodingOptions,
     pub excel_opts: ExcelOptions,
     pub sqlite_opts: SqliteOptions,
+}
+
+struct DiffOptions<'a> {
+    array_diff: &'a ArrayDiffStrategy,
+    ignore_order: bool,
+    ignore_case: bool,
 }
 
 /// diff 서브커맨드 실행. 차이가 있으면 true, 없으면 false 반환.
@@ -42,7 +119,6 @@ pub fn run(args: &DiffArgs) -> Result<bool> {
         &args.sqlite_opts,
     )?;
 
-    // --path 옵션으로 중첩 데이터 접근
     let (v1, v2) = match args.path {
         Some(path_expr) => (
             resolve_path(&value1, path_expr)?,
@@ -51,7 +127,32 @@ pub fn run(args: &DiffArgs) -> Result<bool> {
         None => (value1, value2),
     };
 
-    if v1 == v2 {
+    let opts = DiffOptions {
+        array_diff: &args.array_diff,
+        ignore_order: args.ignore_order,
+        ignore_case: args.ignore_case,
+    };
+
+    let all_diffs = compute_diff("", &v1, &v2, &opts);
+
+    // Filter entries based on mode
+    let display_entries: Vec<&DiffEntry> = match args.mode {
+        DiffMode::Structural => all_diffs.iter().collect(),
+        DiffMode::Value => all_diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Changed { .. }))
+            .collect(),
+        DiffMode::Key => all_diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Added { .. } | DiffEntry::Removed { .. }))
+            .collect(),
+    };
+
+    let has_diff = display_entries
+        .iter()
+        .any(|d| !matches!(d, DiffEntry::Unchanged { .. }));
+
+    if !has_diff {
         if !args.quiet {
             println!("No differences found.");
         }
@@ -62,10 +163,11 @@ pub fn run(args: &DiffArgs) -> Result<bool> {
         return Ok(true);
     }
 
-    // 차이 출력
-    let diffs = compute_diff("", &v1, &v2);
-    for entry in &diffs {
-        print_diff_entry(entry);
+    match args.diff_format {
+        DiffOutputFormat::Unified => print_unified(&display_entries),
+        DiffOutputFormat::SideBySide => print_side_by_side(&display_entries),
+        DiffOutputFormat::Json => print_json_format(&display_entries)?,
+        DiffOutputFormat::Summary => print_summary(&display_entries),
     }
 
     Ok(true)
@@ -203,14 +305,17 @@ enum DiffEntry {
     },
 }
 
-/// 두 Value 간 재귀적 비교. path_prefix는 현재까지의 경로 문자열.
-fn compute_diff(path_prefix: &str, left: &Value, right: &Value) -> Vec<DiffEntry> {
+/// 두 Value 간 재귀적 비교
+fn compute_diff(
+    path_prefix: &str,
+    left: &Value,
+    right: &Value,
+    opts: &DiffOptions,
+) -> Vec<DiffEntry> {
     let mut entries = Vec::new();
 
     match (left, right) {
-        // 두 Object 비교
         (Value::Object(map1), Value::Object(map2)) => {
-            // map1에 있는 키들
             for (key, v1) in map1 {
                 let child_path = if path_prefix.is_empty() {
                     key.clone()
@@ -220,14 +325,13 @@ fn compute_diff(path_prefix: &str, left: &Value, right: &Value) -> Vec<DiffEntry
 
                 match map2.get(key) {
                     Some(v2) => {
-                        entries.extend(compute_diff(&child_path, v1, v2));
+                        entries.extend(compute_diff(&child_path, v1, v2, opts));
                     }
                     None => {
                         entries.extend(collect_removed(&child_path, v1));
                     }
                 }
             }
-            // map2에만 있는 키들 (added)
             for (key, v2) in map2 {
                 if !map1.contains_key(key) {
                     let child_path = if path_prefix.is_empty() {
@@ -239,28 +343,46 @@ fn compute_diff(path_prefix: &str, left: &Value, right: &Value) -> Vec<DiffEntry
                 }
             }
         }
-        // 두 Array 비교 (인덱스 기반)
         (Value::Array(arr1), Value::Array(arr2)) => {
-            let max_len = arr1.len().max(arr2.len());
-            for i in 0..max_len {
-                let child_path = format!("{path_prefix}[{i}]");
-                match (arr1.get(i), arr2.get(i)) {
-                    (Some(v1), Some(v2)) => {
-                        entries.extend(compute_diff(&child_path, v1, v2));
-                    }
-                    (Some(v1), None) => {
-                        entries.extend(collect_removed(&child_path, v1));
-                    }
-                    (None, Some(v2)) => {
-                        entries.extend(collect_added(&child_path, v2));
-                    }
-                    (None, None) => unreachable!(),
+            let arr1_cmp = if opts.ignore_order {
+                let mut s = arr1.clone();
+                s.sort_by_key(|a| a.to_string());
+                s
+            } else {
+                arr1.clone()
+            };
+            let arr2_cmp = if opts.ignore_order {
+                let mut s = arr2.clone();
+                s.sort_by_key(|a| a.to_string());
+                s
+            } else {
+                arr2.clone()
+            };
+
+            match opts.array_diff {
+                ArrayDiffStrategy::Index => {
+                    entries.extend(compare_arrays_index(
+                        path_prefix,
+                        &arr1_cmp,
+                        &arr2_cmp,
+                        opts,
+                    ));
+                }
+                ArrayDiffStrategy::Value => {
+                    entries.extend(compare_arrays_value(
+                        path_prefix,
+                        &arr1_cmp,
+                        &arr2_cmp,
+                        opts,
+                    ));
+                }
+                ArrayDiffStrategy::Key(ref field) => {
+                    entries.extend(compare_arrays_key(path_prefix, arr1, arr2, field, opts));
                 }
             }
         }
-        // 스칼라 값 비교
         _ => {
-            if left == right {
+            if values_equal(left, right, opts.ignore_case) {
                 entries.push(DiffEntry::Unchanged {
                     path: path_prefix.to_string(),
                     value: format_scalar(left),
@@ -276,6 +398,138 @@ fn compute_diff(path_prefix: &str, left: &Value, right: &Value) -> Vec<DiffEntry
     }
 
     entries
+}
+
+/// 인덱스 기반 배열 비교
+fn compare_arrays_index(
+    path_prefix: &str,
+    arr1: &[Value],
+    arr2: &[Value],
+    opts: &DiffOptions,
+) -> Vec<DiffEntry> {
+    let mut entries = Vec::new();
+    let max_len = arr1.len().max(arr2.len());
+    for i in 0..max_len {
+        let child_path = format!("{path_prefix}[{i}]");
+        match (arr1.get(i), arr2.get(i)) {
+            (Some(v1), Some(v2)) => {
+                entries.extend(compute_diff(&child_path, v1, v2, opts));
+            }
+            (Some(v1), None) => {
+                entries.extend(collect_removed(&child_path, v1));
+            }
+            (None, Some(v2)) => {
+                entries.extend(collect_added(&child_path, v2));
+            }
+            (None, None) => unreachable!(),
+        }
+    }
+    entries
+}
+
+/// 값 기반 배열 비교 (순서 무관, 집합처럼 비교)
+fn compare_arrays_value(
+    path_prefix: &str,
+    arr1: &[Value],
+    arr2: &[Value],
+    opts: &DiffOptions,
+) -> Vec<DiffEntry> {
+    let mut entries = Vec::new();
+    let mut matched2 = vec![false; arr2.len()];
+
+    for v1 in arr1 {
+        let found = arr2
+            .iter()
+            .enumerate()
+            .find(|(j, v2)| !matched2[*j] && values_equal(v1, v2, opts.ignore_case));
+        match found {
+            Some((j, _)) => {
+                matched2[j] = true;
+                entries.push(DiffEntry::Unchanged {
+                    path: path_prefix.to_string(),
+                    value: format_scalar(v1),
+                });
+            }
+            None => {
+                entries.push(DiffEntry::Removed {
+                    path: path_prefix.to_string(),
+                    value: format_scalar(v1),
+                });
+            }
+        }
+    }
+
+    for (j, v2) in arr2.iter().enumerate() {
+        if !matched2[j] {
+            entries.push(DiffEntry::Added {
+                path: path_prefix.to_string(),
+                value: format_scalar(v2),
+            });
+        }
+    }
+
+    entries
+}
+
+/// 키 필드 기반 배열 비교 (지정한 필드값으로 매칭)
+fn compare_arrays_key(
+    path_prefix: &str,
+    arr1: &[Value],
+    arr2: &[Value],
+    key_field: &str,
+    opts: &DiffOptions,
+) -> Vec<DiffEntry> {
+    let mut entries = Vec::new();
+    let mut matched2 = vec![false; arr2.len()];
+
+    for (i, v1) in arr1.iter().enumerate() {
+        let key1 = get_key_value(v1, key_field);
+        let match_idx = arr2.iter().enumerate().position(|(j, v2)| {
+            !matched2[j] && key1.is_some() && get_key_value(v2, key_field) == key1
+        });
+
+        match match_idx {
+            Some(j) => {
+                matched2[j] = true;
+                let item_key = key1.unwrap_or_else(|| i.to_string());
+                let item_path = format!("{path_prefix}[{key_field}={item_key}]");
+                entries.extend(compute_diff(&item_path, v1, &arr2[j], opts));
+            }
+            None => {
+                let item_path = format!("{path_prefix}[{i}]");
+                entries.extend(collect_removed(&item_path, v1));
+            }
+        }
+    }
+
+    for (j, v2) in arr2.iter().enumerate() {
+        if !matched2[j] {
+            let item_path = format!("{path_prefix}[{}]", j);
+            entries.extend(collect_added(&item_path, v2));
+        }
+    }
+
+    entries
+}
+
+/// 두 Value가 같은지 비교 (ignore_case 옵션 고려)
+fn values_equal(left: &Value, right: &Value, ignore_case: bool) -> bool {
+    if ignore_case {
+        match (left, right) {
+            (Value::String(s1), Value::String(s2)) => s1.to_lowercase() == s2.to_lowercase(),
+            _ => left == right,
+        }
+    } else {
+        left == right
+    }
+}
+
+/// 객체에서 키 필드의 값을 문자열로 가져오기
+fn get_key_value(value: &Value, key_field: &str) -> Option<String> {
+    match value {
+        Value::Object(map) => map.get(key_field).map(format_scalar),
+        _ => None,
+    }
 }
 
 /// 삭제된 Value의 모든 리프 노드를 DiffEntry::Removed로 수집
@@ -343,23 +597,178 @@ fn format_scalar(value: &Value) -> String {
     }
 }
 
-/// diff 엔트리를 컬러로 출력
-fn print_diff_entry(entry: &DiffEntry) {
-    match entry {
-        DiffEntry::Unchanged { path, value } => {
-            println!("  {path}: {value} (unchanged)");
-        }
-        DiffEntry::Added { path, value } => {
-            println!("{}", format!("+ {path}: {value} (added)").green());
-        }
-        DiffEntry::Removed { path, value } => {
-            println!("{}", format!("- {path}: {value} (removed)").red());
-        }
-        DiffEntry::Changed { path, old, new } => {
-            println!("{}", format!("- {path}: {old}").red());
-            println!("{}", format!("+ {path}: {new}").yellow());
+// ─── 출력 함수들 ──────────────────────────────────────────────────────────────
+
+/// unified diff 형식 출력 (기본)
+fn print_unified(entries: &[&DiffEntry]) {
+    for entry in entries {
+        match entry {
+            DiffEntry::Unchanged { path, value } => {
+                println!("  {path}: {value} (unchanged)");
+            }
+            DiffEntry::Added { path, value } => {
+                println!("{}", format!("+ {path}: {value} (added)").green());
+            }
+            DiffEntry::Removed { path, value } => {
+                println!("{}", format!("- {path}: {value} (removed)").red());
+            }
+            DiffEntry::Changed { path, old, new } => {
+                println!("{}", format!("- {path}: {old}").red());
+                println!("{}", format!("+ {path}: {new}").yellow());
+            }
         }
     }
+}
+
+/// side-by-side 형식 출력
+fn print_side_by_side(entries: &[&DiffEntry]) {
+    // 컬럼 너비 계산
+    let path_width = entries
+        .iter()
+        .map(|e| match e {
+            DiffEntry::Unchanged { path, .. }
+            | DiffEntry::Added { path, .. }
+            | DiffEntry::Removed { path, .. }
+            | DiffEntry::Changed { path, .. } => path.len(),
+        })
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    let val_width = 24usize;
+
+    // 헤더
+    println!(
+        "{:<path_width$}  {:<val_width$}  {:<val_width$}  STATUS",
+        "PATH",
+        "LEFT",
+        "RIGHT",
+        path_width = path_width,
+        val_width = val_width
+    );
+    println!("{}", "-".repeat(path_width + val_width * 2 + 12));
+
+    for entry in entries {
+        match entry {
+            DiffEntry::Unchanged { path, value } => {
+                println!(
+                    "{:<path_width$}  {:<val_width$}  {:<val_width$}  =",
+                    path,
+                    truncate(value, val_width),
+                    truncate(value, val_width),
+                    path_width = path_width,
+                    val_width = val_width
+                );
+            }
+            DiffEntry::Added { path, value } => {
+                let line = format!(
+                    "{:<path_width$}  {:<val_width$}  {:<val_width$}  +",
+                    path,
+                    "(absent)",
+                    truncate(value, val_width),
+                    path_width = path_width,
+                    val_width = val_width
+                );
+                println!("{}", line.green());
+            }
+            DiffEntry::Removed { path, value } => {
+                let line = format!(
+                    "{:<path_width$}  {:<val_width$}  {:<val_width$}  -",
+                    path,
+                    truncate(value, val_width),
+                    "(absent)",
+                    path_width = path_width,
+                    val_width = val_width
+                );
+                println!("{}", line.red());
+            }
+            DiffEntry::Changed { path, old, new } => {
+                let line = format!(
+                    "{:<path_width$}  {:<val_width$}  {:<val_width$}  ~",
+                    path,
+                    truncate(old, val_width),
+                    truncate(new, val_width),
+                    path_width = path_width,
+                    val_width = val_width
+                );
+                println!("{}", line.yellow());
+            }
+        }
+    }
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max_len.saturating_sub(1)])
+    }
+}
+
+/// JSON 형식 출력
+fn print_json_format(entries: &[&DiffEntry]) -> Result<()> {
+    let mut items = Vec::new();
+    for entry in entries {
+        let obj = match entry {
+            DiffEntry::Unchanged { path, value } => {
+                format!(
+                    r#"{{"path":{},"type":"unchanged","value":{}}}"#,
+                    serde_json::to_string(path)?,
+                    serde_json::to_string(value)?
+                )
+            }
+            DiffEntry::Added { path, value } => {
+                format!(
+                    r#"{{"path":{},"type":"added","value":{}}}"#,
+                    serde_json::to_string(path)?,
+                    serde_json::to_string(value)?
+                )
+            }
+            DiffEntry::Removed { path, value } => {
+                format!(
+                    r#"{{"path":{},"type":"removed","value":{}}}"#,
+                    serde_json::to_string(path)?,
+                    serde_json::to_string(value)?
+                )
+            }
+            DiffEntry::Changed { path, old, new } => {
+                format!(
+                    r#"{{"path":{},"type":"changed","old":{},"new":{}}}"#,
+                    serde_json::to_string(path)?,
+                    serde_json::to_string(old)?,
+                    serde_json::to_string(new)?
+                )
+            }
+        };
+        items.push(obj);
+    }
+    println!("[{}]", items.join(",\n "));
+    Ok(())
+}
+
+/// summary 형식 출력
+fn print_summary(entries: &[&DiffEntry]) {
+    let mut added = 0usize;
+    let mut removed = 0usize;
+    let mut changed = 0usize;
+    let mut unchanged = 0usize;
+
+    for entry in entries {
+        match entry {
+            DiffEntry::Added { .. } => added += 1,
+            DiffEntry::Removed { .. } => removed += 1,
+            DiffEntry::Changed { .. } => changed += 1,
+            DiffEntry::Unchanged { .. } => unchanged += 1,
+        }
+    }
+
+    println!(
+        "Summary: {} added, {} removed, {} changed, {} unchanged",
+        added.to_string().green(),
+        removed.to_string().red(),
+        changed.to_string().yellow(),
+        unchanged
+    );
 }
 
 #[cfg(test)]
@@ -375,13 +784,22 @@ mod tests {
         Value::Object(map)
     }
 
+    fn default_opts() -> DiffOptions<'static> {
+        DiffOptions {
+            array_diff: &ArrayDiffStrategy::Index,
+            ignore_order: false,
+            ignore_case: false,
+        }
+    }
+
     #[test]
     fn test_identical_values_no_diff() {
         let v = obj(vec![
             ("host", Value::String("localhost".into())),
             ("port", Value::Integer(5432)),
         ]);
-        let diffs = compute_diff("", &v, &v);
+        let opts = default_opts();
+        let diffs = compute_diff("", &v, &v, &opts);
         assert!(diffs
             .iter()
             .all(|d| matches!(d, DiffEntry::Unchanged { .. })));
@@ -391,7 +809,8 @@ mod tests {
     fn test_changed_scalar() {
         let v1 = obj(vec![("port", Value::Integer(5432))]);
         let v2 = obj(vec![("port", Value::Integer(3306))]);
-        let diffs = compute_diff("", &v1, &v2);
+        let opts = default_opts();
+        let diffs = compute_diff("", &v1, &v2, &opts);
         assert_eq!(diffs.len(), 1);
         assert!(matches!(&diffs[0], DiffEntry::Changed { path, old, new }
             if path == "port" && old == "5432" && new == "3306"));
@@ -404,7 +823,8 @@ mod tests {
             ("host", Value::String("localhost".into())),
             ("port", Value::Integer(5432)),
         ]);
-        let diffs = compute_diff("", &v1, &v2);
+        let opts = default_opts();
+        let diffs = compute_diff("", &v1, &v2, &opts);
         assert_eq!(diffs.len(), 2);
         assert!(matches!(&diffs[0], DiffEntry::Unchanged { path, .. } if path == "host"));
         assert!(matches!(&diffs[1], DiffEntry::Added { path, value }
@@ -418,7 +838,8 @@ mod tests {
             ("debug", Value::Bool(true)),
         ]);
         let v2 = obj(vec![("host", Value::String("localhost".into()))]);
-        let diffs = compute_diff("", &v1, &v2);
+        let opts = default_opts();
+        let diffs = compute_diff("", &v1, &v2, &opts);
         assert_eq!(diffs.len(), 2);
         assert!(matches!(&diffs[0], DiffEntry::Unchanged { path, .. } if path == "host"));
         assert!(matches!(&diffs[1], DiffEntry::Removed { path, value }
@@ -441,21 +862,23 @@ mod tests {
                 ("port", Value::Integer(3306)),
             ]),
         )]);
-        let diffs = compute_diff("", &v1, &v2);
+        let opts = default_opts();
+        let diffs = compute_diff("", &v1, &v2, &opts);
         assert_eq!(diffs.len(), 2);
         assert!(matches!(&diffs[0], DiffEntry::Unchanged { path, .. } if path == "database.host"));
         assert!(matches!(&diffs[1], DiffEntry::Changed { path, .. } if path == "database.port"));
     }
 
     #[test]
-    fn test_array_diff() {
+    fn test_array_diff_index() {
         let v1 = Value::Array(vec![
             Value::Integer(1),
             Value::Integer(2),
             Value::Integer(3),
         ]);
         let v2 = Value::Array(vec![Value::Integer(1), Value::Integer(99)]);
-        let diffs = compute_diff("items", &v1, &v2);
+        let opts = default_opts();
+        let diffs = compute_diff("items", &v1, &v2, &opts);
         assert_eq!(diffs.len(), 3);
         assert!(matches!(&diffs[0], DiffEntry::Unchanged { path, .. } if path == "items[0]"));
         assert!(matches!(&diffs[1], DiffEntry::Changed { path, .. } if path == "items[1]"));
@@ -463,10 +886,153 @@ mod tests {
     }
 
     #[test]
+    fn test_ignore_case() {
+        let v1 = Value::String("Hello".into());
+        let v2 = Value::String("hello".into());
+        let opts_sensitive = DiffOptions {
+            array_diff: &ArrayDiffStrategy::Index,
+            ignore_order: false,
+            ignore_case: false,
+        };
+        let diffs = compute_diff("field", &v1, &v2, &opts_sensitive);
+        assert!(matches!(&diffs[0], DiffEntry::Changed { .. }));
+
+        let opts_insensitive = DiffOptions {
+            array_diff: &ArrayDiffStrategy::Index,
+            ignore_order: false,
+            ignore_case: true,
+        };
+        let diffs = compute_diff("field", &v1, &v2, &opts_insensitive);
+        assert!(matches!(&diffs[0], DiffEntry::Unchanged { .. }));
+    }
+
+    #[test]
+    fn test_ignore_order() {
+        let arr_strategy = ArrayDiffStrategy::Index;
+        let v1 = Value::Array(vec![
+            Value::Integer(3),
+            Value::Integer(1),
+            Value::Integer(2),
+        ]);
+        let v2 = Value::Array(vec![
+            Value::Integer(1),
+            Value::Integer(2),
+            Value::Integer(3),
+        ]);
+        let opts_no_ignore = DiffOptions {
+            array_diff: &arr_strategy,
+            ignore_order: false,
+            ignore_case: false,
+        };
+        let diffs = compute_diff("arr", &v1, &v2, &opts_no_ignore);
+        let changed = diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Changed { .. }))
+            .count();
+        assert!(changed > 0);
+
+        let opts_ignore = DiffOptions {
+            array_diff: &arr_strategy,
+            ignore_order: true,
+            ignore_case: false,
+        };
+        let diffs = compute_diff("arr", &v1, &v2, &opts_ignore);
+        assert!(diffs
+            .iter()
+            .all(|d| matches!(d, DiffEntry::Unchanged { .. })));
+    }
+
+    #[test]
+    fn test_array_diff_value() {
+        let arr_strategy = ArrayDiffStrategy::Value;
+        let v1 = Value::Array(vec![
+            Value::Integer(1),
+            Value::Integer(2),
+            Value::Integer(3),
+        ]);
+        let v2 = Value::Array(vec![
+            Value::Integer(3),
+            Value::Integer(1),
+            Value::Integer(4),
+        ]);
+        let opts = DiffOptions {
+            array_diff: &arr_strategy,
+            ignore_order: false,
+            ignore_case: false,
+        };
+        let diffs = compute_diff("arr", &v1, &v2, &opts);
+        let added = diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Added { .. }))
+            .count();
+        let removed = diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Removed { .. }))
+            .count();
+        let unchanged = diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Unchanged { .. }))
+            .count();
+        assert_eq!(added, 1); // 4 added
+        assert_eq!(removed, 1); // 2 removed
+        assert_eq!(unchanged, 2); // 1, 3 unchanged
+    }
+
+    #[test]
+    fn test_array_diff_key() {
+        let arr_strategy = ArrayDiffStrategy::Key("id".to_string());
+        let v1 = Value::Array(vec![
+            obj(vec![
+                ("id", Value::Integer(1)),
+                ("name", Value::String("Alice".into())),
+            ]),
+            obj(vec![
+                ("id", Value::Integer(2)),
+                ("name", Value::String("Bob".into())),
+            ]),
+        ]);
+        let v2 = Value::Array(vec![
+            obj(vec![
+                ("id", Value::Integer(2)),
+                ("name", Value::String("Bobby".into())),
+            ]),
+            obj(vec![
+                ("id", Value::Integer(3)),
+                ("name", Value::String("Carol".into())),
+            ]),
+        ]);
+        let opts = DiffOptions {
+            array_diff: &arr_strategy,
+            ignore_order: false,
+            ignore_case: false,
+        };
+        let diffs = compute_diff("users", &v1, &v2, &opts);
+        // id=1: removed (Alice)
+        // id=2: name changed (Bob -> Bobby)
+        // id=3: added (Carol)
+        let added = diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Added { .. }))
+            .count();
+        let removed = diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Removed { .. }))
+            .count();
+        let changed = diffs
+            .iter()
+            .filter(|d| matches!(d, DiffEntry::Changed { .. }))
+            .count();
+        assert!(removed >= 1);
+        assert!(added >= 1);
+        assert!(changed >= 1);
+    }
+
+    #[test]
     fn test_scalar_type_change() {
         let v1 = Value::String("hello".into());
         let v2 = Value::Integer(42);
-        let diffs = compute_diff("field", &v1, &v2);
+        let opts = default_opts();
+        let diffs = compute_diff("field", &v1, &v2, &opts);
         assert_eq!(diffs.len(), 1);
         assert!(matches!(&diffs[0], DiffEntry::Changed { path, old, new }
             if path == "field" && old == "\"hello\"" && new == "42"));
@@ -496,5 +1062,54 @@ mod tests {
         assert_eq!(format_scalar(&Value::Integer(42)), "42");
         assert_eq!(format_scalar(&Value::Float(3.14)), "3.14");
         assert_eq!(format_scalar(&Value::String("hello".into())), "\"hello\"");
+    }
+
+    #[test]
+    fn test_diff_mode_parse() {
+        assert_eq!(
+            DiffMode::from_str("structural").unwrap(),
+            DiffMode::Structural
+        );
+        assert_eq!(DiffMode::from_str("value").unwrap(), DiffMode::Value);
+        assert_eq!(DiffMode::from_str("key").unwrap(), DiffMode::Key);
+        assert!(DiffMode::from_str("unknown").is_err());
+    }
+
+    #[test]
+    fn test_diff_output_format_parse() {
+        assert_eq!(
+            DiffOutputFormat::from_str("unified").unwrap(),
+            DiffOutputFormat::Unified
+        );
+        assert_eq!(
+            DiffOutputFormat::from_str("side-by-side").unwrap(),
+            DiffOutputFormat::SideBySide
+        );
+        assert_eq!(
+            DiffOutputFormat::from_str("json").unwrap(),
+            DiffOutputFormat::Json
+        );
+        assert_eq!(
+            DiffOutputFormat::from_str("summary").unwrap(),
+            DiffOutputFormat::Summary
+        );
+        assert!(DiffOutputFormat::from_str("unknown").is_err());
+    }
+
+    #[test]
+    fn test_array_diff_strategy_parse() {
+        assert!(matches!(
+            ArrayDiffStrategy::from_str("index").unwrap(),
+            ArrayDiffStrategy::Index
+        ));
+        assert!(matches!(
+            ArrayDiffStrategy::from_str("value").unwrap(),
+            ArrayDiffStrategy::Value
+        ));
+        assert!(
+            matches!(ArrayDiffStrategy::from_str("key=id").unwrap(), ArrayDiffStrategy::Key(f) if f == "id")
+        );
+        assert!(ArrayDiffStrategy::from_str("key=").is_err());
+        assert!(ArrayDiffStrategy::from_str("unknown").is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,11 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             file2,
             path,
             quiet,
+            mode,
+            diff_format,
+            array_diff,
+            ignore_order,
+            ignore_case,
             encoding,
             detect_encoding,
             sheet,
@@ -325,11 +330,19 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             table,
             sql,
         } => {
+            let diff_mode = commands::diff::DiffMode::from_str(&mode)?;
+            let diff_output_format = commands::diff::DiffOutputFormat::from_str(&diff_format)?;
+            let array_diff_strategy = commands::diff::ArrayDiffStrategy::from_str(&array_diff)?;
             let has_diff = commands::diff::run(&commands::diff::DiffArgs {
                 file1: &file1,
                 file2: &file2,
                 path: path.as_deref(),
                 quiet,
+                mode: diff_mode,
+                diff_format: diff_output_format,
+                array_diff: array_diff_strategy,
+                ignore_order,
+                ignore_case,
                 encoding_opts: EncodingOptions {
                     encoding,
                     detect_encoding,


### PR DESCRIPTION
## Summary

- `--mode structural|value|key`: 비교 모드 선택 (기본값: structural)
- `--diff-format unified|side-by-side|json|summary`: 출력 포맷 선택 (기본값: unified)
- `--array-diff index|value|key=<field>`: 배열 비교 전략 선택 (기본값: index)
- `--ignore-order`: 배열 요소 순서 무시
- `--ignore-case`: 문자열 대소문자 무시

## 상세 변경 내용

### 비교 모드 (`--mode`)
| 모드 | 설명 |
|------|------|
| `structural` | 키 구조 변화 전체 (추가/삭제/변경) — 기본값 |
| `value` | 값이 변경된 항목만 출력 |
| `key` | 키 존재 여부만 비교 (추가/삭제만 출력) |

### 출력 포맷 (`--diff-format`)
| 포맷 | 설명 |
|------|------|
| `unified` | `+/-` 접두사 형식 — 기본값 |
| `side-by-side` | 좌우 비교 테이블 (PATH / LEFT / RIGHT / STATUS) |
| `json` | JSON 배열 출력 (`type`, `path`, `old`/`new` 또는 `value`) |
| `summary` | 변경 통계 요약 (`N added, N removed, N changed, N unchanged`) |

### 배열 비교 전략 (`--array-diff`)
| 전략 | 설명 |
|------|------|
| `index` | 인덱스 기반 위치 비교 — 기본값 |
| `value` | 값 기반 집합 비교 (순서 무관) |
| `key=<field>` | 지정한 키 필드로 항목 매칭 후 비교 (예: `key=id`) |

## Test plan
- [x] 단위 테스트: `DiffMode`, `DiffOutputFormat`, `ArrayDiffStrategy` 파싱
- [x] 단위 테스트: `ignore_case`, `ignore_order` 동작
- [x] 단위 테스트: `array-diff value`, `array-diff key=<field>` 동작
- [x] 기존 통합 테스트 전체 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과

Closes #100

https://claude.ai/code/session_013Uq3Fh5KUEWguSDD3o87od