### PR TITLE
feat: 별칭(alias) 시스템 구현

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use clap_complete::Shell;
 
 #[derive(Parser, Debug)]
@@ -759,6 +759,15 @@ pub enum Commands {
         action: ConfigAction,
     },
 
+    /// Manage command aliases
+    #[command(
+        after_help = "Examples:\n  dkit alias list                              # List all aliases\n  dkit alias set j2c 'convert --from json --to csv'  # Set an alias\n  dkit alias set peek 'view --head 5'         # Set an alias\n  dkit alias remove myalias                   # Remove a user alias\n  dkit j2c data.json                          # Use an alias"
+    )]
+    Alias {
+        #[command(subcommand)]
+        action: AliasAction,
+    },
+
     /// Generate shell completion scripts
     #[command(
         after_help = "Examples:\n  dkit completions bash > ~/.bash_completion.d/dkit\n  dkit completions zsh > ~/.zfunc/_dkit\n  dkit completions fish > ~/.config/fish/completions/dkit.fish\n  dkit completions powershell > dkit.ps1\n\nInstallation:\n  Bash:       dkit completions bash > ~/.bash_completion.d/dkit && source ~/.bash_completion.d/dkit\n  Zsh:        dkit completions zsh > ~/.zfunc/_dkit  (ensure ~/.zfunc is in $fpath)\n  Fish:       dkit completions fish > ~/.config/fish/completions/dkit.fish\n  PowerShell: dkit completions powershell > dkit.ps1 && . ./dkit.ps1"
