### PR TITLE
chore: add crate READMEs, improve metadata, bump to v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "dkit"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "dkit-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arrow",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dkit
 
-**Swiss army knife for data format conversion and querying.**
+**A unified CLI to convert, query, and explore data across formats.**
 
 Convert between JSON, CSV, YAML, TOML, XML, Parquet, and more with a single CLI. Query nested data, compare files, preview as tables, and pipe everything together.
 

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "dkit"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75.0"
-description = "Swiss army knife for data format conversion and querying"
+description = "A unified CLI to convert, query, and explore data across formats"
 license = "MIT"
 repository = "https://github.com/syangkkim/dkit"
 homepage = "https://github.com/syangkkim/dkit"
-keywords = ["cli", "json", "csv", "yaml", "toml"]
+keywords = ["cli", "data-format", "converter", "query", "json"]
 categories = ["command-line-utilities", "encoding"]
 
 [package.metadata.binstall]
@@ -28,7 +28,7 @@ parquet = ["dkit-core/parquet", "dep:arrow", "dep:parquet-impl", "dep:bytes"]
 all = ["xml", "msgpack", "excel", "sqlite", "parquet"]
 
 [dependencies]
-dkit-core = { version = "1.0.0", path = "../dkit-core" }
+dkit-core = { version = "1.0.1", path = "../dkit-core" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 serde = { version = "1", features = ["derive"] }

--- a/dkit-cli/README.md
+++ b/dkit-cli/README.md
@@ -1,0 +1,77 @@
+# dkit
+
+A unified CLI to convert, query, and explore data across formats.
+
+## Features
+
+- **Format conversion** — JSON, CSV, YAML, TOML, XML, MessagePack, Parquet, Excel, SQLite, and more
+- **Query engine** — Filter, sort, aggregate, and transform with a built-in query language
+- **Table preview** — View any data file as a formatted table in the terminal
+- **File diff** — Compare two data files, even across different formats
+- **Statistics** — Count, average, percentiles, histograms
+- **Schema inspection** — Visualize data structure as a tree
+- **Validation** — Validate data against JSON Schema
+- **Sampling** — Random, systematic, or stratified sampling
+- **Flatten / Unflatten** — Convert nested structures to flat keys and back
+- **Streaming** — Chunk-based processing for large files
+- **Watch mode** — Auto re-run on file changes
+
+## Installation
+
+```bash
+# From crates.io
+cargo install dkit
+
+# With cargo-binstall
+cargo binstall dkit
+
+# From source
+git clone https://github.com/syangkkim/dkit.git
+cd dkit && cargo install --path dkit-cli
+```
+
+Pre-built binaries are available on [GitHub Releases](https://github.com/syangkkim/dkit/releases).
+
+## Quick Start
+
+```bash
+# Convert JSON to CSV
+dkit convert data.json --to csv
+
+# Query nested data
+dkit query config.yaml '.database.host'
+
+# Filter and aggregate
+dkit query sales.csv '.[] | where region == "US" | sum revenue'
+
+# Preview as a table
+dkit view users.csv --limit 10 --border rounded --color
+
+# Compare two configs
+dkit diff config_dev.yaml config_prod.yaml
+```
+
+## Supported Formats
+
+| Format      | Extensions             | Read | Write |
+|-------------|------------------------|:----:|:-----:|
+| JSON        | `.json`                |  ✓   |   ✓   |
+| JSONL       | `.jsonl`, `.ndjson`    |  ✓   |   ✓   |
+| CSV / TSV   | `.csv`, `.tsv`         |  ✓   |   ✓   |
+| YAML        | `.yaml`, `.yml`        |  ✓   |   ✓   |
+| TOML        | `.toml`                |  ✓   |   ✓   |
+| XML         | `.xml`                 |  ✓   |   ✓   |
+| MessagePack | `.msgpack`             |  ✓   |   ✓   |
+| Parquet     | `.parquet`             |  ✓   |   ✓   |
+| Excel       | `.xlsx`                |  ✓   |   —   |
+| SQLite      | `.db`, `.sqlite`       |  ✓   |   —   |
+| Markdown    | `.md`                  |  —   |   ✓   |
+| HTML        | `.html`                |  —   |   ✓   |
+
+## Documentation
+
+See the [full README](https://github.com/syangkkim/dkit) for detailed usage, query syntax, and more.
+
+## License
+
+[MIT](https://github.com/syangkkim/dkit/blob/main/LICENSE)

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "dkit-core"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "Core library for dkit — data format conversion and querying engine"
 license = "MIT"
 repository = "https://github.com/syangkkim/dkit"
 homepage = "https://github.com/syangkkim/dkit"
-keywords = ["json", "csv", "yaml", "toml", "data"]
+keywords = ["data-format", "converter", "query", "serialization", "json"]
 categories = ["encoding", "parser-implementations"]
 
 [features]

--- a/dkit-core/README.md
+++ b/dkit-core/README.md
@@ -1,0 +1,66 @@
+# dkit-core
+
+Core library for dkit — a data format conversion and querying engine.
+
+Use `dkit-core` to read, write, convert, and query structured data across multiple formats programmatically.
+
+## Features
+
+- **Multi-format I/O** — JSON, JSONL, CSV, TSV, YAML, TOML, and optionally XML, MessagePack, Parquet, Excel, SQLite
+- **Unified `Value` type** — A common intermediate representation for all formats
+- **Query engine** — Filter, sort, select, aggregate, and transform data with a built-in expression language
+- **Format conversion** — Convert between any supported readable and writable formats
+- **Schema inference** — Inspect and describe data structure
+- **JSON Schema validation** — Validate data against JSON Schema
+
+## Usage
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+dkit-core = "1.0"
+```
+
+### Optional features
+
+Enable additional format support via feature flags:
+
+| Feature   | Formats added          |
+|-----------|------------------------|
+| `xml`     | XML read/write         |
+| `msgpack` | MessagePack read/write |
+| `excel`   | Excel (.xlsx) read     |
+| `sqlite`  | SQLite (.db) read      |
+| `parquet` | Parquet read/write     |
+| `all`     | All of the above       |
+
+```toml
+[dependencies]
+dkit-core = { version = "1.0", features = ["xml", "parquet"] }
+```
+
+### Example
+
+```rust
+use dkit_core::formats::{JsonFormat, CsvFormat, DataFormat};
+use dkit_core::value::Value;
+
+// Read JSON
+let json_data = r#"[{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]"#;
+let value = JsonFormat::read(json_data.as_bytes())?;
+
+// Write as CSV
+let mut output = Vec::new();
+CsvFormat::write(&mut output, &value, &Default::default())?;
+```
+
+## Documentation
+
+- [API Reference](https://github.com/syangkkim/dkit/blob/main/docs/api-reference.md)
+- [Technical Spec](https://github.com/syangkkim/dkit/blob/main/docs/technical-spec.md)
+- [Query Syntax](https://github.com/syangkkim/dkit/blob/main/docs/query-syntax.md)
+
+## License
+
+[MIT](https://github.com/syangkkim/dkit/blob/main/LICENSE)


### PR DESCRIPTION
## Summary\n\n- **README 추가**: `dkit-cli/README.md`, `dkit-core/README.md` 생성 — crates.io에서 \"no README\" 문제 해결\n- **Description 개선**: \"Swiss army knife...\" → \"A unified CLI to convert, query, and explore data across formats\"\n- **Keywords 확장**: 개별 포맷명 나열 대신 `data-format`, `converter`, `query` 등 포괄적 키워드로 변경\n- **Version bump**: 두 크레이트 모두 1.0.0 → 1.0.1\n\n## 검증\n\n- `cargo build` ✓\n- `cargo test` — 428 passed ✓\n- `cargo clippy -- -D warnings` ✓\n- `cargo fmt -- --check` ✓\n- `cargo package --list` — 두 크레이트 모두 README.md 포함 확인 ✓\n\nCloses #224, Closes #225, Closes #226, Closes #227, Closes #228\n\nhttps://claude.ai/code/session_01Q6u6PD1gy8TJnBq33jQobC