### PR TITLE
Add shell completion script generation (bash, zsh, fish, powershell)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +690,7 @@ dependencies = [
  "calamine",
  "chardetng",
  "clap",
+ "clap_complete",
  "colored",
  "comfy-table",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["command-line-utilities", "encoding"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -736,6 +737,16 @@ pub enum Commands {
     Config {
         #[command(subcommand)]
         action: ConfigAction,
+    },
+
+    /// Generate shell completion scripts
+    #[command(
+        after_help = "Examples:\n  dkit completions bash > ~/.bash_completion.d/dkit\n  dkit completions zsh > ~/.zfunc/_dkit\n  dkit completions fish > ~/.config/fish/completions/dkit.fish\n  dkit completions powershell > dkit.ps1\n\nInstallation:\n  Bash:       dkit completions bash > ~/.bash_completion.d/dkit && source ~/.bash_completion.d/dkit\n  Zsh:        dkit completions zsh > ~/.zfunc/_dkit  (ensure ~/.zfunc is in $fpath)\n  Fish:       dkit completions fish > ~/.config/fish/completions/dkit.fish\n  PowerShell: dkit completions powershell > dkit.ps1 && . ./dkit.ps1"
+    )]
+    Completions {
+        /// Target shell (bash, zsh, fish, powershell)
+        #[arg(value_name = "SHELL")]
+        shell: Shell,
     },
 
     /// Compare two data files and show differences

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::process;
 use clap::Parser;
 use colored::Colorize;
 
+use clap::CommandFactory;
 use cli::{Cli, Commands, ConfigAction};
 use commands::{EncodingOptions, ExcelOptions, ParquetWriteOptions, SqliteOptions};
 
@@ -37,7 +38,6 @@ fn run_main() -> i32 {
         Some(_) => {}
         None => {
             // No subcommand and no --list-formats: show help
-            use clap::CommandFactory;
             Cli::command().print_help().ok();
             println!();
             return 2;
@@ -468,6 +468,9 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                 excel_opts: ExcelOptions { sheet, header_row },
                 sqlite_opts: SqliteOptions { table, sql },
             })?;
+        }
+        Commands::Completions { shell } => {
+            clap_complete::generate(shell, &mut Cli::command(), "dkit", &mut std::io::stdout());
         }
         Commands::Config { action } => match action {
             ConfigAction::Show => config::run_show()?,


### PR DESCRIPTION
## Summary
- `dkit completions <shell>` 서브커맨드 추가 (bash, zsh, fish, powershell 지원)
- `clap_complete` 크레이트를 활용하여 서브커맨드, 옵션, 포맷명 자동완성 스크립트 생성
- `--help`에 각 쉘별 설치 가이드 포함

## Test plan
- [x] `dkit completions bash` 정상 출력 확인
- [x] `dkit completions zsh` 정상 출력 확인
- [x] `dkit completions fish` 정상 출력 확인
- [x] `dkit completions powershell` 정상 출력 확인
- [x] `cargo test` 전체 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과

Closes #108

https://claude.ai/code/session_01D4WkuUDBrC76chei4RwLNZ