### PR TITLE
feat: add --output-format flag for stats/schema (JSON/YAML output)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 1.0.69",
  "toml",

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -33,6 +33,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 csv = "1"
 toml = "0.8"
 indexmap = { version = "2", features = ["serde"] }

--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -377,9 +377,15 @@ pub enum Commands {
         #[arg(long, value_name = "FORMAT")]
         from: Option<String>,
 
-        /// Output format (json, table, md)
-        #[arg(short = 'f', long, value_name = "FORMAT")]
-        format: Option<String>,
+        /// Output format (json, yaml, table, md)
+        #[arg(
+            short = 'O',
+            long = "output-format",
+            alias = "format",
+            short_alias = 'f',
+            value_name = "FORMAT"
+        )]
+        output_format: Option<String>,
 
         /// Navigate to nested data path (e.g. '.users')
         #[arg(long, value_name = "QUERY")]
@@ -504,6 +510,10 @@ pub enum Commands {
         /// Input format (required for stdin)
         #[arg(long, value_name = "FORMAT")]
         from: Option<String>,
+
+        /// Output format (json, yaml, table)
+        #[arg(short = 'O', long = "output-format", value_name = "FORMAT")]
+        output_format: Option<String>,
 
         /// Input file encoding (e.g. euc-kr, shift_jis, latin1)
         #[arg(long, value_name = "ENCODING")]

--- a/dkit-cli/src/commands/schema.rs
+++ b/dkit-cli/src/commands/schema.rs
@@ -23,9 +23,31 @@ use dkit_core::value::Value;
 pub struct SchemaArgs<'a> {
     pub input: &'a str,
     pub from: Option<&'a str>,
+    pub output_format: Option<&'a str>,
     pub encoding_opts: EncodingOptions,
     pub excel_opts: ExcelOptions,
     pub sqlite_opts: SqliteOptions,
+}
+
+/// 스키마 출력 포맷
+enum SchemaOutputFormat {
+    Tree,
+    Json,
+    Yaml,
+}
+
+impl SchemaOutputFormat {
+    fn from_str_opt(s: Option<&str>) -> anyhow::Result<Self> {
+        match s {
+            None | Some("tree") | Some("table") | Some("text") => Ok(Self::Tree),
+            Some("json") => Ok(Self::Json),
+            Some("yaml") | Some("yml") => Ok(Self::Yaml),
+            Some(other) => bail!(
+                "Unsupported schema output format: '{}'. Use json, yaml, or table",
+                other
+            ),
+        }
+    }
 }
 
 pub fn run(args: &SchemaArgs) -> Result<()> {
@@ -77,11 +99,74 @@ pub fn run(args: &SchemaArgs) -> Result<()> {
         }
     };
 
-    let mut output = String::new();
-    format_schema(&value, "", true, &mut output);
-    print!("{output}");
+    let output_format = SchemaOutputFormat::from_str_opt(args.output_format)?;
+
+    match output_format {
+        SchemaOutputFormat::Tree => {
+            let mut output = String::new();
+            format_schema(&value, "", true, &mut output);
+            print!("{output}");
+        }
+        SchemaOutputFormat::Json => {
+            let json = build_schema_json(&value);
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        SchemaOutputFormat::Yaml => {
+            let json = build_schema_json(&value);
+            print!("{}", serde_yaml::to_string(&json)?);
+        }
+    }
 
     Ok(())
+}
+
+/// Value를 JSON Schema 형식의 serde_json::Value로 변환
+fn build_schema_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::Null => serde_json::json!({"type": "null"}),
+        Value::Bool(_) => serde_json::json!({"type": "boolean"}),
+        Value::Integer(_) => serde_json::json!({"type": "integer"}),
+        Value::Float(_) => serde_json::json!({"type": "float"}),
+        Value::String(_) => serde_json::json!({"type": "string"}),
+        Value::Array(arr) => {
+            if arr.is_empty() {
+                serde_json::json!({"type": "array", "items": "empty"})
+            } else {
+                let elem_type = array_element_type(arr);
+                let has_objects = arr.iter().any(|v| matches!(v, Value::Object(_)));
+                if has_objects {
+                    let merged = merge_object_schemas(arr);
+                    let properties = build_object_properties_json(&merged);
+                    serde_json::json!({
+                        "type": "array",
+                        "items": {
+                            "type": elem_type,
+                            "properties": properties,
+                        }
+                    })
+                } else {
+                    serde_json::json!({"type": "array", "items": elem_type})
+                }
+            }
+        }
+        Value::Object(obj) => {
+            let properties = build_object_properties_json(obj);
+            serde_json::json!({
+                "type": "object",
+                "properties": properties,
+            })
+        }
+        _ => serde_json::json!({"type": "unknown"}),
+    }
+}
+
+/// Object 필드들을 JSON 프로퍼티로 변환
+fn build_object_properties_json(obj: &indexmap::IndexMap<String, Value>) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for (key, val) in obj {
+        map.insert(key.clone(), build_schema_json(val));
+    }
+    serde_json::Value::Object(map)
 }
 
 /// Schema 타입 이름 반환
