### PR TITLE
Add Miri memory safety CI workflow

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,43 @@
+name: Miri
+
+on:
+  schedule:
+    # Run weekly on Monday at 00:00 UTC
+    - cron: "0 0 * * 1"
+  pull_request:
+    branches: [main]
+    paths:
+      - "dkit-core/**"
+      - "dkit-cli/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  miri:
+    name: Miri Safety Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: miri
+
+      - name: Run Miri (default features)
+        run: cargo +nightly miri test -p dkit-core
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation"
+
+      - name: Run Miri (all features)
+        run: cargo +nightly miri test -p dkit-core --features all
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`.github/workflows/miri.yml`) that runs `cargo +nightly miri test` on `dkit-core`
- Runs on weekly schedule (Monday 00:00 UTC), on PRs touching source code, and via manual dispatch
- Tests both default and `--features all` configurations
- Uses `-Zmiri-disable-isolation` flag for compatibility

## Notes
- No `unsafe` code exists in the codebase currently, so Miri tests should pass cleanly
- Valgrind integration is optional per the issue spec and not included (no unsafe code to warrant it)
- Miri runs only on `dkit-core` (the library crate) as it contains the core logic

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm Miri job runs successfully on nightly Rust
- [ ] Check that both default and all-features test suites pass under Miri

Closes #176

https://claude.ai/code/session_01Qgcx5d8yyNHzEJzH2iU7Jy