### PR TITLE
test: add v1.1.0 integration tests and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ dkit completions powershell > dkit.ps1 && . ./dkit.ps1
 | Parquet     | `.parquet`             |  ✓   |   ✓   | Snappy / Gzip / Zstd compression |
 | Excel       | `.xlsx`                |  ✓   |   —   | Sheet selection, input-only    |
 | SQLite      | `.db`, `.sqlite`       |  ✓   |   —   | Custom SQL queries, input-only |
+| .env        | `.env`                 |  ✓   |   ✓   | Environment variable files     |
 | Markdown    | `.md`                  |  —   |   ✓   | GFM table, output-only         |
 | HTML        | `.html`                |  —   |   ✓   | Styled tables, output-only     |
 
@@ -140,6 +141,19 @@ dkit convert data.csv --to json --detect-encoding
 
 # Streaming for large files
 dkit convert large.jsonl --from jsonl -f csv --chunk-size 1000 -o out.csv
+
+# Column selection and aggregation
+dkit convert data.json --to csv --select 'name, email'
+dkit convert sales.csv --to json --group-by category --agg 'count(), sum(amount)'
+dkit convert data.json --to csv --select 'name, age' --filter 'age > 30' --sort-by age
+
+# Dry-run (preview without writing)
+dkit convert huge.json --to csv -o output.csv --dry-run
+
+# .env format
+dkit convert .env --to json                         # .env → JSON
+dkit convert config.json --to env -o .env            # JSON → .env
+dkit diff .env.dev .env.prod                         # Compare environments
 
 # Watch mode (re-convert on file change)
 dkit convert data.json --to csv --watch
@@ -210,6 +224,8 @@ dkit view users.csv
 dkit view data.json --path '.users' --limit 20
 dkit view data.csv --columns name,email --border rounded --color
 dkit view data.json --row-numbers --max-width 30
+dkit view data.json --select 'name, email'         # Select specific columns
+dkit view sales.csv --group-by status --agg 'count()'  # Aggregation table
 dkit view data.json --format md                   # Output as Markdown table
 dkit view data.xlsx --list-sheets                 # List Excel sheets
 dkit view data.db --list-tables                   # List SQLite tables
@@ -223,6 +239,7 @@ dkit stats data.csv                               # Overall statistics
 dkit stats data.csv --column revenue               # Per-field details
 dkit stats data.csv --column age --histogram       # Text histogram
 dkit stats data.json --path .users --format json   # JSON output
