### PR TITLE
feat: 에러 메시지 개선 - 줄/열 번호, 코드 스니펫, Did you mean?, --verbose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +325,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,7 +575,7 @@ checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -738,6 +771,7 @@ dependencies = [
  "glob",
  "indexmap",
  "jsonschema",
+ "miette",
  "notify",
  "parquet",
  "predicates",
@@ -932,6 +966,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -1170,6 +1210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1448,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1690,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -1918,6 +2009,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2183,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,10 +2239,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -2284,10 +2422,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rand = "0.8"
 dirs = "6.0.0"
 notify = "7"
 ctrlc = { version = "3", features = ["termination"] }
+miette = { version = "7", features = ["fancy"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,10 @@ pub struct Cli {
     /// List all supported output formats
     #[arg(long)]
     pub list_formats: bool,
+
+    /// Show verbose error output (error chain, debug info)
+    #[arg(long, global = true)]
+    pub verbose: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,40 @@ pub const SUPPORTED_FORMATS: &[&str] = &[
     "json", "jsonl", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack", "md", "html", "table",
 ];
 
+/// Compute Levenshtein edit distance between two strings.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let m = a.len();
+    let n = b.len();
+    let mut row: Vec<usize> = (0..=n).collect();
+    for i in 1..=m {
+        let mut prev = row[0];
+        row[0] = i;
+        for j in 1..=n {
+            let temp = row[j];
+            row[j] = if a[i - 1] == b[j - 1] {
+                prev
+            } else {
+                1 + prev.min(row[j]).min(row[j - 1])
+            };
+            prev = temp;
+        }
+    }
+    row[n]
+}
+
+/// Return the closest supported format name for "Did you mean?" hints.
+/// Returns `None` if no candidate is close enough (distance > 3).
+pub fn suggest_format(input: &str) -> Option<&'static str> {
+    let input_lower = input.to_lowercase();
+    SUPPORTED_FORMATS
+        .iter()
+        .copied()
+        .filter(|&f| levenshtein(&input_lower, f) <= 3)
+        .min_by_key(|&f| levenshtein(&input_lower, f))
+}
+
 /// dkit 에러 타입 정의
 ///
 /// 포맷 파싱, 쓰기, IO, 쿼리 등 카테고리별 에러를 구분하며,
@@ -17,6 +51,20 @@ pub enum DkitError {
         format: String,
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// Parse error with source location info for rich display (line/column + snippet).
+    #[error("Failed to parse {format} at line {line}, column {column}: {source}")]
+    ParseErrorAt {
+        format: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+        /// 1-indexed line number
+        line: usize,
+        /// 1-indexed column number
+        column: usize,
+        /// The text of the line where the error occurred
+        line_text: String,
     },
 
     #[error("Failed to write {format}: {source}")]

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -60,11 +60,22 @@ pub struct JsonReader;
 
 impl FormatReader for JsonReader {
     fn read(&self, input: &str) -> anyhow::Result<Value> {
-        let json_val: serde_json::Value =
-            serde_json::from_str(input).map_err(|e| crate::error::DkitError::ParseError {
+        let json_val: serde_json::Value = serde_json::from_str(input).map_err(|e| {
+            let line = e.line();
+            let column = e.column();
+            let line_text = input
+                .lines()
+                .nth(line.saturating_sub(1))
+                .unwrap_or("")
+                .to_string();
+            crate::error::DkitError::ParseErrorAt {
                 format: "JSON".to_string(),
                 source: Box::new(e),
-            })?;
+                line,
+                column,
+                line_text,
+            }
+        })?;
         Ok(from_json_value(json_val))
     }
 

--- a/src/format/toml.rs
+++ b/src/format/toml.rs
@@ -55,13 +55,38 @@ fn to_toml_value(v: &Value) -> toml::Value {
 /// TOML 포맷 Reader
 pub struct TomlReader;
 
+/// Convert a byte offset into a 1-indexed (line, column) pair.
+fn byte_offset_to_line_col(s: &str, offset: usize) -> (usize, usize) {
+    let before = &s[..offset.min(s.len())];
+    let line = before.chars().filter(|&c| c == '\n').count() + 1;
+    let column = before.rfind('\n').map(|p| offset - p).unwrap_or(offset + 1);
+    (line, column)
+}
+
 impl FormatReader for TomlReader {
     fn read(&self, input: &str) -> anyhow::Result<Value> {
-        let toml_val: toml::Value =
-            toml::from_str(input).map_err(|e| crate::error::DkitError::ParseError {
-                format: "TOML".to_string(),
-                source: Box::new(e),
-            })?;
+        let toml_val: toml::Value = toml::from_str(input).map_err(|e: toml::de::Error| {
+            if let Some(span) = e.span() {
+                let (line, column) = byte_offset_to_line_col(input, span.start);
+                let line_text = input
+                    .lines()
+                    .nth(line.saturating_sub(1))
+                    .unwrap_or("")
+                    .to_string();
+                crate::error::DkitError::ParseErrorAt {
+                    format: "TOML".to_string(),
+                    source: Box::new(e),
+                    line,
+                    column,
+                    line_text,
+                }
+            } else {
+                crate::error::DkitError::ParseError {
+                    format: "TOML".to_string(),
+                    source: Box::new(e),
+                }
+            }
+        })?;
         Ok(from_toml_value(toml_val))
     }
 

--- a/src/format/yaml.rs
+++ b/src/format/yaml.rs
@@ -77,9 +77,28 @@ pub struct YamlReader;
 impl FormatReader for YamlReader {
     fn read(&self, input: &str) -> anyhow::Result<Value> {
         let yaml_val: serde_yaml::Value =
-            serde_yaml::from_str(input).map_err(|e| crate::error::DkitError::ParseError {
-                format: "YAML".to_string(),
-                source: Box::new(e),
+            serde_yaml::from_str(input).map_err(|e: serde_yaml::Error| {
+                if let Some(loc) = e.location() {
+                    let line = loc.line();
+                    let column = loc.column();
+                    let line_text = input
+                        .lines()
+                        .nth(line.saturating_sub(1))
+                        .unwrap_or("")
+                        .to_string();
+                    crate::error::DkitError::ParseErrorAt {
+                        format: "YAML".to_string(),
+                        source: Box::new(e),
+                        line,
+                        column,
+                        line_text,
+                    }
+                } else {
+                    crate::error::DkitError::ParseError {
+                        format: "YAML".to_string(),
+                        source: Box::new(e),
+                    }
+                }
             })?;
         Ok(from_yaml_value(yaml_val))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use colored::Colorize;
 use clap::CommandFactory;
 use cli::{Cli, Commands, ConfigAction};
 use commands::{EncodingOptions, ExcelOptions, ParquetWriteOptions, SqliteOptions};
+use error::{suggest_format, DkitError, SUPPORTED_FORMATS};
 
 fn main() {
     // Spawn a thread with a larger stack to prevent stack overflows on Windows,
@@ -28,6 +29,7 @@ fn main() {
 
 fn run_main() -> i32 {
     let cli = Cli::parse();
+    let verbose = cli.verbose;
 
     if cli.list_formats {
         print_formats();
@@ -45,7 +47,7 @@ fn run_main() -> i32 {
     }
 
     if let Err(err) = run_command(cli) {
-        print_error(&err);
+        print_error(&err, verbose);
         return 1;
     }
     0
@@ -61,7 +63,76 @@ fn print_formats() {
 }
 
 /// 에러를 색상 강조와 함께 stderr에 출력
-fn print_error(err: &anyhow::Error) {
+/// - error=빨강, hint/warning=노랑, suggestion=청색
+/// - ParseErrorAt: 줄/열 번호 + 코드 스니펫(화살표)
+/// - UnknownFormat: "Did you mean?" 제안
+/// - verbose=true: 전체 에러 체인 출력
+fn print_error(err: &anyhow::Error, verbose: bool) {
+    // DkitError로 다운캐스트하여 향상된 출력 시도
+    if let Some(dkit_err) = err.downcast_ref::<DkitError>() {
+        match dkit_err {
+            DkitError::UnknownFormat(s) => {
+                eprintln!("{} Unknown format: '{s}'", "error:".red().bold());
+                eprintln!(
+                    "  {}",
+                    format!("Supported formats: {}", SUPPORTED_FORMATS.join(", ")).yellow()
+                );
+                if let Some(suggestion) = suggest_format(s) {
+                    eprintln!(
+                        "  {}",
+                        format!("Did you mean '{suggestion}'?").cyan().bold()
+                    );
+                }
+                return;
+            }
+            DkitError::ParseErrorAt {
+                format,
+                source,
+                line,
+                column,
+                line_text,
+            } => {
+                eprintln!(
+                    "{} Failed to parse {format}: {source}",
+                    "error:".red().bold()
+                );
+                eprintln!("  {} line {line}, column {column}", "-->".blue().bold());
+                if !line_text.is_empty() {
+                    let line_num = line.to_string();
+                    let pad = " ".repeat(line_num.len());
+                    eprintln!("  {pad} {}", "|".blue());
+                    eprintln!("  {line_num} {} {line_text}", "|".blue());
+                    let arrow_pad = " ".repeat(column.saturating_sub(1));
+                    eprintln!("  {pad} {} {arrow_pad}{}", "|".blue(), "^".red().bold());
+                    eprintln!("  {pad} {}", "|".blue());
+                }
+                eprintln!(
+                    "  {}",
+                    format!("Hint: check that the input is valid {format}").yellow()
+                );
+                if verbose {
+                    eprintln!("\n  {}", "verbose backtrace:".dimmed());
+                    eprintln!("  {}", format!("{err:?}").dimmed());
+                }
+                return;
+            }
+            DkitError::FormatDetectionFailed(s) => {
+                eprintln!("{} Failed to detect format: {s}", "error:".red().bold());
+                eprintln!(
+                    "  {}",
+                    "Hint: specify the input format explicitly, e.g. --from json".yellow()
+                );
+                eprintln!(
+                    "  {}",
+                    format!("Supported formats: {}", SUPPORTED_FORMATS.join(", ")).yellow()
+                );
+                return;
+            }
+            _ => {} // fall through to generic display
+        }
+    }
+
+    // 제네릭 에러 출력
     let msg = format!("{err:#}");
     let mut lines = msg.lines();
 
@@ -78,6 +149,11 @@ fn print_error(err: &anyhow::Error) {
         } else if !line.is_empty() {
             eprintln!("  {line}");
         }
+    }
+
+    if verbose {
+        eprintln!("\n  {}", "verbose backtrace:".dimmed());
+        eprintln!("  {}", format!("{err:?}").dimmed());
     }
 }
 


### PR DESCRIPTION
## Summary

- `miette` 크레이트 추가로 fancy error reporting 기반 마련
- `DkitError::ParseErrorAt` 신규 변형 추가: 줄/열 번호 + 코드 스니펫 포함
- JSON/YAML/TOML 파서에서 에러 발생 위치(line/column) 추출
- `suggest_format()`: Levenshtein 거리 기반 "Did you mean?" 포맷 제안
- `--verbose` 글로벌 플래그 추가 (에러 체인/디버그 정보 출력)
- `print_error()` 색상 개선: error=빨강, hint=노랑, suggestion=청색(cyan)

## 주요 변경 내용

### 에러 위치 표시 (JSON 예시)
```
error: Failed to parse JSON: key must be a string at line 1 column 2
  --> line 1, column 2
    |
  1 | {bad json}
    |  ^
    |
  Hint: check that the input is valid JSON
```

### "Did you mean?" 제안 (UnknownFormat 예시)
```
error: Unknown format: 'jsn'
  Supported formats: json, jsonl, csv, tsv, yaml, yml, toml, xml, msgpack, md, html, table
  Did you mean 'json'?
```

### `--verbose` 옵션
에러 발생 시 `--verbose` 플래그를 추가하면 전체 에러 체인과 디버그 정보를 출력한다.

## Test plan

- [x] `cargo build` 통과
- [x] `cargo test` 전체 통과 (664+ 테스트)
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과
- [x] 잘못된 JSON 입력 시 줄/열 번호 + 스니펫 출력 확인
- [x] 잘못된 포맷명 입력 시 "Did you mean?" 제안 출력 확인

Closes #110

https://claude.ai/code/session_013hbDXTw8jCMzxNBW4aJBKT