### PR TITLE
Skip cargo publish if version already exists on crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Publish dkit-core
-        run: cargo publish -p dkit-core
+        run: |
+          OUTPUT=$(cargo publish -p dkit-core 2>&1) && exit 0
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q 'already exists'; then
+            echo "dkit-core version already published, skipping."
+          else
+            exit 1
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -129,6 +136,13 @@ jobs:
         run: sleep 30
 
       - name: Publish dkit
-        run: cargo publish -p dkit
+        run: |
+          OUTPUT=$(cargo publish -p dkit 2>&1) && exit 0
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q 'already exists'; then
+            echo "dkit version already published, skipping."
+          else
+            exit 1
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Release 워크플로우에서 `cargo publish` 시 해당 버전이 이미 crates.io에 존재하면 에러 대신 스킵하도록 변경
- `already exists` 에러만 스킵하고, 그 외 퍼블리시 에러는 기존처럼 실패 처리

## Test plan
- [x] `already exists` 에러 발생 시 워크플로우가 정상 통과되는지 확인
- [x] 다른 퍼블리시 에러(인증 실패 등)는 여전히 실패하는지 확인

https://claude.ai/code/session_014Mv8WbsVyB53G2UJknEnvc