### PR TITLE
refactor: stabilize public API with docs, #[non_exhaustive], and MSRV

### DIFF
--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dkit"
 version = "0.9.0"
 edition = "2021"
+rust-version = "1.75.0"
 description = "Swiss army knife for data format conversion and querying"
 license = "MIT"
 repository = "https://github.com/syangkkim/dkit"

--- a/dkit-cli/src/commands/convert.rs
+++ b/dkit-cli/src/commands/convert.rs
@@ -496,6 +496,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 
@@ -559,6 +560,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
             use crate::output::table::{render_table, TableOptions};
             Ok(render_table(value, &TableOptions::default()) + "\n")
         }
+        _ => bail!("Unsupported output format: {format}"),
     }
 }
 

--- a/dkit-cli/src/commands/diff.rs
+++ b/dkit-cli/src/commands/diff.rs
@@ -225,6 +225,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 
@@ -594,6 +595,7 @@ fn format_scalar(value: &Value) -> String {
             }
         }
         Value::Array(_) | Value::Object(_) => value.to_string(),
+        _ => value.to_string(),
     }
 }
 

--- a/dkit-cli/src/commands/flatten.rs
+++ b/dkit-cli/src/commands/flatten.rs
@@ -489,6 +489,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 
@@ -554,6 +555,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
             use crate::output::table::{render_table, TableOptions};
             Ok(render_table(value, &TableOptions::default()) + "\n")
         }
+        _ => bail!("Unsupported output format: {format}"),
     }
 }
 

--- a/dkit-cli/src/commands/merge.rs
+++ b/dkit-cli/src/commands/merge.rs
@@ -204,6 +204,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 
@@ -225,6 +226,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
             use crate::output::table::{render_table, TableOptions};
             Ok(render_table(value, &TableOptions::default()) + "\n")
         }
+        _ => bail!("Unsupported output format: {format}"),
     }
 }
 

--- a/dkit-cli/src/commands/query.rs
+++ b/dkit-cli/src/commands/query.rs
@@ -191,6 +191,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 
@@ -221,5 +222,6 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
             use crate::output::table::{render_table, TableOptions};
             Ok(render_table(value, &TableOptions::default()) + "\n")
         }
+        _ => bail!("Unsupported output format: {format}"),
     }
 }

--- a/dkit-cli/src/commands/sample.rs
+++ b/dkit-cli/src/commands/sample.rs
@@ -330,6 +330,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 
@@ -395,6 +396,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
             use crate::output::table::{render_table, TableOptions};
             Ok(render_table(value, &TableOptions::default()) + "\n")
         }
+        _ => bail!("Unsupported output format: {format}"),
     }
 }
 

--- a/dkit-cli/src/commands/schema.rs
+++ b/dkit-cli/src/commands/schema.rs
@@ -93,6 +93,7 @@ fn type_name(value: &Value) -> &'static str {
         Value::String(_) => "string",
         Value::Array(_) => "array",
         Value::Object(_) => "object",
+        _ => "unknown",
     }
 }
 
@@ -243,6 +244,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 

--- a/dkit-cli/src/commands/stats.rs
+++ b/dkit-cli/src/commands/stats.rs
@@ -706,6 +706,7 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::String(_) => "string",
         Value::Array(_) => "array",
         Value::Object(_) => "object",
+        _ => "unknown",
     }
 }
 
@@ -843,6 +844,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 

--- a/dkit-cli/src/commands/streaming.rs
+++ b/dkit-cli/src/commands/streaming.rs
@@ -515,6 +515,7 @@ fn value_to_csv_field(v: &Value) -> String {
             let parts: Vec<String> = o.iter().map(|(k, v)| format!("\"{k}\": {v}")).collect();
             format!("{{{}}}", parts.join(", "))
         }
+        _ => format!("{v}"),
     }
 }
 

--- a/dkit-cli/src/commands/validate.rs
+++ b/dkit-cli/src/commands/validate.rs
@@ -125,6 +125,7 @@ fn value_to_json(v: Value) -> serde_json::Value {
                 .collect();
             serde_json::Value::Object(obj)
         }
+        _ => serde_json::Value::Null,
     }
 }
 
@@ -203,6 +204,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 

--- a/dkit-cli/src/commands/view.rs
+++ b/dkit-cli/src/commands/view.rs
@@ -256,6 +256,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
+        _ => bail!("Unsupported input format: {format}"),
     }
 }
 
