### PR TITLE
Add criterion benchmark suite for format I/O, queries, and conversions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,38 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchmark:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run benchmarks
+        run: cargo bench --bench format_benchmarks --bench query_benchmarks --bench conversion_benchmarks -- --output-format bencher | tee benchmark_output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          tool: cargo
+          output-file-path: benchmark_output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-comment-cc-users: "@syangkkim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +503,33 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-targets",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -611,6 +650,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -764,6 +858,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "comfy-table",
+ "criterion",
  "csv",
  "ctrlc",
  "dirs",
@@ -795,6 +890,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -1031,6 +1132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1317,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1346,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1677,6 +1804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1906,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1915,6 +2076,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2365,6 +2546,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,6 +2814,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,16 @@ tempfile = "3"
 rusqlite = { version = "0.31", features = ["bundled"] }
 arrow = { version = "53", default-features = false }
 parquet = { version = "53", default-features = false, features = ["arrow"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "format_benchmarks"
+harness = false
+
+[[bench]]
+name = "query_benchmarks"
+harness = false
+
+[[bench]]
+name = "conversion_benchmarks"
+harness = false

--- a/benches/conversion_benchmarks.rs
+++ b/benches/conversion_benchmarks.rs
@@ -1,0 +1,165 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dkit::format::{FormatOptions, FormatReader, FormatWriter};
+use dkit::format::csv::{CsvReader, CsvWriter};
+use dkit::format::json::{JsonReader, JsonWriter};
+use dkit::format::jsonl::{JsonlReader, JsonlWriter};
+use dkit::value::Value;
+use indexmap::IndexMap;
+
+fn generate_json_array(n: usize) -> String {
+    let records: Vec<String> = (0..n)
+        .map(|i| {
+            format!(
+                r#"{{"id":{i},"name":"User {i}","age":{age},"score":{score:.2},"active":{active}}}"#,
+                i = i,
+                age = 20 + (i % 60),
+                score = (i as f64 * 1.5) % 100.0,
+                active = i % 2 == 0,
+            )
+        })
+        .collect();
+    format!("[{}]", records.join(","))
+}
+
+fn generate_csv(n: usize) -> String {
+    let mut lines = vec!["id,name,age,score,active".to_string()];
+    for i in 0..n {
+        lines.push(format!(
+            "{i},User {i},{},{:.2},{}",
+            20 + (i % 60),
+            (i as f64 * 1.5) % 100.0,
+            i % 2 == 0,
+        ));
+    }
+    lines.join("\n")
+}
+
+fn generate_jsonl(n: usize) -> String {
+    (0..n)
+        .map(|i| {
+            format!(
+                r#"{{"id":{i},"name":"User {i}","age":{age},"score":{score:.2},"active":{active}}}"#,
+                i = i,
+                age = 20 + (i % 60),
+                score = (i as f64 * 1.5) % 100.0,
+                active = i % 2 == 0,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn generate_value(n: usize) -> Value {
+    let records: Vec<Value> = (0..n)
+        .map(|i| {
+            let mut map = IndexMap::new();
+            map.insert("id".to_string(), Value::Integer(i as i64));
+            map.insert("name".to_string(), Value::String(format!("User {i}")));
+            map.insert("age".to_string(), Value::Integer((20 + (i % 60)) as i64));
+            map.insert(
+                "score".to_string(),
+                Value::Float((i as f64 * 1.5) % 100.0),
+            );
+            map.insert("active".to_string(), Value::Bool(i % 2 == 0));
+            Value::Object(map)
+        })
+        .collect();
+    Value::Array(records)
+}
+
+const SMALL: usize = 1_000;
+const MEDIUM: usize = 10_000;
+
+fn bench_json_to_csv(c: &mut Criterion) {
+    let mut group = c.benchmark_group("convert_json_to_csv");
+    let json_reader = JsonReader;
+    let csv_writer = CsvWriter::default();
+    for size in [SMALL, MEDIUM] {
+        let input = generate_json_array(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| {
+                let value = json_reader.read(input).unwrap();
+                csv_writer.write(&value).unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_csv_to_json(c: &mut Criterion) {
+    let mut group = c.benchmark_group("convert_csv_to_json");
+    let csv_reader = CsvReader::default();
+    let json_writer = JsonWriter::new(FormatOptions {
+        compact: true,
+        ..Default::default()
+    });
+    for size in [SMALL, MEDIUM] {
+        let input = generate_csv(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| {
+                let value = csv_reader.read(input).unwrap();
+                json_writer.write(&value).unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_json_to_jsonl(c: &mut Criterion) {
+    let mut group = c.benchmark_group("convert_json_to_jsonl");
+    let json_reader = JsonReader;
+    let jsonl_writer = JsonlWriter;
+    for size in [SMALL, MEDIUM] {
+        let input = generate_json_array(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| {
+                let value = json_reader.read(input).unwrap();
+                jsonl_writer.write(&value).unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_jsonl_to_csv(c: &mut Criterion) {
+    let mut group = c.benchmark_group("convert_jsonl_to_csv");
+    let jsonl_reader = JsonlReader;
+    let csv_writer = CsvWriter::default();
+    for size in [SMALL, MEDIUM] {
+        let input = generate_jsonl(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| {
+                let value = jsonl_reader.read(input).unwrap();
+                csv_writer.write(&value).unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_value_to_formats(c: &mut Criterion) {
+    let mut group = c.benchmark_group("value_serialize");
+    let json_writer = JsonWriter::new(FormatOptions {
+        compact: true,
+        ..Default::default()
+    });
+    let csv_writer = CsvWriter::default();
+    let jsonl_writer = JsonlWriter;
+
+    let value = generate_value(SMALL);
+
+    group.bench_function("json", |b| b.iter(|| json_writer.write(&value).unwrap()));
+    group.bench_function("csv", |b| b.iter(|| csv_writer.write(&value).unwrap()));
+    group.bench_function("jsonl", |b| b.iter(|| jsonl_writer.write(&value).unwrap()));
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_json_to_csv,
+    bench_csv_to_json,
+    bench_json_to_jsonl,
+    bench_jsonl_to_csv,
+    bench_value_to_formats,
+);
+criterion_main!(benches);

--- a/benches/conversion_benchmarks.rs
+++ b/benches/conversion_benchmarks.rs
@@ -1,8 +1,8 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use dkit::format::{FormatOptions, FormatReader, FormatWriter};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use dkit::format::csv::{CsvReader, CsvWriter};
 use dkit::format::json::{JsonReader, JsonWriter};
 use dkit::format::jsonl::{JsonlReader, JsonlWriter};
+use dkit::format::{FormatOptions, FormatReader, FormatWriter};
 use dkit::value::Value;
 use indexmap::IndexMap;
 
@@ -56,10 +56,7 @@ fn generate_value(n: usize) -> Value {
             map.insert("id".to_string(), Value::Integer(i as i64));
             map.insert("name".to_string(), Value::String(format!("User {i}")));
             map.insert("age".to_string(), Value::Integer((20 + (i % 60)) as i64));
-            map.insert(
-                "score".to_string(),
-                Value::Float((i as f64 * 1.5) % 100.0),
-            );
+            map.insert("score".to_string(), Value::Float((i as f64 * 1.5) % 100.0));
             map.insert("active".to_string(), Value::Bool(i % 2 == 0));
             Value::Object(map)
         })

--- a/benches/format_benchmarks.rs
+++ b/benches/format_benchmarks.rs
@@ -1,8 +1,8 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use dkit::format::{FormatOptions, FormatReader, FormatWriter};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use dkit::format::csv::{CsvReader, CsvWriter};
 use dkit::format::json::{JsonReader, JsonWriter};
 use dkit::format::yaml::{YamlReader, YamlWriter};
+use dkit::format::{FormatOptions, FormatReader, FormatWriter};
 use dkit::value::Value;
 use indexmap::IndexMap;
 
@@ -59,10 +59,7 @@ fn generate_value(n: usize) -> Value {
             map.insert("id".to_string(), Value::Integer(i as i64));
             map.insert("name".to_string(), Value::String(format!("User {i}")));
             map.insert("age".to_string(), Value::Integer((20 + (i % 60)) as i64));
-            map.insert(
-                "score".to_string(),
-                Value::Float((i as f64 * 1.5) % 100.0),
-            );
+            map.insert("score".to_string(), Value::Float((i as f64 * 1.5) % 100.0));
             map.insert("active".to_string(), Value::Bool(i % 2 == 0));
             Value::Object(map)
         })

--- a/benches/format_benchmarks.rs
+++ b/benches/format_benchmarks.rs
@@ -1,0 +1,162 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dkit::format::{FormatOptions, FormatReader, FormatWriter};
+use dkit::format::csv::{CsvReader, CsvWriter};
+use dkit::format::json::{JsonReader, JsonWriter};
+use dkit::format::yaml::{YamlReader, YamlWriter};
+use dkit::value::Value;
+use indexmap::IndexMap;
+
+/// Generate a JSON array string with `n` records
+fn generate_json_data(n: usize) -> String {
+    let records: Vec<String> = (0..n)
+        .map(|i| {
+            format!(
+                r#"{{"id":{i},"name":"User {i}","age":{age},"score":{score:.2},"active":{active}}}"#,
+                i = i,
+                age = 20 + (i % 60),
+                score = (i as f64 * 1.5) % 100.0,
+                active = i % 2 == 0,
+            )
+        })
+        .collect();
+    format!("[{}]", records.join(","))
+}
+
+/// Generate a CSV string with `n` records
+fn generate_csv_data(n: usize) -> String {
+    let mut lines = vec!["id,name,age,score,active".to_string()];
+    for i in 0..n {
+        lines.push(format!(
+            "{i},User {i},{},{:.2},{}",
+            20 + (i % 60),
+            (i as f64 * 1.5) % 100.0,
+            i % 2 == 0,
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Generate a YAML array string with `n` records
+fn generate_yaml_data(n: usize) -> String {
+    let mut lines = Vec::new();
+    for i in 0..n {
+        lines.push(format!(
+            "- id: {i}\n  name: \"User {i}\"\n  age: {age}\n  score: {score:.2}\n  active: {active}",
+            i = i,
+            age = 20 + (i % 60),
+            score = (i as f64 * 1.5) % 100.0,
+            active = i % 2 == 0,
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Generate a Value::Array with `n` records for write benchmarks
+fn generate_value(n: usize) -> Value {
+    let records: Vec<Value> = (0..n)
+        .map(|i| {
+            let mut map = IndexMap::new();
+            map.insert("id".to_string(), Value::Integer(i as i64));
+            map.insert("name".to_string(), Value::String(format!("User {i}")));
+            map.insert("age".to_string(), Value::Integer((20 + (i % 60)) as i64));
+            map.insert(
+                "score".to_string(),
+                Value::Float((i as f64 * 1.5) % 100.0),
+            );
+            map.insert("active".to_string(), Value::Bool(i % 2 == 0));
+            Value::Object(map)
+        })
+        .collect();
+    Value::Array(records)
+}
+
+// Benchmark sizes: small (~1K records), medium (~10K records)
+const SMALL: usize = 1_000;
+const MEDIUM: usize = 10_000;
+
+fn bench_json_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_read");
+    for size in [SMALL, MEDIUM] {
+        let data = generate_json_data(size);
+        let reader = JsonReader;
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| reader.read(data).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_json_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_write");
+    for size in [SMALL, MEDIUM] {
+        let value = generate_value(size);
+        let writer = JsonWriter::new(FormatOptions {
+            compact: true,
+            ..Default::default()
+        });
+        group.bench_with_input(BenchmarkId::from_parameter(size), &value, |b, value| {
+            b.iter(|| writer.write(value).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_csv_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("csv_read");
+    for size in [SMALL, MEDIUM] {
+        let data = generate_csv_data(size);
+        let reader = CsvReader::default();
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| reader.read(data).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_csv_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("csv_write");
+    for size in [SMALL, MEDIUM] {
+        let value = generate_value(size);
+        let writer = CsvWriter::default();
+        group.bench_with_input(BenchmarkId::from_parameter(size), &value, |b, value| {
+            b.iter(|| writer.write(value).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_yaml_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("yaml_read");
+    // YAML is significantly slower; use smaller sizes
+    for size in [100, 500] {
+        let data = generate_yaml_data(size);
+        let reader = YamlReader;
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| reader.read(data).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_yaml_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("yaml_write");
+    for size in [100, 500] {
+        let value = generate_value(size);
+        let writer = YamlWriter::default();
+        group.bench_with_input(BenchmarkId::from_parameter(size), &value, |b, value| {
+            b.iter(|| writer.write(value).unwrap())
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_json_read,
+    bench_json_write,
+    bench_csv_read,
+    bench_csv_write,
+    bench_yaml_read,
+    bench_yaml_write,
+);
+criterion_main!(benches);

--- a/benches/query_benchmarks.rs
+++ b/benches/query_benchmarks.rs
@@ -1,0 +1,135 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use dkit::query::filter::apply_operations;
+use dkit::query::parser::parse_query;
+use dkit::value::Value;
+use indexmap::IndexMap;
+
+/// Generate a Value::Array with `n` records for query benchmarks
+fn make_records(n: usize) -> Value {
+    let records: Vec<Value> = (0..n)
+        .map(|i| {
+            let mut map = IndexMap::new();
+            map.insert("id".to_string(), Value::Integer(i as i64));
+            map.insert("name".to_string(), Value::String(format!("User {i}")));
+            map.insert("age".to_string(), Value::Integer((20 + (i % 60)) as i64));
+            map.insert(
+                "score".to_string(),
+                Value::Float((i as f64 * 1.5) % 100.0),
+            );
+            map.insert(
+                "category".to_string(),
+                Value::String(
+                    ["A", "B", "C", "D"][i % 4].to_string(),
+                ),
+            );
+            map.insert("active".to_string(), Value::Bool(i % 2 == 0));
+            Value::Object(map)
+        })
+        .collect();
+    Value::Array(records)
+}
+
+const SMALL: usize = 1_000;
+const MEDIUM: usize = 10_000;
+
+fn bench_filter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_filter");
+    let query = parse_query(". | where age > 30").unwrap();
+    for size in [SMALL, MEDIUM] {
+        let data = make_records(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| apply_operations(data.clone(), &query.operations).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_sort(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_sort");
+    let query = parse_query(". | sort age").unwrap();
+    for size in [SMALL, MEDIUM] {
+        let data = make_records(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| apply_operations(data.clone(), &query.operations).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_sort_desc(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_sort_desc");
+    let query = parse_query(". | sort score desc").unwrap();
+    for size in [SMALL, MEDIUM] {
+        let data = make_records(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| apply_operations(data.clone(), &query.operations).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_aggregate_sum(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_sum");
+    let query = parse_query(". | sum score").unwrap();
+    for size in [SMALL, MEDIUM] {
+        let data = make_records(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| apply_operations(data.clone(), &query.operations).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_aggregate_group_by(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_group_by");
+    let query = parse_query(". | group_by category").unwrap();
+    for size in [SMALL, MEDIUM] {
+        let data = make_records(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| apply_operations(data.clone(), &query.operations).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_filter_and_sort(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_filter_sort");
+    let query = parse_query(". | where age > 30 | sort score desc").unwrap();
+    for size in [SMALL, MEDIUM] {
+        let data = make_records(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| apply_operations(data.clone(), &query.operations).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_query_parse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_parse");
+    let queries = [
+        ". | where age > 30",
+        ". | sort score desc | limit 100",
+        ". | group_by category | select category, count",
+        ". | where active == true | sort age | limit 50",
+    ];
+    for query_str in queries {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(query_str),
+            query_str,
+            |b, q| b.iter(|| parse_query(q).unwrap()),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_filter,
+    bench_sort,
+    bench_sort_desc,
+    bench_aggregate_sum,
+    bench_aggregate_group_by,
+    bench_filter_and_sort,
+    bench_query_parse,
+);
+criterion_main!(benches);

--- a/benches/query_benchmarks.rs
+++ b/benches/query_benchmarks.rs
@@ -1,4 +1,4 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use dkit::query::filter::apply_operations;
 use dkit::query::parser::parse_query;
 use dkit::value::Value;
@@ -12,15 +12,10 @@ fn make_records(n: usize) -> Value {
             map.insert("id".to_string(), Value::Integer(i as i64));
             map.insert("name".to_string(), Value::String(format!("User {i}")));
             map.insert("age".to_string(), Value::Integer((20 + (i % 60)) as i64));
-            map.insert(
-                "score".to_string(),
-                Value::Float((i as f64 * 1.5) % 100.0),
-            );
+            map.insert("score".to_string(), Value::Float((i as f64 * 1.5) % 100.0));
             map.insert(
                 "category".to_string(),
-                Value::String(
-                    ["A", "B", "C", "D"][i % 4].to_string(),
-                ),
+                Value::String(["A", "B", "C", "D"][i % 4].to_string()),
             );
             map.insert("active".to_string(), Value::Bool(i % 2 == 0));
             Value::Object(map)
@@ -113,11 +108,9 @@ fn bench_query_parse(c: &mut Criterion) {
         ". | where active == true | sort age | limit 50",
     ];
     for query_str in queries {
-        group.bench_with_input(
-            BenchmarkId::from_parameter(query_str),
-            query_str,
-            |b, q| b.iter(|| parse_query(q).unwrap()),
-        );
+        group.bench_with_input(BenchmarkId::from_parameter(query_str), query_str, |b, q| {
+            b.iter(|| parse_query(q).unwrap())
+        });
     }
     group.finish();
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -36,6 +36,7 @@ pub enum Format {
 }
 
 impl Format {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Result<Self, DkitError> {
         match s.to_lowercase().as_str() {
             "json" => Ok(Format::Json),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+// Library interface for use in benchmarks and integration tests
+pub mod error;
+pub mod format;
+pub mod query;
+pub mod value;


### PR DESCRIPTION
## Summary

- `src/lib.rs` 추가: 벤치마크에서 내부 모듈을 사용할 수 있도록 라이브러리 크레이트로 노출
- `criterion` dev-dependency 추가 및 3개의 `[[bench]]` 타겟 등록 (Cargo.toml)
- `benches/format_benchmarks.rs`: JSON/CSV/YAML 읽기·쓰기 속도 (1K, 10K 레코드)
- `benches/query_benchmarks.rs`: filter, sort, sum, group_by, 쿼리 파싱 속도
- `benches/conversion_benchmarks.rs`: JSON↔CSV, JSON↔JSONL, 포맷 직렬화 속도 비교
- `.github/workflows/benchmark.yml`: PR/push 시 벤치마크 자동 실행 + 회귀 감지 (임계값 150%)

## Test plan

- [ ] `cargo build --benches` 통과 확인
- [ ] `cargo bench` 로컬 실행하여 결과 출력 확인
- [ ] GitHub Actions benchmark 워크플로우 실행 확인

Closes #112