@@ -400,6 +485,80 @@ mod tests {
              └─ users: array[object]\n   \
                 ├─ name: string\n   \
                 └─ email: string\n"
+        );
+    }
+
+    #[test]
+    fn test_schema_output_format_parse() {
+        assert!(matches!(
+            SchemaOutputFormat::from_str_opt(None).unwrap(),
+            SchemaOutputFormat::Tree
+        ));
+        assert!(matches!(
+            SchemaOutputFormat::from_str_opt(Some("json")).unwrap(),
+            SchemaOutputFormat::Json
+        ));
+        assert!(matches!(
+            SchemaOutputFormat::from_str_opt(Some("yaml")).unwrap(),
+            SchemaOutputFormat::Yaml
+        ));
+        assert!(matches!(
+            SchemaOutputFormat::from_str_opt(Some("yml")).unwrap(),
+            SchemaOutputFormat::Yaml
+        ));
+        assert!(matches!(
+            SchemaOutputFormat::from_str_opt(Some("table")).unwrap(),
+            SchemaOutputFormat::Tree
+        ));
+        assert!(SchemaOutputFormat::from_str_opt(Some("invalid")).is_err());
+    }
+
+    #[test]
+    fn test_build_schema_json_simple_object() {
+        let value = make_object(vec![
+            ("host", Value::String("localhost".into())),
+            ("port", Value::Integer(5432)),
+        ]);
+        let json = build_schema_json(&value);
+        assert_eq!(json["type"], "object");
+        assert_eq!(json["properties"]["host"]["type"], "string");
+        assert_eq!(json["properties"]["port"]["type"], "integer");
+    }
+
+    #[test]
+    fn test_build_schema_json_nested_object() {
+        let inner = make_object(vec![("host", Value::String("localhost".into()))]);
+        let value = make_object(vec![("database", inner)]);
+        let json = build_schema_json(&value);
+        assert_eq!(json["type"], "object");
+        assert_eq!(json["properties"]["database"]["type"], "object");
+        assert_eq!(
+            json["properties"]["database"]["properties"]["host"]["type"],
+            "string"
+        );
+    }
+
+    #[test]
+    fn test_build_schema_json_array_of_objects() {
+        let value = Value::Array(vec![
+            make_object(vec![("name", Value::String("Alice".into()))]),
+            make_object(vec![("name", Value::String("Bob".into()))]),
+        ]);
+        let json = build_schema_json(&value);
+        assert_eq!(json["type"], "array");
+        assert_eq!(json["items"]["type"], "object");
+        assert_eq!(json["items"]["properties"]["name"]["type"], "string");
+    }
+
+    #[test]
+    fn test_build_schema_json_primitive() {
+        assert_eq!(build_schema_json(&Value::Null)["type"], "null");
+        assert_eq!(build_schema_json(&Value::Bool(true))["type"], "boolean");
+        assert_eq!(build_schema_json(&Value::Integer(42))["type"], "integer");
+        assert_eq!(build_schema_json(&Value::Float(3.14))["type"], "float");
+        assert_eq!(
+            build_schema_json(&Value::String("hi".into()))["type"],
+            "string"
         );
     }
 }

--- a/dkit-cli/src/commands/stats.rs
+++ b/dkit-cli/src/commands/stats.rs
@@ -38,6 +38,7 @@ pub struct StatsArgs<'a> {
 enum OutputFormat {
     Text,
     Json,
+    Yaml,
     Markdown,
 }
 