+dkit stats data.csv --output-format json            # Structured JSON for scripting
 ```
 
 ### `schema` — Structure inspection
@@ -316,6 +333,7 @@ dkit y2j config.yaml                # YAML → JSON
 | Parquet | ✓ | — | — | — |
 | Excel (.xlsx) input | ✓ | — | — | — |
 | SQLite input | ✓ | — | — | — |
+| .env files | ✓ | — | — | — |
 | Cross-format convert | ✓ | — | Partial | Partial |
 | Query (where/select/sort) | ✓ | ✓ | ✓ | ✓ |
 | Aggregate / GROUP BY | ✓ | Partial | ✓ | — |

--- a/dkit-cli/tests/fixtures/sample.env
+++ b/dkit-cli/tests/fixtures/sample.env
@@ -1,0 +1,14 @@
+# Database settings
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=myapp
+
+# App settings
+APP_NAME="My Application"
+APP_DEBUG=true
+APP_SECRET='s3cr3t-key'
+
+# Empty and special values
+EMPTY_VAR=
+export EXPORTED_VAR=exported_value
+QUOTED_HASH="value # not a comment"

--- a/dkit-cli/tests/v110_integration_test.rs
+++ b/dkit-cli/tests/v110_integration_test.rs
@@ -1,0 +1,855 @@
+/// v1.1.0 Integration Tests
+///
+/// Comprehensive integration tests for v1.1.0 features:
+/// - `--select` flag for convert/view (column selection)
+/// - `--group-by` + `--agg` flags (aggregation)
+/// - `.env` format Reader/Writer
+/// - `--dry-run` flag (preview without writing)
+/// - `--output-format` flag for stats/schema (JSON/YAML output)
+/// - Combined flag tests (--select + --filter + --sort-by etc.)
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// ============================================================
+// --select flag tests
+// ============================================================
+
+#[test]
+fn select_single_field_json() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--select",
+            "name",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("age").not());
+}
+
+#[test]
+fn select_multiple_fields_json() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--select",
+            "name, city",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("score").not())
+        .stdout(predicate::str::contains("role").not());
+}
+
+#[test]
+fn select_fields_csv_output() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--select",
+            "name, age",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name,age"))
+        .stdout(predicate::str::contains("Alice,30"))
+        .stdout(predicate::str::contains("city").not());
+}
+
+#[test]
+fn select_with_view_command() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/employees.json",
+            "--select",
+            "name, score",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("score"))
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("85"))
+        .stdout(predicate::str::contains("city").not());
+}
+
+#[test]
+fn select_preserves_all_records() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--select",
+            "name",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Header + 5 data rows
+    let line_count = stdout.trim().lines().count();
+    assert_eq!(line_count, 6, "should have header + 5 records");
+}
+
+#[test]
+fn select_with_stdin() {
+    dkit()
+        .args(&[
+            "convert", "-", "--from", "json", "-f", "json", "--select", "name",
+        ])
+        .write_stdin(r#"[{"name":"Alice","age":30},{"name":"Bob","age":25}]"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("age").not());
+}
+
+// ============================================================
+// --group-by + --agg flag tests
+// ============================================================
+
+#[test]
+fn group_by_count() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--group-by",
+            "city",
+            "--agg",
+            "count()",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("3"))
+        .stdout(predicate::str::contains("Busan"))
+        .stdout(predicate::str::contains("1"));
+}
+
+#[test]
+fn group_by_with_sum() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--group-by",
+            "city",
+            "--agg",
+            "sum(score)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("Busan"));
+}
+
+#[test]
+fn group_by_with_multiple_aggregations() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--group-by",
+            "city",
+            "--agg",
+            "count(), avg(score)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("count"))
+        .stdout(predicate::str::contains("avg_score"));
+}
+
+#[test]
+fn group_by_csv_output() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--group-by",
+            "role",
+            "--agg",
+            "count()",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("role"))
+        .stdout(predicate::str::contains("count"))
+        .stdout(predicate::str::contains("engineer"));
+}
+
+#[test]
+fn group_by_with_view_command() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/employees.json",
+            "--group-by",
+            "city",
+            "--agg",
+            "count()",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("Busan"));
+}
+
+#[test]
+fn group_by_min_max() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--group-by",
+            "city",
+            "--agg",
+            "min(score), max(score)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("min_score"))
+        .stdout(predicate::str::contains("max_score"));
+}
+
+// ============================================================
+// .env format Reader/Writer tests
+// ============================================================
+
+#[test]
+fn env_to_json_conversion() {
+    dkit()
+        .args(&["convert", "tests/fixtures/sample.env", "-f", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DB_HOST"))
+        .stdout(predicate::str::contains("localhost"))
+        .stdout(predicate::str::contains("DB_PORT"))
+        .stdout(predicate::str::contains("5432"));
+}
+
+#[test]
+fn env_to_yaml_conversion() {
+    dkit()
+        .args(&["convert", "tests/fixtures/sample.env", "-f", "yaml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DB_HOST"))
+        .stdout(predicate::str::contains("localhost"));
+}
+
+#[test]
+fn json_to_env_conversion() {
+    dkit()
+        .args(&["convert", "-", "--from", "json", "-f", "env"])
+        .write_stdin(r#"{"HOST":"localhost","PORT":"8080"}"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("HOST=localhost"))
+        .stdout(predicate::str::contains("PORT=8080"));
+}
+
+#[test]
+fn env_handles_quoted_values() {
+    dkit()
+        .args(&["convert", "tests/fixtures/sample.env", "-f", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("My Application"))
+        .stdout(predicate::str::contains("s3cr3t-key"));
+}
+
+#[test]
+fn env_handles_export_prefix() {
+    dkit()
+        .args(&["convert", "tests/fixtures/sample.env", "-f", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXPORTED_VAR"))
+        .stdout(predicate::str::contains("exported_value"));
+}
+
+#[test]
+fn env_handles_comments_and_empty_lines() {
+    dkit()
+        .args(&["convert", "tests/fixtures/sample.env", "-f", "json"])
+        .assert()
+        .success()
+        // Comments should not appear as keys
+        .stdout(predicate::str::contains("# Database").not())
+        .stdout(predicate::str::contains("DB_HOST"));
+}
+
+#[test]
+fn env_roundtrip_json() {
+    let tmp = TempDir::new().unwrap();
+    let json_file = tmp.path().join("config.json");
+    let env_file = tmp.path().join("config.env");
+
+    // env → json
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/sample.env",
+            "-f",
+            "json",
+            "-o",
+            json_file.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // json → env
+    dkit()
+        .args(&[
+            "convert",
+            json_file.to_str().unwrap(),
+            "-f",
+            "env",
+            "-o",
+            env_file.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let env_content = fs::read_to_string(&env_file).unwrap();
+    assert!(env_content.contains("DB_HOST=localhost"));
+    assert!(env_content.contains("DB_PORT=5432"));
+}
+
+#[test]
+fn env_view() {
+    dkit()
+        .args(&["view", "tests/fixtures/sample.env"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DB_HOST"))
+        .stdout(predicate::str::contains("localhost"));
+}
+
+#[test]
+fn env_diff() {
+    let tmp = TempDir::new().unwrap();
+    let env1 = tmp.path().join("dev.env");
+    let env2 = tmp.path().join("prod.env");
+
+    fs::write(&env1, "DB_HOST=localhost\nDB_PORT=5432\n").unwrap();
+    fs::write(&env2, "DB_HOST=prod-server\nDB_PORT=5432\n").unwrap();
+
+    dkit()
+        .args(&["diff", env1.to_str().unwrap(), env2.to_str().unwrap()])
+        .assert()
+        .stdout(predicate::str::contains("DB_HOST"));
+}
+
+#[test]
+fn env_merge() {
+    let tmp = TempDir::new().unwrap();
+    let env1 = tmp.path().join("defaults.env");
+    let env2 = tmp.path().join("overrides.env");
+
+    fs::write(&env1, "DB_HOST=localhost\nDB_PORT=5432\n").unwrap();
+    fs::write(&env2, "DB_HOST=prod-server\nAPP_KEY=secret\n").unwrap();
+
+    dkit()
+        .args(&[
+            "merge",
+            env1.to_str().unwrap(),
+            env2.to_str().unwrap(),
+            "--to",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("prod-server"))
+        .stdout(predicate::str::contains("APP_KEY"));
+}
+
+// ============================================================
+// --dry-run flag tests (extended)
+// ============================================================
+
+#[test]
+fn dry_run_with_select() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--select",
+            "name, age",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name,age"))
+        .stdout(predicate::str::contains("Alice"))
+        .stderr(predicate::str::contains("[dry-run]"));
+}
+
+#[test]
+fn dry_run_with_group_by() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--group-by",
+            "city",
+            "--agg",
+            "count()",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stderr(predicate::str::contains("[dry-run]"));
+}
+
+// ============================================================
+// --output-format flag tests (stats / schema)
+// ============================================================
+
+#[test]
+fn stats_output_format_json() {
+    dkit()
+        .args(&[
+            "stats",
+            "tests/fixtures/employees.json",
+            "--output-format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"rows\""))
+        .stdout(predicate::str::contains("\"columns\""));
+}
+
+#[test]
+fn stats_output_format_json_has_valid_structure() {
+    let output = dkit()
+        .args(&[
+            "stats",
+            "tests/fixtures/employees.json",
+            "--output-format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should be valid JSON
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(parsed.get("rows").is_some());
+    assert!(parsed.get("columns").is_some());
+}
+
+#[test]
+fn stats_output_format_json_column_details() {
+    dkit()
+        .args(&[
+            "stats",
+            "tests/fixtures/employees.json",
+            "--output-format",
+            "json",
+            "--column",
+            "age",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"type\""))
+        .stdout(predicate::str::contains("\"mean\""));
+}
+
+#[test]
+fn stats_output_format_yaml() {
+    dkit()
+        .args(&[
+            "stats",
+            "tests/fixtures/employees.json",
+            "--output-format",
+            "yaml",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rows:"));
+}
+
+#[test]
+fn schema_output_format_json() {
+    dkit()
+        .args(&[
+            "schema",
+            "tests/fixtures/employees.json",
+            "--output-format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"type\""))
+        .stdout(predicate::str::contains("\"array\""));
+}
+
+#[test]
+fn schema_output_format_json_has_valid_structure() {
+    let output = dkit()
+        .args(&[
+            "schema",
+            "tests/fixtures/employees.json",
+            "--output-format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed.get("type").unwrap(), "array");
+    assert!(parsed.get("items").is_some());
+}
+
+// ============================================================
+// Combined flag tests
+// ============================================================
+
+#[test]
+fn select_with_filter() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--select",
+            "name, age",
+            "--filter",
+            "age > 30",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Charlie,35"))
+        .stdout(predicate::str::contains("Eve,32"))
+        .stdout(predicate::str::contains("Alice").not());
+}
+
+#[test]
+fn select_with_filter_and_sort() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--select",
+            "name, age",
+            "--filter",
+            "age > 28",
+            "--sort-by",
+            "age",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines[0], "name,age");
+    assert!(lines[1].contains("Alice")); // age 30
+    assert!(lines[2].contains("Eve")); // age 32
+    assert!(lines[3].contains("Charlie")); // age 35
+}
+
+#[test]
+fn select_with_filter_sort_and_head() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--select",
+            "name, age",
+            "--filter",
+            "age > 28",
+            "--sort-by",
+            "age",
+            "--head",
+            "2",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    // header + 2 records
+    assert_eq!(lines.len(), 3);
+    assert!(lines[1].contains("Alice")); // age 30, first after sort
+}
+
+#[test]
+fn select_with_sort_desc() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--select",
+            "name, score",
+            "--sort-by",
+            "score",
+            "--sort-order",
+            "desc",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    // Diana (95) should be first after header
+    assert!(lines[1].contains("Diana"));
+}
+
+#[test]
+fn group_by_with_filter() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--filter",
+            "role == \"engineer\"",
+            "--group-by",
+            "city",
+            "--agg",
+            "count()",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("Incheon"));
+}
+
+#[test]
+fn select_with_yaml_output() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "yaml",
+            "--select",
+            "name, city",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name:"))
+        .stdout(predicate::str::contains("city:"))
+        .stdout(predicate::str::contains("score").not());
+}
+
+#[test]
+fn select_with_toml_output() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "toml",
+            "--select",
+            "name, age",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("Alice"));
+}
+
+#[test]
+fn env_with_select() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/sample.env",
+            "-f",
+            "json",
+            "--select",
+            "DB_HOST, DB_PORT",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DB_HOST"))
+        .stdout(predicate::str::contains("DB_PORT"))
+        .stdout(predicate::str::contains("APP_NAME").not());
+}
+
+// ============================================================
+// Pipeline / multi-format tests
+// ============================================================
+
+#[test]
+fn select_csv_to_json_pipeline() {
+    // CSV input → select → JSON output
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.csv",
+            "-f",
+            "json",
+            "--select",
+            "name, email",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("email"))
+        .stdout(predicate::str::contains("age").not());
+}
+
+#[test]
+fn group_by_csv_input() {
+    dkit()
+        .args(&[
+            "convert",
+            "-",
+            "--from",
+            "csv",
+            "-f",
+            "json",
+            "--group-by",
+            "city",
+            "--agg",
+            "count()",
+        ])
+        .write_stdin("name,city\nAlice,Seoul\nBob,Busan\nCharlie,Seoul\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("2"))
+        .stdout(predicate::str::contains("Busan"))
+        .stdout(predicate::str::contains("1"));
+}
+
+#[test]
+fn output_format_with_file_output() {
+    // Test that --output-format json works and produces parseable JSON
+    let output = dkit()
+        .args(&[
+            "stats",
+            "tests/fixtures/users.json",
+            "--output-format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let _: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("stats --output-format json should produce valid JSON");
+}
+
+// ============================================================
+// Edge cases
+// ============================================================
+
+#[test]
+fn select_nonexistent_field() {
+    // Selecting a field that doesn't exist should not crash
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "-f",
+            "json",
+            "--select",
+            "name, nonexistent",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"));
+}
+
+#[test]
+fn group_by_single_group() {
+    // All records in one group
+    dkit()
+        .args(&[
+            "convert",
+            "-",
+            "--from",
+            "json",
+            "-f",
+            "json",
+            "--group-by",
+            "status",
+            "--agg",
+            "count()",
+        ])
+        .write_stdin(r#"[{"name":"A","status":"active"},{"name":"B","status":"active"}]"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("active"))
+        .stdout(predicate::str::contains("2"));
+}
+
+#[test]
+fn env_empty_file() {
+    let tmp = TempDir::new().unwrap();
+    let empty_env = tmp.path().join("empty.env");
+    fs::write(&empty_env, "# just a comment\n").unwrap();
+
+    dkit()
+        .args(&["convert", empty_env.to_str().unwrap(), "-f", "json"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn env_to_csv_conversion() {
+    // .env is flat key-value, should convert to single-row CSV-like structure
+    dkit()
+        .args(&["convert", "-", "--from", "env", "-f", "json"])
+        .write_stdin("KEY1=value1\nKEY2=value2\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("KEY1"))
+        .stdout(predicate::str::contains("value1"));
+}
+
+#[test]
+fn stats_default_output_is_not_json() {
+    // Without --output-format, stats should produce human-readable table output (not JSON)
+    dkit()
+        .args(&["stats", "tests/fixtures/users.json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("{").not());
+}

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -52,6 +52,16 @@ dkit convert --from <FORMAT> --to <FORMAT>  # stdin 사용 시
 | `--outdir <DIR>` | | 일괄 변환 시 출력 디렉토리 | |
 | `--rename <PATTERN>` | | 일괄 변환 시 파일명 패턴 (`{name}`, `{ext}`) | |
 | `--continue-on-error` | | 일괄 변환 시 에러 발생해도 계속 진행 | false |
+| `--select <FIELDS>` | | 선택할 필드 목록 (쉼표 구분) | 전체 |
+| `--group-by <FIELDS>` | | 그룹핑 기준 필드 (쉼표 구분) | |
+| `--agg <EXPR>` | | 집계 함수 (`count()`, `sum(field)`, `avg(field)`, `min(field)`, `max(field)`) | |
+| `--filter <EXPR>` | | 필터 표현식 | |
+| `--sort-by <FIELD>` | | 정렬 기준 필드 | |
+| `--sort-order <ORDER>` | | 정렬 방향 (`asc`, `desc`) | `asc` |
+| `--head <N>` | | 처음 N개 레코드만 출력 | |
+| `--tail <N>` | | 마지막 N개 레코드만 출력 | |
+| `--dry-run` | | 미리보기 모드 (파일 생성 없이 stdout으로 출력) | false |
+| `--dry-run-limit <N>` | | 미리보기 시 출력 레코드 수 | 10 |
 
 ### Examples
 
@@ -119,6 +129,27 @@ dkit convert data.csv --to json --encoding euc-kr        # EUC-KR 입력
 dkit convert data.csv --to json --encoding shift_jis     # Shift-JIS 입력
 dkit convert data.csv --to json --encoding latin1        # Latin1 입력
 dkit convert data.csv --to json --detect-encoding        # 인코딩 자동 감지
+
+# 컬럼 선택 (--select)
+dkit convert data.json --to csv --select 'name, email'   # name, email 컬럼만 출력
+dkit convert data.csv --to json --select 'id, status'    # 특정 필드만 선택
+
+# 그룹핑 및 집계 (--group-by + --agg)
+dkit convert sales.csv --to json --group-by category --agg 'count(), sum(amount)'
+dkit convert data.json --to csv --group-by status --agg 'count(), avg(score), min(score), max(score)'
+
+# 필터 + 선택 + 정렬 조합
+dkit convert data.json --to csv --select 'name, age' --filter 'age > 30' --sort-by age
+dkit convert data.csv --to json --filter 'status == "active"' --head 10
+
+# 미리보기 (--dry-run)
+dkit convert huge.json --to csv -o output.csv --dry-run         # 파일 생성 없이 미리보기
+dkit convert data.json --to csv --dry-run --dry-run-limit 5     # 처음 5개 레코드만 미리보기
+
+# .env 포맷 변환
+dkit convert .env --to json                              # .env → JSON
+dkit convert config.json --to env -o .env                # JSON → .env
+dkit convert .env --to yaml                              # .env → YAML
 ```
 
 ## query
