### PR TITLE
Implement sample subcommand for data sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "parquet",
  "predicates",
  "quick-xml 0.37.5",
+ "rand",
  "rmp-serde",
  "rusqlite",
  "serde",
@@ -1466,6 +1467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1563,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ parquet = { version = "53", default-features = false, features = ["arrow", "snap
 bytes = "1"
 glob = "0.3"
 jsonschema = { version = "0.17", default-features = false }
+rand = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -519,6 +519,84 @@ pub enum Commands {
         sql: Option<String>,
     },
 
+    /// Sample records from data
+    #[command(
+        after_help = "Examples:\n  dkit sample data.csv -n 100\n  dkit sample data.json --ratio 0.1\n  dkit sample data.csv -n 50 --seed 42\n  dkit sample data.csv -n 100 --method systematic\n  dkit sample data.csv -n 50 --method stratified --stratify-by category\n  dkit sample data.csv -n 100 -o sample.json -f json"
+    )]
+    Sample {
+        /// Input file path (use '-' for stdin)
+        #[arg(value_name = "INPUT")]
+        input: String,
+
+        /// Number of records to sample
+        #[arg(short = 'n', long, value_name = "N")]
+        count: Option<usize>,
+
+        /// Ratio of records to sample (0.0 to 1.0)
+        #[arg(long, value_name = "RATIO")]
+        ratio: Option<f64>,
+
+        /// Random seed for reproducible sampling
+        #[arg(long, value_name = "SEED")]
+        seed: Option<u64>,
+
+        /// Sampling method: random, systematic, stratified
+        #[arg(long, value_name = "METHOD", default_value = "random")]
+        method: String,
+
+        /// Field to stratify by (required for stratified sampling)
+        #[arg(long, value_name = "FIELD")]
+        stratify_by: Option<String>,
+
+        /// Input format (auto-detected from file extension)
+        #[arg(long, value_name = "FORMAT")]
+        from: Option<String>,
+
+        /// Output format (default: same as input)
+        #[arg(short = 'f', long, alias = "to", value_name = "FORMAT")]
+        format: Option<String>,
+
+        /// Output file path (default: stdout)
+        #[arg(short, long, value_name = "FILE")]
+        output: Option<PathBuf>,
+
+        /// CSV delimiter character (default: ',')
+        #[arg(long, value_name = "CHAR")]
+        delimiter: Option<char>,
+
+        /// Treat CSV as having no header row
+        #[arg(long)]
+        no_header: bool,
+
+        /// Pretty-print output
+        #[arg(long)]
+        pretty: bool,
+
+        /// Input file encoding (e.g. euc-kr, shift_jis, latin1)
+        #[arg(long, value_name = "ENCODING")]
+        encoding: Option<String>,
+
+        /// Auto-detect input file encoding
+        #[arg(long)]
+        detect_encoding: bool,
+
+        /// Excel sheet name or index (default: first sheet)
+        #[arg(long, value_name = "SHEET")]
+        sheet: Option<String>,
+
+        /// Excel header row number, 1-based (default: 1)
+        #[arg(long, value_name = "N")]
+        header_row: Option<usize>,
+
+        /// SQLite table name to read from
+        #[arg(long, value_name = "TABLE")]
+        table: Option<String>,
+
+        /// SQL query to execute on SQLite database
+        #[arg(long, value_name = "SQL")]
+        sql: Option<String>,
+    },
+
     /// Compare two data files and show differences
     #[command(
         after_help = "Examples:\n  dkit diff old.json new.json\n  dkit diff config_dev.yaml config_prod.yaml\n  dkit diff data.json data.yaml\n  dkit diff old.json new.json --path '.database'\n  dkit diff a.json b.json --quiet && echo 'same' || echo 'different'\n  dkit diff a.json b.json --mode value --diff-format json\n  dkit diff a.json b.json --array-diff key=id --ignore-order"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod convert;
 pub mod diff;
 pub mod merge;
 pub mod query;
+pub mod sample;
 pub mod schema;
 pub mod stats;
 pub mod streaming;