@@ -274,6 +275,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Markdown => MarkdownWriter.write(value),
         Format::Html => HtmlWriter::new(options.styled, options.full_html).write(value),
         Format::Table => bail!("Table format is handled separately"),
+        _ => bail!("Unsupported output format: {format}"),
     }
 }
 

--- a/dkit-cli/src/output/table.rs
+++ b/dkit-cli/src/output/table.rs
@@ -233,6 +233,7 @@ fn format_cell_value(v: &Value) -> String {
             format!("[{}]", items.join(", "))
         }
         Value::Object(_) => "{...}".to_string(),
+        _ => format!("{v}"),
     }
 }
 

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dkit-core"
 version = "0.9.0"
 edition = "2021"
+rust-version = "1.75.0"
 description = "Core library for dkit — data format conversion and querying engine"
 license = "MIT"
 repository = "https://github.com/syangkkim/dkit"

--- a/dkit-core/src/error.rs
+++ b/dkit-core/src/error.rs
@@ -37,11 +37,12 @@ pub fn suggest_format(input: &str) -> Option<&'static str> {
         .min_by_key(|&f| levenshtein(&input_lower, f))
 }
 
-/// dkit 에러 타입 정의
+/// Error types for dkit operations.
 ///
-/// 포맷 파싱, 쓰기, IO, 쿼리 등 카테고리별 에러를 구분하며,
-/// `thiserror`로 `Display`와 `Error`를 자동 구현한다.
+/// Covers format parsing, writing, IO, query evaluation, and path navigation.
+/// Uses `thiserror` for automatic `Display` and `Error` implementations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DkitError {
     #[error("Unknown format: '{0}'\n  Supported formats: {}", SUPPORTED_FORMATS.join(", "))]
     UnknownFormat(String),

--- a/dkit-core/src/format/mod.rs
+++ b/dkit-core/src/format/mod.rs
@@ -1,14 +1,26 @@
+/// CSV/TSV reader and writer.
 pub mod csv;
+/// HTML table writer.
 pub mod html;
+/// JSON reader, writer, and value conversion utilities.
 pub mod json;
+/// JSON Lines (NDJSON) reader and writer.
 pub mod jsonl;
+/// Markdown table writer.
 pub mod markdown;
+/// MessagePack binary reader and writer.
 pub mod msgpack;
+/// Apache Parquet columnar format reader and writer.
 pub mod parquet;
+/// SQLite database reader.
 pub mod sqlite;
+/// TOML reader and writer.
 pub mod toml;
+/// Excel (XLSX) reader.
 pub mod xlsx;
+/// XML reader and writer.
 pub mod xml;
+/// YAML reader and writer.
 pub mod yaml;
 
 use std::io::{Read, Write};
@@ -17,21 +29,38 @@ use std::path::Path;
 use crate::error::DkitError;
 use crate::value::Value;
 
-/// 지원하는 데이터 포맷
+/// Supported data formats for reading and writing.
+///
+/// Each variant represents a data serialization format that dkit can
+/// convert to or from the unified [`Value`] model.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum Format {
+    /// JSON (`*.json`)
     Json,
+    /// JSON Lines / NDJSON (`*.jsonl`, `*.ndjson`)
     Jsonl,
+    /// Comma/Tab-separated values (`*.csv`, `*.tsv`)
     Csv,
+    /// YAML (`*.yaml`, `*.yml`)
     Yaml,
+    /// TOML (`*.toml`)
     Toml,
+    /// XML (`*.xml`)
     Xml,
+    /// MessagePack binary format (`*.msgpack`)
     Msgpack,
+    /// Excel spreadsheet (`*.xlsx`, read-only)
     Xlsx,
+    /// SQLite database (`*.sqlite`, read-only)
     Sqlite,
+    /// Apache Parquet columnar format (`*.parquet`)
     Parquet,
+    /// Markdown table (write-only)
     Markdown,
+    /// HTML table (write-only)
     Html,
+    /// Terminal table (write-only, used by `dkit view`)
     Table,
 }
 
@@ -231,7 +260,9 @@ pub fn default_delimiter_for_format(format_str: &str) -> Option<char> {
     }
 }
 
-/// 포맷별 옵션
+/// Format-specific options controlling how data is read or written.
+///
+/// Use [`Default::default()`] to get sensible defaults.
 #[derive(Debug, Clone)]
 pub struct FormatOptions {
     /// CSV delimiter (기본: ',')
@@ -267,17 +298,27 @@ impl Default for FormatOptions {
     }
 }
 
