### PR TITLE
Add cross-platform CI test matrix with feature flag combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,28 @@ env:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }})
+    name: Test (${{ matrix.os }}, ${{ matrix.features == '' && 'default' || matrix.features }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        features: ["", "--features all"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.features }}
+
+      - name: Run tests
+        run: cargo test --verbose ${{ matrix.features }}
+
+  clippy:
+    name: Clippy (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -22,26 +43,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run tests
-        run: cargo test --verbose
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run clippy
+      - name: Run clippy (default features)
         run: cargo clippy -- -D warnings
+
+      - name: Run clippy (all features)
+        run: cargo clippy --features all -- -D warnings
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
## Summary
- **테스트**: Linux, macOS, Windows 3개 플랫폼에서 default features와 `--features all` 두 가지 조합으로 테스트 실행 (총 6개 매트릭스)
- **Clippy**: 3개 플랫폼 모두에서 default + all features 린트 검사
- **Rustfmt**: Ubuntu에서 포맷 검사 (플랫폼 독립적이므로 1회만 실행)
- rust-cache에 feature 기반 키를 추가하여 캐시 효율 향상

## Test plan
- [ ] GitHub Actions에서 6개 테스트 매트릭스(3 OS × 2 features) 모두 통과 확인
- [ ] Clippy가 3개 플랫폼에서 default/all features 모두 통과 확인
- [ ] Rustfmt 체크 통과 확인
- [ ] PR 생성 시 자동 실행되는지 확인

Closes #175

https://claude.ai/code/session_0133cgzQPi11T2poSmxsMk9a