--- a/src/commands/sample.rs
+++ b/src/commands/sample.rs
@@ -1,0 +1,524 @@
+use std::collections::HashMap;
+use std::fs;
+use std::io::{self, Read, Write as _};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+
+use super::{
+    read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
+    read_xlsx_from_bytes, EncodingOptions, ExcelOptions, ParquetWriteOptions, SqliteOptions,
+};
+use crate::format::csv::{CsvReader, CsvWriter};
+use crate::format::html::HtmlWriter;
+use crate::format::json::{JsonReader, JsonWriter};
+use crate::format::jsonl::{JsonlReader, JsonlWriter};
+use crate::format::markdown::MarkdownWriter;
+use crate::format::msgpack::{MsgpackReader, MsgpackWriter};
+use crate::format::toml::{TomlReader, TomlWriter};
+use crate::format::xml::{XmlReader, XmlWriter};
+use crate::format::yaml::{YamlReader, YamlWriter};
+use crate::format::{
+    default_delimiter, default_delimiter_for_format, detect_format, detect_format_from_content,
+    Format, FormatOptions, FormatReader, FormatWriter,
+};
+use crate::value::Value;
+
+pub struct SampleArgs<'a> {
+    pub input: &'a str,
+    pub count: Option<usize>,
+    pub ratio: Option<f64>,
+    pub seed: Option<u64>,
+    pub method: &'a str,
+    pub stratify_by: Option<&'a str>,
+    pub from: Option<&'a str>,
+    pub format: Option<&'a str>,
+    pub output: Option<&'a Path>,
+    pub delimiter: Option<char>,
+    pub no_header: bool,
+    pub pretty: bool,
+    pub encoding_opts: EncodingOptions,
+    pub excel_opts: ExcelOptions,
+    pub sqlite_opts: SqliteOptions,
+}
+
+pub fn run(args: &SampleArgs) -> Result<()> {
+    // Validate arguments
+    if args.count.is_none() && args.ratio.is_none() {
+        bail!("Either -n/--count or --ratio is required\n  Hint: use -n 100 for 100 records or --ratio 0.1 for 10%");
+    }
+    if args.count.is_some() && args.ratio.is_some() {
+        bail!("Cannot specify both -n/--count and --ratio");
+    }
+    if let Some(ratio) = args.ratio {
+        if !(0.0..=1.0).contains(&ratio) {
+            bail!("--ratio must be between 0.0 and 1.0, got {ratio}");
+        }
+    }
+
+    let method = SamplingMethod::from_str(args.method)?;
+    if matches!(method, SamplingMethod::Stratified) && args.stratify_by.is_none() {
+        bail!("--stratify-by is required for stratified sampling\n  Hint: specify the field to stratify by, e.g. --stratify-by category");
+    }
+
+    let (value, source_format) = read_input_as_value(args)?;
+
+    let records = match &value {
+        Value::Array(arr) => arr.clone(),
+        _ => bail!("Input data must be an array of records for sampling"),
+    };
+
+    if records.is_empty() {
+        bail!("Input data is empty, nothing to sample");
+    }
+
+    let sample_count = match args.count {
+        Some(n) => n,
+        None => {
+            let ratio = args.ratio.unwrap();
+            ((records.len() as f64 * ratio).ceil() as usize).max(1)
+        }
+    };
+
+    let sampled = match method {
+        SamplingMethod::Random => sample_random(&records, sample_count, args.seed)?,
+        SamplingMethod::Systematic => sample_systematic(&records, sample_count)?,
+        SamplingMethod::Stratified => {
+            let field = args.stratify_by.unwrap();
+            sample_stratified(&records, sample_count, field, args.seed)?
+        }
+    };
+
+    let result = Value::Array(sampled);
+
+    // Determine output format
+    let output_format = match args.format {
+        Some(f) => Format::from_str(f)?,
+        None => source_format,
+    };
+
+    let write_options = FormatOptions {
+        delimiter: args.delimiter,
+        no_header: args.no_header,
+        pretty: args.pretty,
+        ..Default::default()
+    };
+
+    write_output(&result, output_format, &write_options, args.output)?;
+
+    Ok(())
+}
+
+enum SamplingMethod {
+    Random,
+    Systematic,
+    Stratified,
+}
+
+impl SamplingMethod {
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "random" => Ok(Self::Random),
+            "systematic" => Ok(Self::Systematic),
+            "stratified" => Ok(Self::Stratified),
+            other => bail!(
+                "Unknown sampling method: '{}'\n  Hint: supported methods are random, systematic, stratified",
+                other
+            ),
+        }
+    }
+}
+
+fn sample_random(records: &[Value], count: usize, seed: Option<u64>) -> Result<Vec<Value>> {
+    let count = count.min(records.len());
+    let mut indices: Vec<usize> = (0..records.len()).collect();
+
+    match seed {
+        Some(s) => {
+            let mut rng = StdRng::seed_from_u64(s);
+            indices.shuffle(&mut rng);
+        }
+        None => {
+            let mut rng = rand::thread_rng();
+            indices.shuffle(&mut rng);
+        }
+    }
+
+    indices.truncate(count);
+    indices.sort_unstable(); // preserve original order
+    Ok(indices.iter().map(|&i| records[i].clone()).collect())
+}
+
+fn sample_systematic(records: &[Value], count: usize) -> Result<Vec<Value>> {
+    let count = count.min(records.len());
+    if count == 0 {
+        return Ok(vec![]);
+    }
+
+    let step = records.len() as f64 / count as f64;
+    let mut result = Vec::with_capacity(count);
+
+    for i in 0..count {
+        let idx = (i as f64 * step).floor() as usize;
+        let idx = idx.min(records.len() - 1);
+        result.push(records[idx].clone());
+    }
+
+    Ok(result)
+}
+
+fn sample_stratified(
+    records: &[Value],
+    count: usize,
+    field: &str,
+    seed: Option<u64>,
+) -> Result<Vec<Value>> {
+    // Group records by field value
+    let mut groups: HashMap<String, Vec<(usize, &Value)>> = HashMap::new();
+
+    for (i, record) in records.iter().enumerate() {
+        let key = match record {
+            Value::Object(obj) => match obj.get(field) {
+                Some(Value::String(s)) => s.clone(),
+                Some(v) => format!("{v}"),
+                None => "__null__".to_string(),
+            },
+            _ => "__non_object__".to_string(),
+        };
+        groups.entry(key).or_default().push((i, record));
+    }
+
+    let total = records.len();
+    let count = count.min(total);
+    let mut result_indices: Vec<usize> = Vec::with_capacity(count);
+
+    // Allocate proportionally per group
+    let mut remaining = count;
+    let mut group_entries: Vec<(String, Vec<(usize, &Value)>)> = groups.into_iter().collect();
+    group_entries.sort_by(|a, b| a.0.cmp(&b.0)); // deterministic order
+
+    let num_groups = group_entries.len();
+    for (gi, (_, group)) in group_entries.iter().enumerate() {
+        let group_count = if gi == num_groups - 1 {
+            remaining
+        } else {
+            let proportion = group.len() as f64 / total as f64;
+            let alloc = (proportion * count as f64).round() as usize;
+            alloc.min(remaining).min(group.len())
+        };
+
+        let mut group_indices: Vec<usize> = group.iter().map(|(i, _)| *i).collect();
+
+        match seed {
+            Some(s) => {
+                let mut rng = StdRng::seed_from_u64(s.wrapping_add(gi as u64));
+                group_indices.shuffle(&mut rng);
+            }
+            None => {
+                let mut rng = rand::thread_rng();
+                group_indices.shuffle(&mut rng);
+            }
+        }
+
+        group_indices.truncate(group_count);
+        result_indices.extend_from_slice(&group_indices);
+        remaining = remaining.saturating_sub(group_count);
+    }
+
+    result_indices.sort_unstable(); // preserve original order
+    Ok(result_indices.iter().map(|&i| records[i].clone()).collect())
+}
+
+// ── Input reading ──
+
+fn read_input_as_value(args: &SampleArgs) -> Result<(Value, Format)> {
+    if args.input == "-" {
+        if args.from == Some("msgpack") || args.from == Some("messagepack") {
+            let mut buf = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buf)
+                .context("Failed to read from stdin")?;
+            let value = MsgpackReader.read_from_bytes(&buf)?;
+            Ok((value, Format::Msgpack))
+        } else {
+            let buf = read_stdin_with_encoding(&args.encoding_opts)?;
+            let (format, sniffed_delimiter) = match args.from {
+                Some(f) => (Format::from_str(f)?, None),
+                None => detect_format_from_content(&buf)?,
+            };
+            let auto_delimiter =
+                sniffed_delimiter.or_else(|| args.from.and_then(default_delimiter_for_format));
+            let read_options = FormatOptions {
+                delimiter: args.delimiter.or(auto_delimiter),
+                no_header: args.no_header,
+                ..Default::default()
+            };
+            let value = read_value(&buf, format, &read_options)?;
+            Ok((value, format))
+        }
+    } else {
+        let format = match args.from {
+            Some(f) => Format::from_str(f)?,
+            None => detect_format(Path::new(args.input))?,
+        };
+        if format == Format::Msgpack {
+            let bytes = read_file_bytes(Path::new(args.input))?;
+            let value = MsgpackReader.read_from_bytes(&bytes)?;
+            Ok((value, format))
+        } else if format == Format::Xlsx {
+            let bytes = read_file_bytes(Path::new(args.input))?;
+            let value = read_xlsx_from_bytes(&bytes, &args.excel_opts)?;
+            Ok((value, format))
+        } else if format == Format::Sqlite {
+            let value = read_sqlite_from_path(Path::new(args.input), &args.sqlite_opts)?;
+            Ok((value, format))
+        } else if format == Format::Parquet {
+            let bytes = read_file_bytes(Path::new(args.input))?;
+            let value = read_parquet_from_bytes(&bytes)?;
+            Ok((value, format))
+        } else {
+            let content = read_file_with_encoding(Path::new(args.input), &args.encoding_opts)?;
+            let auto_delimiter = default_delimiter(Path::new(args.input));
+            let read_options = FormatOptions {
+                delimiter: args.delimiter.or(auto_delimiter),
+                no_header: args.no_header,
+                ..Default::default()
+            };
+            let value = read_value(&content, format, &read_options)?;
+            Ok((value, format))
+        }
+    }
+}
+
+fn read_stdin_with_encoding(opts: &EncodingOptions) -> Result<String> {
+    if opts.encoding.is_some() || opts.detect_encoding {
+        let mut buf = Vec::new();
+        io::stdin()
+            .read_to_end(&mut buf)
+            .context("Failed to read from stdin")?;
+        super::decode_bytes(&buf, opts)
+    } else {
+        let mut buf = String::new();
+        io::stdin()
+            .read_to_string(&mut buf)
+            .context("Failed to read from stdin")?;
+        Ok(buf)
+    }
+}
+
+fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<Value> {
+    match format {
+        Format::Json => JsonReader.read(content),
+        Format::Jsonl => JsonlReader.read(content),
+        Format::Csv => CsvReader::new(options.clone()).read(content),
+        Format::Yaml => YamlReader.read(content),
+        Format::Toml => TomlReader.read(content),
+        Format::Xml => XmlReader::default().read(content),
+        Format::Msgpack => MsgpackReader.read(content),
+        Format::Xlsx => {
+            bail!("Excel files must be read as binary; use file path input instead of stdin")
+        }
+        Format::Sqlite => {
+            bail!("SQLite files must be read from a file path, not from text input")
+        }
+        Format::Parquet => {
+            bail!("Parquet files must be read from a file path, not from text input")
+        }
+        Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
+        Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
+        Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+    }
+}
+
+// ── Output writing ──
+
+fn write_output(
+    value: &Value,
+    format: Format,
+    options: &FormatOptions,
+    output: Option<&Path>,
+) -> Result<()> {
+    if format == Format::Msgpack {
+        let bytes = MsgpackWriter.write_bytes(value)?;
+        if let Some(out_path) = output {
+            fs::write(out_path, &bytes)
+                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        } else {
+            io::stdout()
+                .write_all(&bytes)
+                .context("Failed to write to stdout")?;
+        }
+    } else if format == Format::Parquet {
+        let bytes = super::write_parquet_to_bytes(value, &ParquetWriteOptions::default())?;
+        if let Some(out_path) = output {
+            fs::write(out_path, &bytes)
+                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        } else {
+            io::stdout()
+                .write_all(&bytes)
+                .context("Failed to write Parquet to stdout")?;
+        }
+    } else {
+        let result = write_value(value, format, options)?;
+        if let Some(out_path) = output {
+            fs::write(out_path, &result)
+                .with_context(|| format!("Failed to write to {}", out_path.display()))?;
+        } else if result.ends_with('\n') {
+            print!("{result}");
+        } else {
+            println!("{result}");
+        }
+    }
+    Ok(())
+}
+
+fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result<String> {
+    match format {
+        Format::Json => JsonWriter::new(options.clone()).write(value),
+        Format::Jsonl => JsonlWriter.write(value),
+        Format::Csv => CsvWriter::new(options.clone()).write(value),
+        Format::Yaml => YamlWriter::new(options.clone()).write(value),
+        Format::Toml => TomlWriter::new(options.clone()).write(value),
+        Format::Xml => XmlWriter::new(options.pretty, options.root_element.clone()).write(value),
+        Format::Msgpack => MsgpackWriter.write(value),
+        Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
+        Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),
+        Format::Parquet => {
+            bail!("Internal error: Parquet output should be handled via write_output")
+        }
+        Format::Markdown => MarkdownWriter.write(value),
+        Format::Html => HtmlWriter::new(options.styled, options.full_html).write(value),
+        Format::Table => {
+            use crate::output::table::{render_table, TableOptions};
+            Ok(render_table(value, &TableOptions::default()) + "\n")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn make_record(name: &str, category: &str, age: i64) -> Value {
+        let mut m = IndexMap::new();
+        m.insert("name".to_string(), Value::String(name.to_string()));
+        m.insert("category".to_string(), Value::String(category.to_string()));
+        m.insert("age".to_string(), Value::Integer(age));
+        Value::Object(m)
+    }
+
+    fn sample_data() -> Vec<Value> {
+        vec![
+            make_record("Alice", "A", 30),
+            make_record("Bob", "B", 25),
+            make_record("Charlie", "A", 35),
+            make_record("Diana", "B", 28),
+            make_record("Eve", "A", 22),
+            make_record("Frank", "C", 40),
+            make_record("Grace", "C", 33),
+            make_record("Hank", "B", 27),
+            make_record("Ivy", "A", 31),
+            make_record("Jack", "C", 29),
+        ]
+    }
+
+    #[test]
+    fn test_sample_random_basic() {
+        let data = sample_data();
+        let result = sample_random(&data, 3, Some(42)).unwrap();
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_sample_random_reproducible() {
+        let data = sample_data();
+        let r1 = sample_random(&data, 5, Some(123)).unwrap();
+        let r2 = sample_random(&data, 5, Some(123)).unwrap();
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn test_sample_random_different_seeds() {
+        let data = sample_data();
+        let r1 = sample_random(&data, 5, Some(1)).unwrap();
+        let r2 = sample_random(&data, 5, Some(2)).unwrap();
+        assert_ne!(r1, r2);
+    }
+
+    #[test]
+    fn test_sample_random_count_exceeds_total() {
+        let data = sample_data();
+        let result = sample_random(&data, 100, Some(42)).unwrap();
+        assert_eq!(result.len(), 10); // capped at total
+    }
+
+    #[test]
+    fn test_sample_systematic_basic() {
+        let data = sample_data();
+        let result = sample_systematic(&data, 3).unwrap();
+        assert_eq!(result.len(), 3);
+        // Should pick evenly spaced records
+        assert_eq!(result[0], data[0]); // index 0
+        assert_eq!(result[1], data[3]); // index 3
+        assert_eq!(result[2], data[6]); // index 6
+    }
+
+    #[test]
+    fn test_sample_systematic_all() {
+        let data = sample_data();
+        let result = sample_systematic(&data, 10).unwrap();
+        assert_eq!(result.len(), 10);
+    }
+
+    #[test]
+    fn test_sample_stratified_basic() {
+        let data = sample_data();
+        // 4 in A, 3 in B, 3 in C → proportional allocation of 6
+        let result = sample_stratified(&data, 6, "category", Some(42)).unwrap();
+        assert_eq!(result.len(), 6);
+    }
+
+    #[test]
+    fn test_sample_stratified_reproducible() {
+        let data = sample_data();
+        let r1 = sample_stratified(&data, 6, "category", Some(42)).unwrap();
+        let r2 = sample_stratified(&data, 6, "category", Some(42)).unwrap();
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn test_sample_method_from_str() {
+        assert!(matches!(
+            SamplingMethod::from_str("random").unwrap(),
+            SamplingMethod::Random
+        ));
+        assert!(matches!(
+            SamplingMethod::from_str("systematic").unwrap(),
+            SamplingMethod::Systematic
+        ));
+        assert!(matches!(
+            SamplingMethod::from_str("stratified").unwrap(),
+            SamplingMethod::Stratified
+        ));
+        assert!(SamplingMethod::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_sample_random_preserves_order() {
+        let data = sample_data();
+        let result = sample_random(&data, 5, Some(42)).unwrap();
+        // Check that sampled records maintain their relative order
+        let mut prev_idx = None;
+        for r in &result {
+            let idx = data.iter().position(|d| d == r).unwrap();
+            if let Some(pi) = prev_idx {
+                assert!(idx > pi, "Records should be in original order");
+            }
+            prev_idx = Some(idx);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,6 +356,47 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                 process::exit(1);
             }
         }
+        Commands::Sample {
+            input,
+            count,
+            ratio,
+            seed,
+            method,
+            stratify_by,
+            from,
+            format,
+            output,
+            delimiter,
+            no_header,
+            pretty,
+            encoding,
+            detect_encoding,
+            sheet,
+            header_row,
+            table,
+            sql,
+        } => {
+            commands::sample::run(&commands::sample::SampleArgs {
+                input: &input,
+                count,
+                ratio,
+                seed,
+                method: &method,
+                stratify_by: stratify_by.as_deref(),
+                from: from.as_deref(),
+                format: format.as_deref(),
+                output: output.as_deref(),
+                delimiter,
+                no_header,
+                pretty,
+                encoding_opts: EncodingOptions {
+                    encoding,
+                    detect_encoding,
+                },
+                excel_opts: ExcelOptions { sheet, header_row },
+                sqlite_opts: SqliteOptions { table, sql },
+            })?;
+        }
         Commands::Diff {
             file1,
             file2,


### PR DESCRIPTION
## Summary
- Add `dkit sample` subcommand for extracting samples from data files
- Support three sampling methods: `random`, `systematic`, `stratified`
- Support `-n`/`--count` (absolute count) and `--ratio` (proportional) modes
- Support `--seed` for reproducible sampling and `--stratify-by` for stratified sampling
- Support output format conversion via `-f`/`-o` options (e.g., `dkit sample data.csv -n 100 -o sample.json -f json`)

## Test plan
- [x] Unit tests for random sampling (basic, reproducibility, seed variation, count capping, order preservation)
- [x] Unit tests for systematic sampling (even spacing, full selection)
- [x] Unit tests for stratified sampling (proportional allocation, reproducibility)
- [x] Unit tests for sampling method parsing
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` passes
- [x] Full test suite passes (626+ existing tests unaffected)

Closes #103

https://claude.ai/code/session_016wWwrMCymcKewTcYbVyE1K