-/// 데이터 포맷 읽기 트레이트
+/// Trait for reading a data format into a [`Value`].
+///
+/// Implement this trait to add support for reading a new data format.
 #[allow(dead_code)]
 pub trait FormatReader {
+    /// Parse the given string content and return a [`Value`].
     fn read(&self, input: &str) -> anyhow::Result<Value>;
+
+    /// Parse data from an [`io::Read`](std::io::Read) source and return a [`Value`].
     fn read_from_reader(&self, reader: impl Read) -> anyhow::Result<Value>;
 }
 
-/// 데이터 포맷 쓰기 트레이트
+/// Trait for writing a [`Value`] to a data format.
+///
+/// Implement this trait to add support for writing a new data format.
 #[allow(dead_code)]
 pub trait FormatWriter {
+    /// Serialize the given [`Value`] and return the formatted string.
     fn write(&self, value: &Value) -> anyhow::Result<String>;
+
+    /// Serialize the given [`Value`] and write to an [`io::Write`](std::io::Write) destination.
     fn write_to_writer(&self, value: &Value, writer: impl Write) -> anyhow::Result<()>;
 }
 

--- a/dkit-core/src/query/mod.rs
+++ b/dkit-core/src/query/mod.rs
@@ -1,4 +1,8 @@
+/// Path evaluator — navigates a [`Value`](crate::value::Value) tree using parsed paths.
 pub mod evaluator;
+/// Pipeline filter operations (where, sort, limit, aggregation, etc.).
 pub mod filter;
+/// Built-in query functions (string, math, date, type conversion).
 pub mod functions;
+/// Query parser — converts query strings into an AST.
 pub mod parser;

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -15,8 +15,9 @@ pub struct Path {
     pub segments: Vec<Segment>,
 }
 
-/// 경로 세그먼트
+/// A single segment of a navigation path.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Segment {
     /// 필드 접근 (`.name`)
     Field(String),
@@ -26,8 +27,9 @@ pub enum Segment {
     Iterate,
 }
 
