### PR TITLE
feat: add --dry-run flag for convert command

### DIFF
--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -174,6 +174,14 @@ pub enum Commands {
         /// Additional paths to watch for changes
         #[arg(long = "watch-path", value_name = "PATH")]
         watch_paths: Vec<std::path::PathBuf>,
+
+        /// Preview conversion result without writing output file (prints first N records to stdout)
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Number of records to show in dry-run preview (default: 10)
+        #[arg(long, value_name = "N", default_value = "10")]
+        dry_run_limit: usize,
     },
 
     /// Query data using path expressions

--- a/dkit-cli/src/commands/convert.rs
+++ b/dkit-cli/src/commands/convert.rs
@@ -53,6 +53,8 @@ pub struct ConvertArgs<'a> {
     pub data_filter: super::DataFilterOptions,
     pub parquet_opts: ParquetWriteOptions,
     pub streaming_opts: Option<super::streaming::StreamingOptions>,
+    pub dry_run: bool,
+    pub dry_run_limit: usize,
 }
 
 /// convert 서브커맨드 실행
@@ -92,6 +94,11 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
     // stdin mode: no input files or explicit "-"
     let is_stdin =
         args.input.is_empty() || (args.input.len() == 1 && args.input[0] == Path::new("-"));
+
+    // --dry-run with streaming is not supported
+    if args.dry_run && args.streaming_opts.is_some() {
+        bail!("--dry-run cannot be used with --chunk-size (streaming mode)");
+    }
 
     // 스트리밍 모드: --chunk-size가 지정된 경우 스트리밍 파이프라인 시도
     if let Some(ref streaming_opts) = args.streaming_opts {
@@ -190,6 +197,19 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         };
 
         let value = super::apply_data_filters(value, &args.data_filter)?;
+
+        if args.dry_run {
+            let preview = truncate_for_preview(value, args.dry_run_limit);
+            write_output(
+                &preview,
+                target_format,
+                &write_options,
+                None,
+                &args.parquet_opts,
+            )?;
+            return Ok(());
+        }
+
         write_output(
             &value,
             target_format,
@@ -205,6 +225,11 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
 
     if resolved_files.is_empty() {
         bail!("No matching files found");
+    }
+
+    // --dry-run with batch mode is not supported
+    if args.dry_run && resolved_files.len() > 1 {
+        bail!("--dry-run cannot be used with multiple input files (batch mode)");
     }
 
     // Multiple files with --outdir (batch mode)
@@ -284,6 +309,18 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
     )?;
     let value = super::apply_data_filters(value, &args.data_filter)?;
 
+    if args.dry_run {
+        let preview = truncate_for_preview(value, args.dry_run_limit);
+        write_output(
+            &preview,
+            target_format,
+            &write_options,
+            None,
+            &args.parquet_opts,
+        )?;
+        return Ok(());
+    }
+
     let outdir_path = args.outdir.map(|d| {
         let name = make_output_name(path, args.to, args.rename);
         d.join(name)
@@ -348,6 +385,29 @@ fn convert_single_file(
         Some(&out_path),
         &args.parquet_opts,
     )
+}
+
+/// dry-run 미리보기를 위해 Value를 최대 limit개 레코드로 자른다.
+fn truncate_for_preview(value: Value, limit: usize) -> Value {
+    match value {
+        Value::Array(arr) => {
+            let total = arr.len();
+            let truncated: Vec<Value> = arr.into_iter().take(limit).collect();
+            let shown = truncated.len();
+            if total > shown {
+                eprintln!(
+                    "[dry-run] Showing {shown} of {total} records (use --dry-run-limit to adjust)"
+                );
+            } else {
+                eprintln!("[dry-run] Showing all {total} records");
+            }
+            Value::Array(truncated)
+        }
+        other => {
+            eprintln!("[dry-run] Showing result (non-array data)");
+            other
+        }
+    }
 }
 
 /// 입력 경로를 확장한다: 글롭 패턴, 디렉토리, 일반 파일을 처리

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -323,6 +323,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             progress,
             watch,
             watch_paths,
+            dry_run,
+            dry_run_limit,
         } => {
             let run = || {
                 commands::convert::run(&commands::convert::ConvertArgs {
@@ -371,6 +373,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         chunk_size: cs,
                         progress,
                     }),
+                    dry_run,
+                    dry_run_limit,
                 })
             };
 