@@ -214,6 +245,11 @@ dkit view <INPUT> [OPTIONS]
 | `--list-sheets` | Excel 시트 목록 출력 | |
 | `--table <TABLE>` | SQLite 테이블 이름 | 첫 번째 테이블 |
 | `--list-tables` | SQLite 테이블 목록 출력 | |
+| `--select <FIELDS>` | 선택할 필드 목록 (쉼표 구분) | 전체 |
+| `--group-by <FIELDS>` | 그룹핑 기준 필드 (쉼표 구분) | |
+| `--agg <EXPR>` | 집계 함수 | |
+| `--filter <EXPR>` | 필터 표현식 | |
+| `--sort-by <FIELD>` | 정렬 기준 필드 | |
 
 ### Examples
 
@@ -244,6 +280,14 @@ dkit view data.xlsx --list-sheets                # 시트 목록
 dkit view data.db                                # SQLite 테이블 미리보기
 dkit view data.db --table users                  # 특정 테이블 보기
 dkit view data.db --list-tables                  # 테이블 목록
+
+# 컬럼 선택 및 집계
+dkit view data.json --select 'name, email'       # 특정 필드만 표시
+dkit view sales.csv --group-by category --agg 'count(), sum(amount)'  # 집계 테이블
+dkit view data.csv --select 'name, score' --filter 'score > 80' --sort-by score
+
+# .env 파일 보기
+dkit view .env                                   # .env 파일 테이블로 보기
 ```
 
 ## stats
@@ -264,6 +308,7 @@ dkit stats <INPUT> [OPTIONS]
 | `--column <NAME>` | 특정 컬럼 통계 |
 | `--field <NAME>` | 특정 필드 상세 분석 (`--column` 별칭) |
 | `-f, --format <FORMAT>` | 출력 포맷 (`json`, `table`, `md`) |
+| `--output-format <FORMAT>` / `-O` | 출력 포맷 (`table`, `json`, `yaml`) — 기본값: `table` |
 | `--histogram` | 숫자 필드에 텍스트 히스토그램 출력 |
 
 ### Output
@@ -321,6 +366,11 @@ dkit stats data.csv --column revenue
 dkit stats data.csv --field revenue --format json
 dkit stats data.csv --format md
 dkit stats data.csv --column age --histogram
+
+# JSON/YAML 출력 (프로그래밍적 활용)
+dkit stats data.csv --output-format json         # JSON 구조화 출력
+dkit stats data.csv --output-format yaml         # YAML 출력
+dkit stats data.csv --output-format json | dkit query - '.columns[].name'  # 파이프라인
 ```
 
 ## schema