-/// 파이프라인 연산
+/// Pipeline operation applied after path navigation (e.g., `| where ...`, `| sort ...`).
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Operation {
     /// `where` 필터링
     Where(Condition),
@@ -66,8 +68,9 @@ pub struct GroupAggregate {
     pub alias: String,
 }
 
-/// 집계 함수 종류
+/// Aggregate function used in `group_by` operations.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum AggregateFunc {
     Count,
     Sum,
@@ -76,8 +79,9 @@ pub enum AggregateFunc {
     Max,
 }
 
-/// 조건식 (where 절)
+/// Boolean condition used in `where` clauses.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Condition {
     /// 단일 비교: `field op value`
     Comparison(Comparison),
@@ -95,8 +99,9 @@ pub struct Comparison {
     pub value: LiteralValue,
 }
 
-/// 비교 연산자
+/// Comparison operator used in `where` conditions.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum CompareOp {
     Eq,         // ==
     Ne,         // !=
@@ -109,8 +114,9 @@ pub enum CompareOp {
     EndsWith,   // ends_with
 }
 
-/// 리터럴 값 (비교 대상)
+/// Literal value used as a comparison operand or in expressions.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum LiteralValue {
     String(String),
     Integer(i64),
@@ -119,8 +125,9 @@ pub enum LiteralValue {
     Null,
 }
 
-/// 표현식 (select 절 등에서 사용)
+/// Expression used in `select` clauses and function arguments.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Expr {
     /// 필드 참조: `name`
     Field(String),
@@ -138,22 +145,24 @@ pub struct SelectExpr {
     pub alias: Option<String>,
 }
 
-/// 쿼리 문자열을 파싱하는 파서
-pub struct Parser {
+/// Internal query string parser.
+///
+/// Use the public [`parse_query`] function instead of constructing this directly.
+pub(crate) struct Parser {
     input: Vec<char>,
     pos: usize,
 }
 
 impl Parser {
-    pub fn new(input: &str) -> Self {
+    pub(crate) fn new(input: &str) -> Self {
         Self {
             input: input.chars().collect(),
             pos: 0,
         }
     }
 
-    /// 쿼리 문자열을 파싱하여 Query AST를 반환
-    pub fn parse(&mut self) -> Result<Query, DkitError> {
+    /// Parse the query string into a [`Query`] AST.
+    pub(crate) fn parse(&mut self) -> Result<Query, DkitError> {
         self.skip_whitespace();
         let path = self.parse_path()?;
         self.skip_whitespace();

--- a/dkit-core/src/value.rs
+++ b/dkit-core/src/value.rs
@@ -3,14 +3,37 @@ use std::fmt;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
+/// Unified data model for all supported formats.
+///
+/// Every data format (JSON, CSV, YAML, TOML, XML, etc.) is converted to and
+/// from this common representation. The variants cover all primitive and
+/// composite data types needed for lossless round-trip conversion.
+///
+/// # Examples
+///
+/// ```
+/// use dkit_core::value::Value;
+///
+/// let v = Value::Integer(42);
+/// assert_eq!(v.as_i64(), Some(42));
+/// assert!(v.as_str().is_none());
+/// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum Value {
+    /// JSON `null` / missing value.
     Null,
+    /// Boolean value.
     Bool(bool),
+    /// 64-bit signed integer.
     Integer(i64),
+    /// 64-bit floating-point number.
     Float(f64),
+    /// UTF-8 string.
     String(String),
+    /// Ordered sequence of values.
     Array(Vec<Value>),
+    /// Ordered map of string keys to values (insertion order preserved).
     Object(IndexMap<String, Value>),
 }
 
@@ -60,6 +83,7 @@ impl fmt::Display for Value {
 
 #[allow(dead_code)]
 impl Value {
+    /// Returns the boolean value if this is a `Bool`, otherwise `None`.
     pub fn as_bool(&self) -> Option<bool> {
         match self {
             Value::Bool(b) => Some(*b),
@@ -67,6 +91,7 @@ impl Value {
         }
     }
 
+    /// Returns the integer value if this is an `Integer`, otherwise `None`.
     pub fn as_i64(&self) -> Option<i64> {
         match self {
             Value::Integer(n) => Some(*n),
@@ -74,6 +99,7 @@ impl Value {
         }
     }
 
+    /// Returns the value as `f64`. Works for both `Float` and `Integer` variants.
     pub fn as_f64(&self) -> Option<f64> {
         match self {
             Value::Float(f) => Some(*f),
@@ -82,6 +108,7 @@ impl Value {
         }
     }
 
+    /// Returns a string slice if this is a `String`, otherwise `None`.
     pub fn as_str(&self) -> Option<&str> {
         match self {
             Value::String(s) => Some(s),
@@ -89,6 +116,7 @@ impl Value {
         }
     }
 
+    /// Returns a reference to the inner `Vec` if this is an `Array`, otherwise `None`.
     pub fn as_array(&self) -> Option<&Vec<Value>> {
         match self {
             Value::Array(a) => Some(a),
@@ -96,6 +124,7 @@ impl Value {
         }
     }
 
+    /// Returns a reference to the inner `IndexMap` if this is an `Object`, otherwise `None`.
     pub fn as_object(&self) -> Option<&IndexMap<String, Value>> {
         match self {
             Value::Object(o) => Some(o),
@@ -103,6 +132,7 @@ impl Value {
         }
     }
 
+    /// Returns `true` if this value is `Null`.
     pub fn is_null(&self) -> bool {
         matches!(self, Value::Null)
     }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,237 @@
+# dkit-core Public API Reference
+
+This document lists the public API surface of the `dkit-core` crate (v0.9.0+).
+
+All items marked with `#[non_exhaustive]` may gain new variants or fields in future minor versions without a breaking change.
+
+## MSRV
+
+Minimum Supported Rust Version: **1.75.0**
+
+---
+
+## `value` module
+
+### `Value` enum (`#[non_exhaustive]`)
+
+Unified data model for all supported formats.
+
+| Variant | Description |
+|---------|-------------|
+| `Null` | JSON null / missing value |
+| `Bool(bool)` | Boolean |
+| `Integer(i64)` | 64-bit signed integer |
+| `Float(f64)` | 64-bit floating-point |
+| `String(String)` | UTF-8 string |
+| `Array(Vec<Value>)` | Ordered sequence |
+| `Object(IndexMap<String, Value>)` | Ordered key-value map |
+
+**Methods:**
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `as_bool()` | `Option<bool>` | Extract boolean value |
+| `as_i64()` | `Option<i64>` | Extract integer value |
+| `as_f64()` | `Option<f64>` | Extract as f64 (works for Integer too) |
+| `as_str()` | `Option<&str>` | Extract string slice |
+| `as_array()` | `Option<&Vec<Value>>` | Extract array reference |
+| `as_object()` | `Option<&IndexMap<String, Value>>` | Extract object reference |
+| `is_null()` | `bool` | Check if null |
+
+**Trait implementations:** `Debug`, `Clone`, `PartialEq`, `Serialize`, `Deserialize`, `Display`
+
+---
+
+## `error` module
+
+### `DkitError` enum (`#[non_exhaustive]`)
+
+| Variant | Description |
+|---------|-------------|
+| `UnknownFormat(String)` | Unrecognized format name |
+| `ParseError { format, source }` | Format parsing failure |
+| `ParseErrorAt { format, source, line, column, line_text }` | Parse error with location |
+| `WriteError { format, source }` | Format writing failure |
+| `FormatDetectionFailed(String)` | Could not auto-detect format |
+| `QueryError(String)` | Invalid query or evaluation error |
+| `IoError(io::Error)` | IO error (auto-converted via `From`) |
+| `PathNotFound(String)` | Path navigation failed |
+
+### `Result<T>` type alias
+
+`type Result<T> = std::result::Result<T, DkitError>`
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `suggest_format(input: &str) -> Option<&'static str>` | Suggest closest format name for typo correction |
+
+### Constants
+
+| Constant | Description |
+|----------|-------------|
+| `SUPPORTED_FORMATS: &[&str]` | List of supported format name strings |
+
+---
+
+## `format` module
+
+### `Format` enum (`#[non_exhaustive]`)
+
+| Variant | Extension(s) | Direction |
+|---------|-------------|-----------|
+| `Json` | `.json` | Read/Write |
+| `Jsonl` | `.jsonl`, `.ndjson` | Read/Write |
+| `Csv` | `.csv`, `.tsv` | Read/Write |
+| `Yaml` | `.yaml`, `.yml` | Read/Write |
+| `Toml` | `.toml` | Read/Write |
+| `Xml` | `.xml` | Read/Write |
+| `Msgpack` | `.msgpack` | Read/Write |
+| `Xlsx` | `.xlsx` | Read only |
+| `Sqlite` | `.sqlite`, `.db` | Read only |
+| `Parquet` | `.parquet` | Read/Write |
+| `Markdown` | `.md` | Write only |
+| `Html` | `.html` | Write only |
+| `Table` | — | Write only (terminal) |
+
+**Methods:**
+
+| Method | Description |
+|--------|-------------|
+| `from_str(s) -> Result<Format, DkitError>` | Parse format name string |
+| `list_output_formats() -> &[(&str, &str)]` | List all formats with descriptions |
+
+### `FormatOptions` struct (`#[non_exhaustive]`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `delimiter` | `Option<char>` | `None` | CSV delimiter |
+| `no_header` | `bool` | `false` | CSV headerless mode |
+| `pretty` | `bool` | `true` | Pretty-print output |
+| `compact` | `bool` | `false` | Compact output (JSON) |
+| `flow_style` | `bool` | `false` | YAML flow style |
+| `root_element` | `Option<String>` | `None` | XML root element name |
+| `styled` | `bool` | `false` | HTML inline CSS |
+| `full_html` | `bool` | `false` | Full HTML document |
+
+### `FormatReader` trait
+
+| Method | Description |
+|--------|-------------|
+| `read(&self, input: &str) -> Result<Value>` | Parse string content |
+| `read_from_reader(&self, reader: impl Read) -> Result<Value>` | Parse from reader |
+
+### `FormatWriter` trait
+
+| Method | Description |
+|--------|-------------|
+| `write(&self, value: &Value) -> Result<String>` | Serialize to string |
+| `write_to_writer(&self, value: &Value, writer: impl Write) -> Result<()>` | Serialize to writer |
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `detect_format(path: &Path) -> Result<Format>` | Detect format from file extension |
+| `detect_format_from_content(content: &str) -> Result<(Format, Option<char>)>` | Detect format from content sniffing |
+| `default_delimiter(path: &Path) -> Option<char>` | Default delimiter for file extension |
+| `default_delimiter_for_format(format_str: &str) -> Option<char>` | Default delimiter for format name |
+
+### Format Readers & Writers
+
+| Module | Reader | Writer |
+|--------|--------|--------|
+| `json` | `JsonReader` | `JsonWriter` |
+| `jsonl` | `JsonlReader` | `JsonlWriter` |
+| `csv` | `CsvReader` | `CsvWriter` |
+| `yaml` | `YamlReader` | `YamlWriter` |
+| `toml` | `TomlReader` | `TomlWriter` |
+| `xml` | `XmlReader` | `XmlWriter` |
+| `msgpack` | `MsgpackReader` | `MsgpackWriter` |
+| `xlsx` | `XlsxReader` | — |
+| `sqlite` | `SqliteReader` | — |
+| `parquet` | `ParquetReader` | `ParquetWriter` |
+| `markdown` | — | `MarkdownWriter` |
+| `html` | — | `HtmlWriter` |
+
+### Conversion Utilities
+
+| Function | Module | Description |
+|----------|--------|-------------|
+| `from_json_value(v: serde_json::Value) -> Value` | `json` | Convert serde_json Value to dkit Value |
+| `to_json_value(v: &Value) -> serde_json::Value` | `json` | Convert dkit Value to serde_json Value |
+
+---
+
+## `query` module
+
+### Parser Functions
+
+| Function | Description |
+|----------|-------------|
+| `parse_query(input: &str) -> Result<Query>` | Parse a query string into an AST |
+| `parse_condition_expr(input: &str) -> Result<Condition>` | Parse a standalone condition expression |
+
+### `Query` struct
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `Path` | Navigation path (`.users[0].name`) |
+| `operations` | `Vec<Operation>` | Pipeline operations (`\| where ...`) |
+
+### `Path` struct
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `segments` | `Vec<Segment>` | Path segments |
+
+### `Segment` enum (`#[non_exhaustive]`)
+
+| Variant | Description |
+|---------|-------------|
+| `Field(String)` | Field access (`.name`) |
+| `Index(i64)` | Array index (`[0]`, `[-1]`) |
+| `Iterate` | Array iteration (`[]`) |
+
+### `Operation` enum (`#[non_exhaustive]`)
+
+`Where`, `Select`, `Sort`, `Limit`, `Count`, `Sum`, `Avg`, `Min`, `Max`, `Distinct`, `GroupBy`
+
+### `Condition` enum (`#[non_exhaustive]`)
+
+`Comparison`, `And`, `Or`
+
+### `CompareOp` enum (`#[non_exhaustive]`)
+
+`Eq` (`==`), `Ne` (`!=`), `Gt` (`>`), `Lt` (`<`), `Ge` (`>=`), `Le` (`<=`), `Contains`, `StartsWith`, `EndsWith`
+
+### `Expr` enum (`#[non_exhaustive]`)
+
+`Field`, `Literal`, `FuncCall`
+
+### `LiteralValue` enum (`#[non_exhaustive]`)
+
+`String`, `Integer`, `Float`, `Bool`, `Null`
+
+### `AggregateFunc` enum (`#[non_exhaustive]`)
+
+`Count`, `Sum`, `Avg`, `Min`, `Max`
+
+### Evaluator & Filter Functions
+
+| Function | Description |
+|----------|-------------|
+| `evaluate_path(value: &Value, path: &Path) -> Result<Value>` | Navigate a Value using a parsed path |
+| `apply_operations(value: Value, ops: &[Operation]) -> Result<Value>` | Apply pipeline operations to a Value |
+| `evaluate_expr(row: &Value, expr: &Expr) -> Result<Value>` | Evaluate an expression against a record |
+| `expr_default_key(expr: &Expr) -> String` | Generate a default output key for an expression |
+
+---
+
+## Deprecation Policy
+
+- Public API items will be marked `#[deprecated]` for at least one minor version before removal.
+- Deprecated items will include a message describing the replacement.
+- Removals happen only in the next major version (`1.0.0` → `2.0.0`).
+- `#[non_exhaustive]` enums and structs may gain new variants/fields in minor versions.


### PR DESCRIPTION
## Summary

- Add `#[doc]` documentation to all public types, methods, traits, and modules in dkit-core (`Value`, `DkitError`, `Format`, `FormatOptions`, `FormatReader`, `FormatWriter`, query parser types, evaluator, filter, functions)
- Apply `#[non_exhaustive]` to extensible enums: `Value`, `DkitError`, `Format`, `Operation`, `CompareOp`, `AggregateFunc`, `Condition`, `Segment`, `LiteralValue`, `Expr`
- Hide internal `Parser` struct behind `pub(crate)`, exposing only `parse_query()` and `parse_condition_expr()`
- Add MSRV (`rust-version = "1.75.0"`) to both `Cargo.toml` files
- Add wildcard match arms in dkit-cli for non-exhaustive enum handling
- Create `docs/api-reference.md` with full public API inventory and deprecation policy

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 519 tests + 2 doc-tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #116