### PR TITLE
Add man page generation and --examples flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +865,7 @@ dependencies = [
  "chardetng",
  "clap",
  "clap_complete",
+ "clap_mangen",
  "colored",
  "comfy-table",
  "csv",
@@ -2195,6 +2206,12 @@ dependencies = [
  "rmp",
  "serde",
 ]
+
+[[package]]
+name = "roff"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf2048e0e979efb2ca7b91c4f1a8d77c91853e9b987c94c555668a8994915ad"
 
 [[package]]
 name = "rusqlite"

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -44,6 +44,11 @@ ctrlc = { version = "3", features = ["termination"] }
 miette = { version = "7", features = ["fancy"] }
 rand = "0.8"
 
+[build-dependencies]
+clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+clap_mangen = "0.2"
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/dkit-cli/build.rs
+++ b/dkit-cli/build.rs
@@ -12,6 +12,13 @@ use std::fs;
 use std::path::PathBuf;
 
 fn main() {
+    // Use a larger stack thread to avoid stack overflow on Windows (default 1MB).
+    let builder = std::thread::Builder::new().stack_size(8 * 1024 * 1024);
+    let handler = builder.spawn(generate_man_pages).expect("failed to spawn thread");
+    handler.join().unwrap();
+}
+
+fn generate_man_pages() {
     let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
     let man_dir = out_dir.join("man");
     fs::create_dir_all(&man_dir).expect("failed to create man directory");

--- a/dkit-cli/build.rs
+++ b/dkit-cli/build.rs
@@ -14,7 +14,9 @@ use std::path::PathBuf;
 fn main() {
     // Use a larger stack thread to avoid stack overflow on Windows (default 1MB).
     let builder = std::thread::Builder::new().stack_size(8 * 1024 * 1024);
-    let handler = builder.spawn(generate_man_pages).expect("failed to spawn thread");
+    let handler = builder
+        .spawn(generate_man_pages)
+        .expect("failed to spawn thread");
     handler.join().unwrap();
 }
 

--- a/dkit-cli/build.rs
+++ b/dkit-cli/build.rs
@@ -1,0 +1,40 @@
+// build.rs — Generate man pages for dkit and its subcommands using clap_mangen.
+//
+// Man pages are written to $OUT_DIR/man/ during `cargo build`.
+// To install them, copy the generated .1 files to a man page directory
+// (e.g. /usr/local/share/man/man1/).
+
+#[path = "src/cli.rs"]
+mod cli;
+
+use clap::CommandFactory;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    let man_dir = out_dir.join("man");
+    fs::create_dir_all(&man_dir).expect("failed to create man directory");
+
+    let cmd = cli::Cli::command();
+
+    // Generate man page for the top-level command
+    let man = clap_mangen::Man::new(cmd.clone());
+    let mut buf = Vec::new();
+    man.render(&mut buf).expect("failed to render man page");
+    fs::write(man_dir.join("dkit.1"), buf).expect("failed to write dkit.1");
+
+    // Generate man pages for each subcommand
+    for sub in cmd.get_subcommands() {
+        let sub_name = sub.get_name().to_owned();
+        let filename = format!("dkit-{sub_name}.1");
+        let man = clap_mangen::Man::new(sub.clone());
+        let mut buf = Vec::new();
+        man.render(&mut buf).expect("failed to render man page");
+        fs::write(man_dir.join(&filename), buf)
+            .unwrap_or_else(|_| panic!("failed to write {filename}"));
+    }
+
+    // Write the man directory path so the binary can reference it if needed
+    println!("cargo:rustc-env=DKIT_MAN_DIR={}", man_dir.display());
+}

--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -19,6 +19,10 @@ pub struct Cli {
     #[arg(long)]
     pub list_formats: bool,
 
+    /// Show frequently used examples
+    #[arg(long)]
+    pub examples: bool,
+
     /// Show verbose error output (error chain, debug info)
     #[arg(long, global = true)]
     pub verbose: bool,

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -41,6 +41,11 @@ fn run_main() -> i32 {
         return 0;
     }
 
+    if cli.examples {
+        print_examples();
+        return 0;
+    }
+
     match cli.command {
         Some(_) => {}
         None => {
@@ -117,6 +122,63 @@ fn expand_alias(args: Vec<std::ffi::OsString>) -> Vec<std::ffi::OsString> {
     } else {
         args
     }
+}
+
+/// 자주 사용하는 예시 모음 출력
+fn print_examples() {
+    println!(
+        "\
+Frequently used examples:
+
+  Format conversion:
+    dkit convert data.json -f csv              # JSON → CSV
+    dkit convert data.csv -f yaml -o out.yaml  # CSV → YAML (file output)
+    dkit convert '*.json' -f csv --outdir out  # Batch convert all JSON files
+    cat data.json | dkit convert --from json -f toml  # Pipe: JSON → TOML
+
+  Querying:
+    dkit query data.json '.users[0].name'      # Extract a field
+    dkit query data.yaml '.config.database'    # Navigate nested data
+    dkit query data.json '.items[*].price' -f csv  # Query with output format
+
+  Viewing:
+    dkit view data.csv                         # Pretty table output
+    dkit view data.json --path .users -n 5     # Nested data, limit rows
+    dkit view data.csv --columns name,email    # Select columns
+    dkit view data.csv --sort-by age --head 10 # Sort and limit
+
+  Statistics:
+    dkit stats data.csv                        # Overview statistics
+    dkit stats data.csv --column revenue       # Single column stats
+    dkit stats data.csv --histogram            # Text histogram
+
+  Comparing:
+    dkit diff old.json new.json                # Show differences
+    dkit diff a.yaml b.yaml --quiet            # Exit code only
+
+  Merging:
+    dkit merge a.json b.json -f json           # Merge files
+    dkit merge users1.csv users2.csv -f csv    # Merge CSV files
+
+  Sampling:
+    dkit sample data.csv -n 100               # Random sample
+    dkit sample data.csv -n 50 --seed 42      # Reproducible sample
+
+  Schema & validation:
+    dkit schema data.json                     # Show data structure
+    dkit validate data.json --schema s.json   # Validate against schema
+
+  Flatten / unflatten:
+    dkit flatten nested.json                  # Flatten nested keys
+    dkit unflatten flat.json                  # Restore nested structure
+
+  Other:
+    dkit completions bash > ~/.bash_completion.d/dkit  # Shell completions
+    dkit config show                          # Show configuration
+    dkit alias set j2c 'convert -f csv'       # Create alias
+
+Use 'dkit <command> --help' for detailed help on each command."
+    );
 }
 
 /// 지원 포맷 목록 출력


### PR DESCRIPTION
## Summary
- Add `clap_mangen` build dependency and `build.rs` to auto-generate Unix man pages for `dkit` and all 14 subcommands (`dkit-convert.1`, `dkit-query.1`, etc.) at build time
- Add `--examples` flag that prints a curated collection of frequently used example commands across all subcommands
- Man pages are generated in `$OUT_DIR/man/` and can be installed to `/usr/local/share/man/man1/`

## Test plan
- [x] `cargo build` succeeds and generates all 15 man pages in `$OUT_DIR/man/`
- [x] `cargo run -- --examples` prints example collection
- [x] `cargo test` — all 519 unit tests + 13 integration tests pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

Closes #118

https://claude.ai/code/session_017zzvqcAyyrSrw8WWWbZW3E