@@ -846,4 +855,28 @@ pub enum ConfigAction {
         #[arg(long)]
         project: bool,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AliasAction {
+    /// Register or update a command alias
+    Set(AliasSetArgs),
+    /// List all aliases (builtin and user-defined)
+    List,
+    /// Remove a user-defined alias
+    Remove {
+        /// Alias name to remove
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
+}
+
+#[derive(Args, Debug)]
+pub struct AliasSetArgs {
+    /// Alias name (e.g. j2c)
+    #[arg(value_name = "NAME")]
+    pub name: String,
+    /// Command to expand to (e.g. 'convert --from json --to csv')
+    #[arg(value_name = "COMMAND")]
+    pub command: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -16,6 +17,9 @@ pub struct DkitConfig {
     /// Table display settings
     #[serde(default)]
     pub table: Option<TableConfig>,
+    /// User-defined command aliases
+    #[serde(default)]
+    pub aliases: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -37,6 +41,10 @@ pub struct ConfigSource {
 impl DkitConfig {
     /// Merge another config on top of self (other takes priority for set values).
     pub fn merge(self, other: &DkitConfig) -> DkitConfig {
+        let mut aliases = self.aliases.clone();
+        for (k, v) in &other.aliases {
+            aliases.insert(k.clone(), v.clone());
+        }
         DkitConfig {
             default_format: other.default_format.clone().or(self.default_format),
             color: other.color.clone().or(self.color),
@@ -50,6 +58,7 @@ impl DkitConfig {
                     max_width: b.max_width.or(a.max_width),
                 }),
             },
+            aliases,
         }
     }
 }
@@ -185,6 +194,130 @@ pub fn run_show() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Returns the built-in aliases.
+pub fn builtin_aliases() -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    m.insert(
+        "j2c".to_string(),
+        "convert --from json --to csv".to_string(),
+    );
+    m.insert(
+        "c2j".to_string(),
+        "convert --from csv --to json".to_string(),
+    );
+    m.insert(
+        "j2y".to_string(),
+        "convert --from json --to yaml".to_string(),
+    );
+    m.insert(
+        "y2j".to_string(),
+        "convert --from yaml --to json".to_string(),
+    );
+    m.insert(
+        "j2t".to_string(),
+        "convert --from json --to toml".to_string(),
+    );
+    m.insert(
+        "t2j".to_string(),
+        "convert --from toml --to json".to_string(),
+    );
+    m.insert(
+        "c2y".to_string(),
+        "convert --from csv --to yaml".to_string(),
+    );
+    m.insert(
+        "y2c".to_string(),
+        "convert --from yaml --to csv".to_string(),
+    );
+    m
+}
+
+/// Save config to a TOML file, creating parent directories if needed.
+fn save_config(path: &Path, config: &DkitConfig) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let toml_str = toml::to_string_pretty(config)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize config: {e}"))?;
+    fs::write(path, toml_str)?;
+    Ok(())
+}
+
+/// Returns the write path for user aliases (existing config path or init path).
+fn user_config_write_path() -> Option<PathBuf> {
+    user_config_path().or_else(user_config_init_path)
+}
+
+/// Run `dkit alias set <name> <command>` — register or update a user alias.
+pub fn run_alias_set(name: &str, command: &str) -> anyhow::Result<()> {
+    let path = user_config_write_path()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine config directory"))?;
+
+    let mut config = if path.exists() {
+        load_from_file(&path)
+    } else {
+        DkitConfig::default()
+    };
+
+    config.aliases.insert(name.to_string(), command.to_string());
+    save_config(&path, &config)?;
+    println!("Alias '{}' = '{}'", name, command);
+    Ok(())
+}
+
+/// Run `dkit alias list` — list all aliases (builtin + user).
+pub fn run_alias_list(user_aliases: &HashMap<String, String>) -> anyhow::Result<()> {
+    let builtins = builtin_aliases();
+
+    // Merge: user aliases override builtins
+    let mut all: std::collections::BTreeMap<String, (String, &str)> =
+        std::collections::BTreeMap::new();
+    for (name, cmd) in &builtins {
+        all.insert(name.clone(), (cmd.clone(), "builtin"));
+    }
+    for (name, cmd) in user_aliases {
+        all.insert(name.clone(), (cmd.clone(), "user"));
+    }
+
+    if all.is_empty() {
+        println!("No aliases defined.");
+        return Ok(());
+    }
+
+    println!("{:<16} {:<44} SOURCE", "NAME", "COMMAND");
+    println!("{:-<16} {:-<44} {:-<8}", "", "", "");
+    for (name, (cmd, source)) in &all {
+        println!("{:<16} {:<44} {}", name, cmd, source);
+    }
+    Ok(())
+}
+
+/// Run `dkit alias remove <name>` — remove a user-defined alias.
+pub fn run_alias_remove(name: &str) -> anyhow::Result<()> {
+    let builtins = builtin_aliases();
+    if builtins.contains_key(name) {
+        anyhow::bail!("Cannot remove built-in alias '{name}'. Use 'alias set {name} <command>' to override it.");
+    }
+
+    let path = user_config_write_path()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine config directory"))?;
+
+    if !path.exists() {
+        anyhow::bail!("Alias '{name}' not found.");
+    }
+
+    let mut config = load_from_file(&path);
+    if config.aliases.remove(name).is_none() {
+        anyhow::bail!("Alias '{name}' not found.");
+    }
+
+    save_config(&path, &config)?;
+    println!("Alias '{name}' removed.");
+    Ok(())
+}
+
 /// Run `dkit config init` — create a default config file.
 pub fn run_init(project: bool) -> anyhow::Result<()> {
     let path = if project {
@@ -265,6 +398,7 @@ color = "never"
                 border_style: Some("simple".to_string()),
                 max_width: Some(40),
             }),
+            ..Default::default()
         };
         let override_cfg = DkitConfig {
             default_format: None,
@@ -274,6 +408,7 @@ color = "never"
                 border_style: None,
                 max_width: Some(80),
             }),
+            ..Default::default()
         };
 
         let merged = base.merge(&override_cfg);
@@ -304,6 +439,7 @@ color = "never"
             color: None,
             encoding: None,
             table: None,
