### PR TITLE
feat: add feature flags for optional format dependencies

### DIFF
--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -18,6 +18,15 @@ pkg-fmt = "tgz"
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"
 
+[features]
+default = []
+xml = ["dkit-core/xml"]
+msgpack = ["dkit-core/msgpack"]
+excel = ["dkit-core/excel"]
+sqlite = ["dkit-core/sqlite"]
+parquet = ["dkit-core/parquet", "dep:arrow", "dep:parquet-impl", "dep:bytes"]
+all = ["xml", "msgpack", "excel", "sqlite", "parquet"]
+
 [dependencies]
 dkit-core = { path = "../dkit-core" }
 clap = { version = "4", features = ["derive"] }
@@ -33,9 +42,9 @@ thiserror = "1"
 anyhow = "1"
 encoding_rs = "0.8"
 chardetng = "0.1"
-arrow = { version = "53", default-features = false, features = ["prettyprint"] }
-parquet = { version = "53", default-features = false, features = ["arrow", "snap", "zstd"] }
-bytes = "1"
+arrow = { version = "53", default-features = false, features = ["prettyprint"], optional = true }
+parquet-impl = { package = "parquet", version = "53", default-features = false, features = ["arrow", "snap", "zstd"], optional = true }
+bytes = { version = "1", optional = true }
 glob = "0.3"
 jsonschema = { version = "0.17", default-features = false }
 dirs = "6.0.0"
@@ -55,4 +64,4 @@ predicates = "3"
 tempfile = "3"
 rusqlite = { version = "0.31", features = ["bundled"] }
 arrow = { version = "53", default-features = false }
-parquet = { version = "53", default-features = false, features = ["arrow"] }
+parquet-impl = { package = "parquet", version = "53", default-features = false, features = ["arrow"] }

