### PR TITLE
Fix cargo publish error for dkit-core dependency

### DIFF
--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -28,7 +28,7 @@ parquet = ["dkit-core/parquet", "dep:arrow", "dep:parquet-impl", "dep:bytes"]
 all = ["xml", "msgpack", "excel", "sqlite", "parquet"]
 
 [dependencies]
-dkit-core = { path = "../dkit-core" }
+dkit-core = { version = "1.0.0", path = "../dkit-core" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- `dkit-cli/Cargo.toml`에서 `dkit-core` 의존성에 `version = "1.0.0"`을 추가
- crates.io 퍼블리시 시 path 의존성에도 version이 필수로 요구됨

## Test plan
- [x] `cargo check` 빌드 성공 확인

https://claude.ai/code/session_014Mv8WbsVyB53G2UJknEnvc