+            ..Default::default()
         };
         let display = format!("{}", config);
         assert!(display.contains("default_format"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use colored::Colorize;
 
 use clap::CommandFactory;
-use cli::{Cli, Commands, ConfigAction};
+use cli::{AliasAction, Cli, Commands, ConfigAction};
 use commands::{EncodingOptions, ExcelOptions, ParquetWriteOptions, SqliteOptions};
 use error::{suggest_format, DkitError, SUPPORTED_FORMATS};
 
@@ -28,7 +28,16 @@ fn main() {
 }
 
 fn run_main() -> i32 {
-    let cli = Cli::parse();
+    // Collect raw args and expand aliases before clap parsing
+    let raw_args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    let expanded = expand_alias(raw_args);
+
+    let cli = match Cli::try_parse_from(&expanded) {
+        Ok(cli) => cli,
+        Err(e) => {
+            e.exit();
+        }
+    };
     let verbose = cli.verbose;
 
     if cli.list_formats {
@@ -51,6 +60,67 @@ fn run_main() -> i32 {
         return 1;
     }
     0
+}
+
+/// Split an alias command string into individual arguments,
+/// handling single and double quoted strings.
+fn split_alias_command(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+
+    for ch in s.chars() {
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            ' ' | '\t' if !in_single && !in_double => {
+                if !current.is_empty() {
+                    parts.push(current.clone());
+                    current.clear();
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        parts.push(current);
+    }
+    parts
+}
+
+/// Expand aliases in the raw argument list.
+/// If args[1] matches a known alias, replace it with the alias expansion.
+fn expand_alias(args: Vec<std::ffi::OsString>) -> Vec<std::ffi::OsString> {
+    if args.len() < 2 {
+        return args;
+    }
+
+    let candidate = match args[1].to_str() {
+        Some(s) if !s.starts_with('-') => s.to_string(),
+        _ => return args,
+    };
+
+    // Check built-in aliases first
+    let builtins = config::builtin_aliases();
+    let alias_cmd = if let Some(cmd) = builtins.get(&candidate) {
+        Some(cmd.clone())
+    } else {
+        // Check user-defined aliases from config
+        let source = config::load_config();
+        source.config.aliases.get(&candidate).cloned()
+    };
+
+    if let Some(cmd) = alias_cmd {
+        let mut new_args = vec![args[0].clone()];
+        for part in split_alias_command(&cmd) {
+            new_args.push(std::ffi::OsString::from(part));
+        }
+        new_args.extend_from_slice(&args[2..]);
+        new_args
+    } else {
+        args
+    }
 }
 
 /// 지원 포맷 목록 출력
@@ -587,6 +657,14 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             ConfigAction::Show => config::run_show()?,
             ConfigAction::Init { project } => config::run_init(project)?,
         },
+        Commands::Alias { action } => {
+            let source = config::load_config();
+            match action {
+                AliasAction::Set(args) => config::run_alias_set(&args.name, &args.command)?,
+                AliasAction::List => config::run_alias_list(&source.config.aliases)?,
+                AliasAction::Remove { name } => config::run_alias_remove(&name)?,
+            }
+        }
         Commands::Diff {
             file1,
             file2,


### PR DESCRIPTION
## Summary

- `dkit alias set/list/remove` 서브커맨드로 별칭 관리
- 내장 별칭 8개 제공: `j2c`, `c2j`, `j2y`, `y2j`, `j2t`, `t2j`, `c2y`, `y2c`
- `dkit <alias> [args]` 실행 시 clap 파싱 전에 자동 확장
- 사용자 별칭은 `~/.dkit.toml`의 `[aliases]` 섹션에 저장

## Test plan

- [ ] `dkit alias list` → 내장 별칭 8개 출력 확인
- [ ] `dkit j2c data.json` → JSON을 CSV로 변환 확인
- [ ] `dkit alias set peek 'view --head 5'` → 별칭 등록 후 `dkit peek data.json` 동작 확인
- [ ] `dkit alias remove peek` → 별칭 삭제 확인
- [ ] 내장 별칭 remove 시 에러 메시지 확인
- [ ] `cargo test` 전체 통과 확인

Closes #111

https://claude.ai/code/session_014hrVKBJDVqJbJLYcnzD2Ev