--- a/dkit-cli/src/commands/streaming.rs
+++ b/dkit-cli/src/commands/streaming.rs
@@ -29,7 +29,8 @@ impl Default for StreamingOptions {
 
 /// 스트리밍 변환이 가능한 소스/타겟 포맷 조합인지 확인한다.
 pub fn supports_streaming(source: Format, target: Format) -> bool {
-    let readable = matches!(source, Format::Csv | Format::Jsonl | Format::Parquet);
+    let readable = matches!(source, Format::Csv | Format::Jsonl)
+        || (cfg!(feature = "parquet") && matches!(source, Format::Parquet));
     let writable = matches!(target, Format::Csv | Format::Jsonl);
     readable && writable
 }
@@ -84,6 +85,7 @@ pub fn stream_convert(
             opts,
             file_size,
         ),
+        #[cfg(feature = "parquet")]
         Format::Parquet => {
             // Parquet은 메모리 매핑 기반이므로 바이트를 읽어서 Row Group 단위로 처리
             let bytes = std::fs::read(source_path)
@@ -293,6 +295,7 @@ fn stream_from_csv(
 
 // ── Parquet 스트리밍 리더 (Row Group 단위) ──────────────────────
 
+#[cfg(feature = "parquet")]
 fn stream_from_parquet(
     bytes: &[u8],
     writer: impl Write,
@@ -301,7 +304,7 @@ fn stream_from_parquet(
     opts: &StreamingOptions,
 ) -> Result<()> {
     use bytes::Bytes;
-    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet_impl::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
     let bytes = Bytes::copy_from_slice(bytes);
     let builder = ParquetRecordBatchReaderBuilder::try_new(bytes).map_err(|e| {
@@ -595,8 +598,11 @@ mod tests {
         assert!(supports_streaming(Format::Jsonl, Format::Csv));
         assert!(supports_streaming(Format::Csv, Format::Jsonl));
         assert!(supports_streaming(Format::Csv, Format::Csv));
-        assert!(supports_streaming(Format::Parquet, Format::Jsonl));
-        assert!(supports_streaming(Format::Parquet, Format::Csv));
+        #[cfg(feature = "parquet")]
+        {
+            assert!(supports_streaming(Format::Parquet, Format::Jsonl));
+            assert!(supports_streaming(Format::Parquet, Format::Csv));
+        }
 
         assert!(!supports_streaming(Format::Json, Format::Jsonl));
         assert!(!supports_streaming(Format::Jsonl, Format::Json));

--- a/dkit-cli/tests/convert_test.rs
+++ b/dkit-cli/tests/convert_test.rs
@@ -258,6 +258,7 @@ fn convert_unknown_format() {
 }
 
 #[test]
+#[cfg(feature = "xml")]
 fn convert_json_to_xml() {
     dkit()
         .args(&["convert", "tests/fixtures/users.json", "--to", "xml"])
@@ -267,6 +268,7 @@ fn convert_json_to_xml() {
 }
 
 #[test]
+#[cfg(feature = "xml")]
 fn convert_xml_to_json() {
     dkit()
         .args(&["convert", "tests/fixtures/users.xml", "--to", "json"])

--- a/dkit-cli/tests/parquet_test.rs
+++ b/dkit-cli/tests/parquet_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "parquet")]
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 
@@ -10,7 +12,7 @@ fn create_test_parquet(path: &std::path::Path) {
     use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use parquet::arrow::ArrowWriter;
+    use parquet_impl::arrow::ArrowWriter;
     use std::sync::Arc;
 
     let schema = Arc::new(Schema::new(vec![

--- a/dkit-cli/tests/sqlite_test.rs
+++ b/dkit-cli/tests/sqlite_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sqlite")]
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::NamedTempFile;

--- a/dkit-cli/tests/v030_integration_test.rs
+++ b/dkit-cli/tests/v030_integration_test.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "xml", feature = "msgpack"))]
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;

--- a/dkit-cli/tests/v040_xml_jsonl_integration_test.rs
+++ b/dkit-cli/tests/v040_xml_jsonl_integration_test.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "xml", feature = "msgpack"))]
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;

--- a/dkit-cli/tests/v050_integration_test.rs
+++ b/dkit-cli/tests/v050_integration_test.rs
@@ -173,6 +173,7 @@ mod markdown_output {
     }
 
     #[test]
+    #[cfg(feature = "xml")]
     fn convert_xml_to_md() {
         dkit()
             .args(&["convert", "tests/fixtures/users.xml", "--to", "md"])

--- a/dkit-cli/tests/v060_integration_test.rs
+++ b/dkit-cli/tests/v060_integration_test.rs
@@ -1,3 +1,4 @@
+#![cfg(all(feature = "excel", feature = "sqlite", feature = "xml"))]
 //! v0.6.0 통합 테스트: Excel 읽기, SQLite 읽기, 파이프라인 체이닝, 일괄 변환
 
 use assert_cmd::Command;

--- a/dkit-cli/tests/v070_integration_test.rs
+++ b/dkit-cli/tests/v070_integration_test.rs
@@ -13,12 +13,13 @@ fn dkit() -> Command {
 // Parquet 다양한 스키마 및 압축 테스트
 // ============================================================
 
+#[cfg(feature = "parquet")]
 /// 다양한 타입(int, float, string, bool, null 포함)의 Parquet 파일 생성
 fn create_typed_parquet(path: &std::path::Path) {
     use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use parquet::arrow::ArrowWriter;
+    use parquet_impl::arrow::ArrowWriter;
     use std::sync::Arc;
 
     let schema = Arc::new(Schema::new(vec![
@@ -61,14 +62,15 @@ fn create_typed_parquet(path: &std::path::Path) {
     writer.close().unwrap();
 }
 
+#[cfg(feature = "parquet")]
 /// SNAPPY 압축으로 Parquet 파일 생성
 fn create_snappy_parquet(path: &std::path::Path) {
     use arrow::array::{ArrayRef, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use parquet::arrow::ArrowWriter;
-    use parquet::basic::Compression;
-    use parquet::file::properties::WriterProperties;
+    use parquet_impl::arrow::ArrowWriter;
+    use parquet_impl::basic::Compression;
+    use parquet_impl::file::properties::WriterProperties;
     use std::sync::Arc;
 
     let schema = Arc::new(Schema::new(vec![
@@ -91,14 +93,15 @@ fn create_snappy_parquet(path: &std::path::Path) {
     writer.close().unwrap();
 }
 
+#[cfg(feature = "parquet")]
 /// ZSTD 압축으로 Parquet 파일 생성
 fn create_zstd_parquet(path: &std::path::Path) {
     use arrow::array::{ArrayRef, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use parquet::arrow::ArrowWriter;
-    use parquet::basic::{Compression, ZstdLevel};
-    use parquet::file::properties::WriterProperties;
+    use parquet_impl::arrow::ArrowWriter;
+    use parquet_impl::basic::{Compression, ZstdLevel};
+    use parquet_impl::file::properties::WriterProperties;
     use std::sync::Arc;
 
     let schema = Arc::new(Schema::new(vec![
@@ -121,6 +124,7 @@ fn create_zstd_parquet(path: &std::path::Path) {
     writer.close().unwrap();
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_various_types_to_json() {
     let dir = TempDir::new().unwrap();
@@ -138,6 +142,7 @@ fn parquet_various_types_to_json() {
         .stdout(predicate::str::contains("false"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_various_types_to_csv() {
     let dir = TempDir::new().unwrap();
@@ -153,6 +158,7 @@ fn parquet_various_types_to_csv() {
         .stdout(predicate::str::contains("85"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_snappy_compression_roundtrip() {
     let dir = TempDir::new().unwrap();
@@ -169,6 +175,7 @@ fn parquet_snappy_compression_roundtrip() {
         .stdout(predicate::str::contains("z"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_zstd_compression_roundtrip() {
     let dir = TempDir::new().unwrap();
@@ -184,6 +191,7 @@ fn parquet_zstd_compression_roundtrip() {
         .stdout(predicate::str::contains("bar"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn json_to_parquet_with_snappy_compression() {
     let dir = TempDir::new().unwrap();
@@ -214,6 +222,7 @@ fn json_to_parquet_with_snappy_compression() {
     assert!(bytes.starts_with(b"PAR1"), "output should be Parquet");
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn json_to_parquet_with_zstd_compression() {
     let dir = TempDir::new().unwrap();
@@ -240,6 +249,7 @@ fn json_to_parquet_with_zstd_compression() {
     assert!(bytes.starts_with(b"PAR1"), "output should be Parquet");
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_null_values_preserved_in_csv() {
     let dir = TempDir::new().unwrap();
@@ -257,6 +267,7 @@ fn parquet_null_values_preserved_in_csv() {
     assert!(stdout.contains("Diana"), "Diana should be present");
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_schema_detection() {
     let dir = TempDir::new().unwrap();
@@ -274,6 +285,7 @@ fn parquet_schema_detection() {
         .stdout(predicate::str::contains("category"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_stats_output() {
     let dir = TempDir::new().unwrap();
@@ -666,6 +678,7 @@ fn streaming_large_csv_to_csv() {
     assert_eq!(data_lines.len(), 1000, "should have 1000 data rows");
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn streaming_parquet_to_csv_chunk_size() {
     let dir = TempDir::new().unwrap();
@@ -905,6 +918,7 @@ fn query_func_with_where_filter() {
 // Parquet + 쿼리 통합 테스트
 // ============================================================
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_query_with_aggregate() {
     let dir = TempDir::new().unwrap();
@@ -918,6 +932,7 @@ fn parquet_query_with_aggregate() {
         .stdout(predicate::str::contains("5"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_query_with_filter_and_aggregate() {
     let dir = TempDir::new().unwrap();
@@ -935,6 +950,7 @@ fn parquet_query_with_filter_and_aggregate() {
         .stdout(predicate::str::contains("3"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_query_func_upper() {
     let dir = TempDir::new().unwrap();
@@ -952,6 +968,7 @@ fn parquet_query_func_upper() {
         .stdout(predicate::str::contains("ALICE"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn parquet_roundtrip_via_csv() {
     // parquet → csv → parquet → json 라운드트립

--- a/dkit-cli/tests/xlsx_test.rs
+++ b/dkit-cli/tests/xlsx_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "excel")]
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -10,22 +10,31 @@ homepage = "https://github.com/syangkkim/dkit"
 keywords = ["json", "csv", "yaml", "toml", "data"]
 categories = ["encoding", "parser-implementations"]
 
+[features]
+default = []
+xml = ["dep:quick-xml"]
+msgpack = ["dep:rmp-serde"]
+excel = ["dep:calamine"]
+sqlite = ["dep:rusqlite"]
+parquet = ["dep:arrow", "dep:parquet-impl", "dep:bytes"]
+all = ["xml", "msgpack", "excel", "sqlite", "parquet"]
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 csv = "1"
 toml = "0.8"
-quick-xml = "0.37"
-rmp-serde = "1"
+quick-xml = { version = "0.37", optional = true }
+rmp-serde = { version = "1", optional = true }
 indexmap = { version = "2", features = ["serde"] }
 thiserror = "1"
 anyhow = "1"
-calamine = "0.26"
-rusqlite = { version = "0.31", features = ["bundled"] }
-arrow = { version = "53", default-features = false, features = ["prettyprint"] }
-parquet = { version = "53", default-features = false, features = ["arrow", "snap", "zstd"] }
-bytes = "1"
+calamine = { version = "0.26", optional = true }
+rusqlite = { version = "0.31", features = ["bundled"], optional = true }
+arrow = { version = "53", default-features = false, features = ["prettyprint"], optional = true }
+parquet-impl = { package = "parquet", version = "53", default-features = false, features = ["arrow", "snap", "zstd"], optional = true }
+bytes = { version = "1", optional = true }
 jsonschema = { version = "0.17", default-features = false }
 rand = "0.8"
 

--- a/dkit-core/src/error.rs
+++ b/dkit-core/src/error.rs
@@ -1,6 +1,7 @@
 /// 지원하는 포맷 목록 (에러 메시지용)
 pub const SUPPORTED_FORMATS: &[&str] = &[
-    "json", "jsonl", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack", "md", "html", "table",
+    "json", "jsonl", "csv", "tsv", "yaml", "yml", "toml", "xml", "msgpack", "xlsx", "sqlite",
+    "parquet", "md", "html", "table",
 ];
 
 /// Compute Levenshtein edit distance between two strings.

--- a/dkit-core/src/format/mod.rs
+++ b/dkit-core/src/format/mod.rs
@@ -8,20 +8,246 @@ pub mod json;
 pub mod jsonl;
 /// Markdown table writer.
 pub mod markdown;
-/// MessagePack binary reader and writer.
-pub mod msgpack;
-/// Apache Parquet columnar format reader and writer.
-pub mod parquet;
-/// SQLite database reader.
-pub mod sqlite;
 /// TOML reader and writer.
 pub mod toml;
-/// Excel (XLSX) reader.
-pub mod xlsx;
-/// XML reader and writer.
-pub mod xml;
 /// YAML reader and writer.
 pub mod yaml;
+
+// --- Feature-gated format modules ---
+
+/// MessagePack binary reader and writer.
+#[cfg(feature = "msgpack")]
+pub mod msgpack;
+#[cfg(not(feature = "msgpack"))]
+pub mod msgpack {
+    //! Stub module — MessagePack feature not enabled.
+    use super::{FormatReader, FormatWriter};
+    use crate::value::Value;
+    use std::io::{Read, Write};
+
+    const MSG: &str = "MessagePack support requires the 'msgpack' feature.\n  Install with: cargo install dkit --features msgpack";
+
+    pub struct MsgpackReader;
+    impl MsgpackReader {
+        pub fn read_from_bytes(&self, _bytes: &[u8]) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+    }
+    impl FormatReader for MsgpackReader {
+        fn read(&self, _: &str) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+        fn read_from_reader(&self, _: impl Read) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+    }
+    pub struct MsgpackWriter;
+    impl MsgpackWriter {
+        pub fn write_bytes(&self, _value: &Value) -> anyhow::Result<Vec<u8>> {
+            anyhow::bail!(MSG)
+        }
+    }
+    impl FormatWriter for MsgpackWriter {
+        fn write(&self, _: &Value) -> anyhow::Result<String> {
+            anyhow::bail!(MSG)
+        }
+        fn write_to_writer(&self, _: &Value, _: impl Write) -> anyhow::Result<()> {
+            anyhow::bail!(MSG)
+        }
+    }
+}
+
+/// Apache Parquet columnar format reader and writer.
+#[cfg(feature = "parquet")]
+pub mod parquet;
+#[cfg(not(feature = "parquet"))]
+pub mod parquet {
+    //! Stub module — Parquet feature not enabled.
+    use crate::value::Value;
+
+    const MSG: &str = "Parquet support requires the 'parquet' feature.\n  Install with: cargo install dkit --features parquet";
+
+    #[derive(Debug, Clone, Default)]
+    pub struct ParquetOptions {
+        pub row_group: Option<usize>,
+    }
+    pub struct ParquetReader {
+        _options: ParquetOptions,
+    }
+    impl ParquetReader {
+        pub fn new(options: ParquetOptions) -> Self {
+            Self { _options: options }
+        }
+        pub fn read_from_bytes(&self, _bytes: &[u8]) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+        #[allow(dead_code)]
+        pub fn read_metadata(_bytes: &[u8]) -> anyhow::Result<ParquetMetadata> {
+            anyhow::bail!(MSG)
+        }
+    }
+    #[allow(dead_code)]
+    pub struct ParquetMetadata {
+        pub num_rows: usize,
+        pub num_row_groups: usize,
+        pub columns: Vec<String>,
+        pub column_types: Vec<String>,
+    }
+    #[derive(Debug, Clone, Default)]
+    pub enum ParquetCompression {
+        #[default]
+        None,
+        Snappy,
+        Gzip,
+        Zstd,
+    }
+    impl std::str::FromStr for ParquetCompression {
+        type Err = anyhow::Error;
+        fn from_str(s: &str) -> anyhow::Result<Self> {
+            match s.to_lowercase().as_str() {
+                "none" | "uncompressed" => Ok(Self::None),
+                "snappy" => Ok(Self::Snappy),
+                "gzip" => Ok(Self::Gzip),
+                "zstd" => Ok(Self::Zstd),
+                _ => anyhow::bail!(
+                    "Unknown Parquet compression '{}'. Valid options: none, snappy, gzip, zstd",
+                    s
+                ),
+            }
+        }
+    }
+    #[derive(Debug, Clone, Default)]
+    pub struct ParquetWriteOptions {
+        pub compression: ParquetCompression,
+        pub row_group_size: Option<usize>,
+    }
+    pub struct ParquetWriter {
+        _options: ParquetWriteOptions,
+    }
+    impl ParquetWriter {
+        pub fn new(options: ParquetWriteOptions) -> Self {
+            Self { _options: options }
+        }
+        pub fn write_to_bytes(&self, _value: &Value) -> anyhow::Result<Vec<u8>> {
+            anyhow::bail!(MSG)
+        }
+    }
+    /// Stub for arrow_value_to_value when parquet feature is disabled.
+    pub fn arrow_value_to_value(_array: &dyn std::any::Any, _idx: usize) -> Value {
+        Value::Null
+    }
+}
+
+/// SQLite database reader.
+#[cfg(feature = "sqlite")]
+pub mod sqlite;
+#[cfg(not(feature = "sqlite"))]
+pub mod sqlite {
+    //! Stub module — SQLite feature not enabled.
+    use crate::value::Value;
+    use std::path::Path;
+
+    const MSG: &str = "SQLite support requires the 'sqlite' feature.\n  Install with: cargo install dkit --features sqlite";
+
+    #[derive(Debug, Clone, Default)]
+    pub struct SqliteOptions {
+        pub table: Option<String>,
+        pub sql: Option<String>,
+    }
+    pub struct SqliteReader {
+        _options: SqliteOptions,
+    }
+    impl SqliteReader {
+        pub fn new(options: SqliteOptions) -> Self {
+            Self { _options: options }
+        }
+        pub fn read_from_path(&self, _path: &Path) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+        pub fn list_tables(_path: &Path) -> anyhow::Result<Vec<String>> {
+            anyhow::bail!(MSG)
+        }
+    }
+}
+
+/// Excel (XLSX) reader.
+#[cfg(feature = "excel")]
+pub mod xlsx;
+#[cfg(not(feature = "excel"))]
+pub mod xlsx {
+    //! Stub module — Excel feature not enabled.
+    use crate::value::Value;
+
+    const MSG: &str = "Excel support requires the 'excel' feature.\n  Install with: cargo install dkit --features excel";
+
+    #[derive(Debug, Clone, Default)]
+    pub struct XlsxOptions {
+        pub sheet: Option<String>,
+        pub header_row: usize,
+    }
+    pub struct XlsxReader {
+        _options: XlsxOptions,
+    }
+    impl XlsxReader {
+        pub fn new(options: XlsxOptions) -> Self {
+            Self { _options: options }
+        }
+        pub fn read_from_bytes(&self, _bytes: &[u8]) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+        pub fn list_sheets(_bytes: &[u8]) -> anyhow::Result<Vec<String>> {
+            anyhow::bail!(MSG)
+        }
+    }
+}
+
+/// XML reader and writer.
+#[cfg(feature = "xml")]
+pub mod xml;
+#[cfg(not(feature = "xml"))]
+pub mod xml {
+    //! Stub module — XML feature not enabled.
+    use super::{FormatReader, FormatWriter};
+    use crate::value::Value;
+    use std::io::{Read, Write};
+
+    const MSG: &str = "XML support requires the 'xml' feature.\n  Install with: cargo install dkit --features xml";
+
+    #[derive(Default)]
+    pub struct XmlReader {
+        _private: (),
+    }
+    impl XmlReader {
+        #[allow(dead_code)]
+        pub fn new(_strip_namespaces: bool) -> Self {
+            Self { _private: () }
+        }
+    }
+    impl FormatReader for XmlReader {
+        fn read(&self, _: &str) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+        fn read_from_reader(&self, _: impl Read) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+    }
+    pub struct XmlWriter {
+        _private: (),
+    }
+    impl XmlWriter {
+        pub fn new(_pretty: bool, _root_element: Option<String>) -> Self {
+            Self { _private: () }
+        }
+    }
+    impl FormatWriter for XmlWriter {
+        fn write(&self, _: &Value) -> anyhow::Result<String> {
+            anyhow::bail!(MSG)
+        }
+        fn write_to_writer(&self, _: &Value, _: impl Write) -> anyhow::Result<()> {
+            anyhow::bail!(MSG)
+        }
+    }
+}
 
 use std::io::{Read, Write};
 use std::path::Path;
@@ -86,23 +312,53 @@ impl Format {
     }
 
     /// 사용 가능한 출력 포맷 목록을 반환한다
-    pub fn list_output_formats() -> &'static [(&'static str, &'static str)] {
-        &[
+    pub fn list_output_formats() -> Vec<(&'static str, &'static str)> {
+        let mut formats = vec![
             ("json", "JSON format"),
             ("csv", "Comma-separated values"),
             ("tsv", "Tab-separated values (CSV variant)"),
             ("yaml", "YAML format"),
             ("toml", "TOML format"),
-            ("xml", "XML format"),
             ("jsonl", "JSON Lines (one JSON object per line)"),
-            ("msgpack", "MessagePack binary format"),
-            ("xlsx", "Excel spreadsheet (input only)"),
-            ("sqlite", "SQLite database (input only)"),
-            ("parquet", "Apache Parquet columnar format"),
-            ("md", "Markdown table"),
-            ("html", "HTML table"),
-            ("table", "Terminal table (default for view)"),
-        ]
+        ];
+
+        if cfg!(feature = "xml") {
+            formats.push(("xml", "XML format"));
+        } else {
+            formats.push(("xml", "XML format (requires --features xml)"));
+        }
+        if cfg!(feature = "msgpack") {
+            formats.push(("msgpack", "MessagePack binary format"));
+        } else {
+            formats.push((
+                "msgpack",
+                "MessagePack binary format (requires --features msgpack)",
+            ));
+        }
+        if cfg!(feature = "excel") {
+            formats.push(("xlsx", "Excel spreadsheet (input only)"));
+        } else {
+            formats.push(("xlsx", "Excel spreadsheet (requires --features excel)"));
+        }
+        if cfg!(feature = "sqlite") {
+            formats.push(("sqlite", "SQLite database (input only)"));
+        } else {
+            formats.push(("sqlite", "SQLite database (requires --features sqlite)"));
+        }
+        if cfg!(feature = "parquet") {
+            formats.push(("parquet", "Apache Parquet columnar format"));
+        } else {
+            formats.push((
+                "parquet",
+                "Apache Parquet columnar format (requires --features parquet)",
+            ));
+        }
+
+        formats.push(("md", "Markdown table"));
+        formats.push(("html", "HTML table"));
+        formats.push(("table", "Terminal table (default for view)"));
+
+        formats
     }
 }
 

--- a/dkit-core/src/format/parquet.rs
+++ b/dkit-core/src/format/parquet.rs
@@ -11,10 +11,10 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use bytes::Bytes;
 use indexmap::IndexMap;
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use parquet::arrow::ArrowWriter;
-use parquet::basic::{Compression, GzipLevel, ZstdLevel};
-use parquet::file::properties::WriterProperties;
+use parquet_impl::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet_impl::arrow::ArrowWriter;
+use parquet_impl::basic::{Compression, GzipLevel, ZstdLevel};
+use parquet_impl::file::properties::WriterProperties;
 
 use crate::error::DkitError;
 use crate::value::Value;
@@ -637,7 +637,7 @@ mod tests {
     use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use parquet::arrow::ArrowWriter;
+    use parquet_impl::arrow::ArrowWriter;
     use std::sync::Arc;
 
     /// 테스트용 Parquet 바이트를 생성한다


### PR DESCRIPTION
## Summary
- Add Cargo feature flags to manage heavy dependencies (XML, MessagePack, Excel, SQLite, Parquet) as optional
- `cargo install dkit` installs only basic formats (JSON, CSV, TSV, YAML, TOML, JSONL) for a lightweight binary
- `cargo install dkit --features all` installs with full format support
- Disabled formats show clear error messages guiding users to enable the required feature

## Feature Configuration

| Feature | Dependencies | Description |
|---------|-------------|-------------|
| `default` | — | Basic formats (JSON, CSV, TSV, YAML, TOML, JSONL) |
| `xml` | quick-xml | XML read/write |
| `msgpack` | rmp-serde | MessagePack binary format |
| `excel` | calamine | Excel (XLSX) reading |
| `sqlite` | rusqlite | SQLite database reading |
| `parquet` | arrow, parquet | Apache Parquet columnar format |
| `all` | all of the above | Full format support |

## Implementation Approach
- Stub modules with matching public APIs are provided when features are disabled, so CLI code requires minimal `cfg` changes
- Integration tests are feature-gated to match the formats they test
- `--list-formats` output indicates which formats require features

## Test plan
- [x] `cargo build` succeeds (default features — lightweight)
- [x] `cargo build --features all` succeeds (full features)
- [x] `cargo test` passes (default features)
- [x] `cargo test --features all` passes (all tests)
- [x] `cargo clippy -- -D warnings` passes (both default and all)
- [x] `cargo fmt -- --check` passes
- [x] Disabled format usage shows clear error message

Closes #120

https://claude.ai/code/session_014TSb5GrWWzWk4H8MHcxyoG