--- a/dkit-cli/tests/convert_test.rs
+++ b/dkit-cli/tests/convert_test.rs
@@ -333,7 +333,10 @@ fn convert_dry_run_does_not_create_output_file() {
         .success()
         .stdout(predicate::str::contains("Alice"));
 
-    assert!(!out.exists(), "output file should not be created in dry-run mode");
+    assert!(
+        !out.exists(),
+        "output file should not be created in dry-run mode"
+    );
 }
 
 #[test]
@@ -341,11 +344,7 @@ fn convert_dry_run_limit_truncates_records() {
     // Create a file with 5 records
     let tmp = TempDir::new().unwrap();
     let input = tmp.path().join("data.json");
-    fs::write(
-        &input,
-        r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]"#,
-    )
-    .unwrap();
+    fs::write(&input, r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]"#).unwrap();
 
     dkit()
         .args(&[
@@ -383,15 +382,7 @@ fn convert_dry_run_with_filter() {
 #[test]
 fn convert_dry_run_stdin() {
     dkit()
-        .args(&[
-            "convert",
-            "-",
-            "-f",
-            "csv",
-            "--from",
-            "json",
-            "--dry-run",
-        ])
+        .args(&["convert", "-", "-f", "csv", "--from", "json", "--dry-run"])
         .write_stdin(r#"[{"a":1},{"a":2},{"a":3}]"#)
         .assert()
         .success()

--- a/dkit-cli/tests/convert_test.rs
+++ b/dkit-cli/tests/convert_test.rs
@@ -296,6 +296,108 @@ fn convert_stdin_without_from() {
         .stdout(predicate::str::contains("name: test"));
 }
 
+// --- dry-run tests ---
+
+#[test]
+fn convert_dry_run_outputs_to_stdout() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "-f",
+            "csv",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stderr(predicate::str::contains("[dry-run]"));
+}
+
+#[test]
+fn convert_dry_run_does_not_create_output_file() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("output.csv");
+
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "-f",
+            "csv",
+            "-o",
+            out.to_str().unwrap(),
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+
+    assert!(!out.exists(), "output file should not be created in dry-run mode");
+}
+
+#[test]
+fn convert_dry_run_limit_truncates_records() {
+    // Create a file with 5 records
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]"#,
+    )
+    .unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--dry-run",
+            "--dry-run-limit",
+            "2",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Showing 2 of 5 records"));
+}
+
+#[test]
+fn convert_dry_run_with_filter() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "-f",
+            "csv",
+            "--filter",
+            "age > 28",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob").not());
+}
+
+#[test]
+fn convert_dry_run_stdin() {
+    dkit()
+        .args(&[
+            "convert",
+            "-",
+            "-f",
+            "csv",
+            "--from",
+            "json",
+            "--dry-run",
+        ])
+        .write_stdin(r#"[{"a":1},{"a":2},{"a":3}]"#)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[dry-run]"));
+}
+
 #[test]
 fn convert_multiple_files_without_outdir() {
     dkit()


### PR DESCRIPTION
## Summary
- Add `--dry-run` flag to `convert` subcommand to preview conversion results without writing output files
- Add `--dry-run-limit N` option to control how many records are shown in preview (default: 10)
- Output always goes to stdout in dry-run mode, ignoring `-o` / `--outdir`
- Incompatible with batch mode (multiple files) and streaming mode (`--chunk-size`)

## Test plan
- [x] `--dry-run` outputs preview to stdout
- [x] `--dry-run` does not create output file even when `-o` is specified
- [x] `--dry-run-limit` truncates records correctly
- [x] `--dry-run` works with `--filter` and other data pipeline flags
- [x] `--dry-run` works with stdin input
- [x] `cargo test` — all 458 unit + 5 new integration tests pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

Closes #206

https://claude.ai/code/session_01WctcXJx1QuAMyDxfoJHqUK