### PR TITLE
Disable pull request triggers for miri and benchmark workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,8 +3,7 @@ name: Benchmarks
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -4,13 +4,6 @@ on:
   schedule:
     # Run weekly on Monday at 00:00 UTC
     - cron: "0 0 * * 1"
-  pull_request:
-    branches: [main]
-    paths:
-      - "dkit-core/**"
-      - "dkit-cli/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
This change removes automatic pull request triggers from the miri and benchmark CI workflows, making them manual-only workflows that run on schedule or explicit dispatch.

## Key Changes
- **miri.yml**: Removed the `pull_request` trigger that was configured to run on changes to core packages and manifest files
- **benchmark.yml**: Replaced the `pull_request` trigger with `workflow_dispatch`, allowing benchmarks to be run manually instead of automatically on every PR

## Rationale
These workflows are now triggered only on:
- **miri.yml**: Weekly schedule (Monday at 00:00 UTC) and manual dispatch
- **benchmark.yml**: Push to main branch and manual dispatch

This reduces CI overhead by preventing these potentially resource-intensive checks from running on every pull request, while still allowing them to be triggered manually when needed or run on a scheduled basis.

https://claude.ai/code/session_01JGGoCcDTpQu8YwMkBCQ44g