### PR TITLE
feat: add --select flag for convert/view (column selection)

### DIFF
--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -139,6 +139,10 @@ pub enum Commands {
         #[arg(long, value_name = "EXPR", alias = "where")]
         filter: Option<String>,
 
+        /// Select specific fields (comma-separated, e.g. 'name, city, age')
+        #[arg(long, value_name = "FIELDS")]
+        select: Option<String>,
+
         /// Parquet compression codec (none, snappy, gzip, zstd)
         #[arg(long, value_name = "CODEC", default_value = "none")]
         compression: String,
@@ -322,6 +326,10 @@ pub enum Commands {
         /// Filter expression (e.g. 'age > 30 and city == "Seoul"')
         #[arg(long, value_name = "EXPR", alias = "where")]
         filter: Option<String>,
+
+        /// Select specific fields (comma-separated, e.g. 'name, city, age')
+        #[arg(long, value_name = "FIELDS")]
+        select: Option<String>,
 
         /// Watch input file for changes and auto re-run
         #[arg(long)]

--- a/dkit-cli/src/commands/mod.rs
+++ b/dkit-cli/src/commands/mod.rs
@@ -236,10 +236,33 @@ pub struct DataFilterOptions {
     pub tail: Option<usize>,
     /// 필터 표현식 문자열
     pub filter: Option<String>,
+    /// 선택할 필드 목록 (쉼표 구분)
+    pub select: Option<String>,
+}
+
+/// 쉼표 구분 필드 목록을 SelectExpr 벡터로 파싱한다.
+fn parse_select_fields(fields: &str) -> anyhow::Result<Vec<dkit_core::query::parser::SelectExpr>> {
+    use dkit_core::query::parser::{Expr, SelectExpr};
+
+    let exprs: Vec<SelectExpr> = fields
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| SelectExpr {
+            expr: Expr::Field(s.to_string()),
+            alias: None,
+        })
+        .collect();
+
+    if exprs.is_empty() {
+        anyhow::bail!("--select requires at least one field name\n  Hint: use format like --select 'name, city, age'");
+    }
+
+    Ok(exprs)
 }
 
 /// 데이터 필터/정렬 옵션을 Value에 적용한다.
-/// 적용 순서: where → sort → head/tail
+/// 적용 순서: where → select → sort → head/tail
 pub fn apply_data_filters(
     value: dkit_core::value::Value,
     opts: &DataFilterOptions,
@@ -259,7 +282,13 @@ pub fn apply_data_filters(
         operations.push(Operation::Where(condition));
     }
 
-    // 2. sort
+    // 2. select (컬럼 선택)
+    if let Some(ref fields) = opts.select {
+        let select_exprs = parse_select_fields(fields)?;
+        operations.push(Operation::Select(select_exprs));
+    }
+
+    // 3. sort
     if let Some(ref field) = opts.sort_by {
         operations.push(Operation::Sort {
             field: field.clone(),
@@ -267,7 +296,7 @@ pub fn apply_data_filters(
         });
     }
 
-    // 3. head (= limit)
+    // 4. head (= limit)
     if let Some(n) = opts.head {
         operations.push(Operation::Limit(n));
     }
@@ -284,7 +313,7 @@ pub fn apply_data_filters(
         apply_operations(value, &operations)?
     };
 
-    // 4. tail: 배열의 마지막 N개 요소 추출
+    // 5. tail: 배열의 마지막 N개 요소 추출
     if let Some(n) = opts.tail {
         if let dkit_core::value::Value::Array(ref arr) = result {
             let start = arr.len().saturating_sub(n);
@@ -574,5 +603,81 @@ mod tests {
         let opts = DataFilterOptions::default();
         let result = apply_data_filters(data, &opts).unwrap();
         assert_eq!(result, Value::Integer(42));
+    }
+
+    #[test]
+    fn test_data_filter_select() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            select: Some("name".to_string()),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        // Each record should only have "name" field
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.len(), 1);
+            assert!(obj.contains_key("name"));
+        }
+    }
+
+    #[test]
+    fn test_data_filter_select_multiple_fields() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            select: Some("name, age".to_string()),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.len(), 2);
+            assert!(obj.contains_key("name"));
+            assert!(obj.contains_key("age"));
+        }
+    }
+
+    #[test]
+    fn test_data_filter_select_with_filter() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            filter: Some("age > 27".to_string()),
+            select: Some("name".to_string()),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // Alice(30), Charlie(35), Diana(28)
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.len(), 1);
+            assert!(obj.contains_key("name"));
+        }
+    }
+
+    #[test]
+    fn test_data_filter_select_with_sort() {
+        let data = sample_data();
+        let opts = DataFilterOptions {
+            select: Some("name, age".to_string()),
+            sort_by: Some("age".to_string()),
+            ..Default::default()
+        };
+        let result = apply_data_filters(data, &opts).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_object().unwrap()["name"].as_str().unwrap(), "Eve");
+        assert_eq!(
+            arr[4].as_object().unwrap()["name"].as_str().unwrap(),
+            "Charlie"
+        );
+    }
+
+    #[test]
+    fn test_parse_select_fields_empty() {
+        assert!(parse_select_fields("").is_err());
     }
 }

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -314,6 +314,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             head,
             tail,
             filter,
+            select,
             compression,
             row_group_size,
             chunk_size,
@@ -356,6 +357,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         head,
                         tail,
                         filter: filter.clone(),
+                        select: select.clone(),
                     },
                     parquet_opts: ParquetWriteOptions {
                         compression: compression.clone(),
@@ -429,6 +431,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             head,
             tail,
             filter,
+            select,
             watch,
             watch_paths,
         } => {
@@ -467,6 +470,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         head,
                         tail,
                         filter: filter.clone(),
+                        select: select.clone(),
                     },
                 })
             };


### PR DESCRIPTION
## Summary
- `convert` 및 `view` 서브커맨드에 `--select` 플래그 추가 (쉼표 구분 필드명 목록)
- 기존 `--filter`, `--sort-by`, `--head`, `--tail` 파이프라인과 조합 가능 (적용 순서: filter → select → sort → head/tail)
- 단위 테스트 5개 추가 (select 단독, 복수 필드, filter 조합, sort 조합, 빈 입력 에러)

## 사용 예시
```bash
dkit convert data.json -f csv --select 'name, city, age'
dkit view data.csv --select 'id, email, status'
dkit convert data.json -f json --select 'name' --filter 'age > 30'
```

## Test plan
- [x] `cargo test` 전체 통과 (428 tests)
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과
- [x] 수동 테스트: convert + view에서 --select 단독 및 --filter 조합 확인

Closes #184

https://claude.ai/code/session_018eVa1ydFputhk4ng3UcaRv