@@ -330,8 +380,14 @@ dkit stats data.csv --column age --histogram
 ### Usage
 
 ```bash
-dkit schema <INPUT>
+dkit schema <INPUT> [OPTIONS]
 ```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--output-format <FORMAT>` / `-O` | 출력 포맷 (`tree`, `json`, `yaml`) — 기본값: `tree` |
 
 ### Output
 
@@ -347,6 +403,16 @@ root: object
 └─ users: array[object]
    ├─ name: string
    └─ email: string
+```
+
+### Examples
+
+```bash
+dkit schema config.yaml
+dkit schema data.json
+dkit schema data.json --output-format json       # JSON Schema 형태로 출력
+dkit schema data.json --output-format yaml       # YAML 출력
+cat data.json | dkit schema - --from json
 ```
 
 ## merge

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -207,6 +207,24 @@ pub struct FormatOptions {
 - `list_tables()`: 테이블 이름 목록 반환
 - **제한**: 입력 전용 (쓰기 불가)
 
+### .env ↔ Value
+
+- `KEY=VALUE` 라인 기반 포맷 (환경 변수 설정 파일)
+- 주석: `#` 으로 시작하는 줄 (무시)
+- 빈 줄 무시
+- `export` 접두사 자동 제거 (`export KEY=VALUE` → `KEY=VALUE`)
+- 큰따옴표/작은따옴표 값 지원 (`KEY="value with spaces"`, `KEY='literal'`)
+- 큰따옴표 내 이스케이프 시퀀스: `\n`, `\r`, `\t`, `\"`, `\\`
+- 인라인 주석 지원 (따옴표 밖 `#` 이후)
+- 데이터 모델: flat `Value::Object` (중첩 구조 없음)
+- 읽기: 항상 `Value::Object(IndexMap<String, Value>)` 반환 (값은 `Value::String`)
+- 쓰기: 특수문자 포함 값은 자동으로 큰따옴표 감싸기
+- 빈 값: `KEY=` → `Value::String("")`
+- Null 값: `KEY=` 로 출력
+- 배열/객체 값: JSON 직렬화 후 작은따옴표로 감싸기
+- 포맷 자동 감지: `.env` 확장자
+- **제한**: 변수 확장 (`$VAR`, `${VAR}`) 미지원
+
 ### HTML → Value (출력 전용)
 
 - HTML 테이블 생성 (Array<Object>, Single Object, Array<Primitive>)


### PR DESCRIPTION
## Summary
- Add 46 integration tests covering all v1.1.0 features: `--select`, `--group-by` + `--agg`, `.env` format, `--dry-run`, `--output-format`
- Add combined flag tests (`--select` + `--filter` + `--sort-by` + `--head`)
- Update `docs/cli-spec.md` with new options and examples for convert, view, stats, schema
- Update `docs/technical-spec.md` with `.env` format specification
- Update `README.md` with `.env` in supported formats table and new feature examples

## Test plan
- [x] All 46 new integration tests pass (`cargo test --test v110_integration_test`)
- [x] Full test suite passes (`cargo test`)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

Closes #198

https://claude.ai/code/session_017BaszmPe86UWsTcBUncPuF