@@ -46,9 +47,10 @@ impl OutputFormat {
         match s {
             None | Some("text") | Some("table") => Ok(Self::Text),
             Some("json") => Ok(Self::Json),
+            Some("yaml") | Some("yml") => Ok(Self::Yaml),
             Some("md") | Some("markdown") => Ok(Self::Markdown),
             Some(other) => bail!(
-                "Unsupported stats output format: '{}'. Use json, table, or md",
+                "Unsupported stats output format: '{}'. Use json, yaml, table, or md",
                 other
             ),
         }
@@ -135,6 +137,10 @@ fn run_overall_stats(value: &Value, output_format: &OutputFormat, histogram: boo
                     let json = build_overall_json(rows, &col_stats);
                     println!("{}", serde_json::to_string_pretty(&json)?);
                 }
+                OutputFormat::Yaml => {
+                    let json = build_overall_json(rows, &col_stats);
+                    print!("{}", serde_yaml::to_string(&json)?);
+                }
                 OutputFormat::Markdown => {
                     println!("# Statistics");
                     println!();
@@ -183,6 +189,24 @@ fn run_overall_stats(value: &Value, output_format: &OutputFormat, histogram: boo
                     serde_json::to_string_pretty(&serde_json::Value::Object(map))?
                 );
             }
+            OutputFormat::Yaml => {
+                let mut map = serde_json::Map::new();
+                map.insert("rows".to_string(), serde_json::Value::Number(1.into()));
+                let columns: Vec<&String> = obj.keys().collect();
+                map.insert(
+                    "columns".to_string(),
+                    serde_json::Value::Array(
+                        columns
+                            .iter()
+                            .map(|c| serde_json::Value::String(c.to_string()))
+                            .collect(),
+                    ),
+                );
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&serde_json::Value::Object(map))?
+                );
+            }
             OutputFormat::Markdown => {
                 println!("# Statistics");
                 println!();
@@ -217,6 +241,21 @@ fn run_overall_stats(value: &Value, output_format: &OutputFormat, histogram: boo
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&serde_json::Value::Object(map))?
+                );
+            }
+            OutputFormat::Yaml => {
+                let mut map = serde_json::Map::new();
+                map.insert(
+                    "type".to_string(),
+                    serde_json::Value::String(value_type_name(value).to_string()),
+                );
+                map.insert(
+                    "value".to_string(),
+                    serde_json::Value::String(format!("{}", value)),
+                );
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&serde_json::Value::Object(map))?
                 );
             }
             OutputFormat::Markdown => {
@@ -256,6 +295,10 @@ fn run_column_stats(
         OutputFormat::Json => {
             let json = build_column_json(&cs);
             println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        OutputFormat::Yaml => {
+            let json = build_column_json(&cs);
+            print!("{}", serde_yaml::to_string(&json)?);
         }
         OutputFormat::Markdown => {
             println!("## {}", cs.name);

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -498,7 +498,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
         Commands::Stats {
             input,
             from,
-            format,
+            output_format,
             path,
             column,
             field,
@@ -516,7 +516,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             commands::stats::run(&commands::stats::StatsArgs {
                 input: &input,
                 from: from.as_deref(),
-                format: format.as_deref(),
+                format: output_format.as_deref(),
                 path: path.as_deref(),
                 column: effective_column.as_deref(),
                 histogram,
@@ -566,6 +566,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
         Commands::Schema {
             input,
             from,
+            output_format,
             encoding,
             detect_encoding,
             sheet,
@@ -576,6 +577,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             commands::schema::run(&commands::schema::SchemaArgs {
                 input: &input,
                 from: from.as_deref(),
+                output_format: output_format.as_deref(),
                 encoding_opts: EncodingOptions {
                     encoding,
                     detect_encoding,


### PR DESCRIPTION
## Summary
- `stats` 및 `schema` 서브커맨드에 `--output-format` (`-O`) 플래그 추가 (json, yaml, table/tree 지원)
- `stats`는 기존 `-f`/`--format` 별칭을 유지하여 하위 호환성 보장
- `schema`의 JSON 출력은 JSON Schema 스타일 구조 (`type`, `properties`, `items`)로 반환

## Test plan
- [x] 기존 458개 단위 테스트 전체 통과
- [x] schema에 5개 신규 단위 테스트 추가 (출력 포맷 파싱, JSON 스키마 빌드)
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과
- [x] stats JSON/YAML 출력 수동 검증 완료
- [x] schema JSON/YAML 출력 수동 검증 완료
- [x] stats `-f` 하위 호환성 검증 완료

Closes #207

https://claude.ai/code/session_01NvZJKj9MCg9hzuBFS1kWB1