### PR TITLE
feat: add --unique and --unique-by flags for deduplication

### DIFF
--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -151,6 +151,14 @@ pub enum Commands {
         #[arg(long, value_name = "EXPR")]
         agg: Option<String>,
 
+        /// Remove duplicate records (based on entire record equality)
+        #[arg(long)]
+        unique: bool,
+
+        /// Remove duplicate records based on a specific field (keeps first occurrence)
+        #[arg(long, value_name = "FIELD")]
+        unique_by: Option<String>,
+
         /// Parquet compression codec (none, snappy, gzip, zstd)
         #[arg(long, value_name = "CODEC", default_value = "none")]
         compression: String,
@@ -354,6 +362,14 @@ pub enum Commands {
         /// Aggregation functions (e.g. 'count(), sum(amount), avg(price)')
         #[arg(long, value_name = "EXPR")]
         agg: Option<String>,
+
+        /// Remove duplicate records (based on entire record equality)
+        #[arg(long)]
+        unique: bool,
+
+        /// Remove duplicate records based on a specific field (keeps first occurrence)
+        #[arg(long, value_name = "FIELD")]
+        unique_by: Option<String>,
 
         /// Watch input file for changes and auto re-run
         #[arg(long)]

--- a/dkit-cli/src/commands/mod.rs
+++ b/dkit-cli/src/commands/mod.rs
@@ -242,6 +242,10 @@ pub struct DataFilterOptions {
     pub group_by: Option<String>,
     /// 집계 함수 목록 (예: "count(), sum(amount), avg(price)")
     pub agg: Option<String>,
+    /// 전체 레코드 기준 중복 제거
+    pub unique: bool,
+    /// 특정 필드 기준 중복 제거
+    pub unique_by: Option<String>,
 }
 
 /// --agg 문자열을 GroupAggregate 벡터로 파싱한다.
@@ -376,7 +380,17 @@ pub fn apply_data_filters(
         operations.push(Operation::Where(condition));
     }
 
-    // 2. group_by + agg (집계)
+    // 2. unique / unique-by (중복 제거)
+    if opts.unique {
+        operations.push(Operation::Unique);
+    }
+    if let Some(ref field) = opts.unique_by {
+        operations.push(Operation::UniqueBy {
+            field: field.clone(),
+        });
+    }
+
+    // 3. group_by + agg (집계)
     if let Some(ref group_fields) = opts.group_by {
         let fields: Vec<String> = group_fields
             .split(',')
@@ -402,13 +416,13 @@ pub fn apply_data_filters(
         anyhow::bail!("--agg requires --group-by\n  Hint: use --group-by 'field' --agg 'count(), sum(amount)'");
     }
 
-    // 3. select (컬럼 선택)
+    // 4. select (컬럼 선택)
     if let Some(ref fields) = opts.select {
         let select_exprs = parse_select_fields(fields)?;
         operations.push(Operation::Select(select_exprs));
     }
 
-    // 4. sort
+    // 5. sort
     if let Some(ref field) = opts.sort_by {
         operations.push(Operation::Sort {
             field: field.clone(),
@@ -416,7 +430,7 @@ pub fn apply_data_filters(
         });
     }
 
-    // 5. head (= limit)
+    // 6. head (= limit)
     if let Some(n) = opts.head {
         operations.push(Operation::Limit(n));
     }

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -317,6 +317,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             select,
             group_by,
             agg,
+            unique,
+            unique_by,
             compression,
             row_group_size,
             chunk_size,
@@ -364,6 +366,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         select: select.clone(),
                         group_by: group_by.clone(),
                         agg: agg.clone(),
+                        unique,
+                        unique_by: unique_by.clone(),
                     },
                     parquet_opts: ParquetWriteOptions {
                         compression: compression.clone(),
@@ -442,6 +446,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             select,
             group_by,
             agg,
+            unique,
+            unique_by,
             watch,
             watch_paths,
         } => {
@@ -483,6 +489,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         select: select.clone(),
                         group_by: group_by.clone(),
                         agg: agg.clone(),
+                        unique,
+                        unique_by: unique_by.clone(),
                     },
                 })
             };

--- a/dkit-core/src/query/filter.rs
+++ b/dkit-core/src/query/filter.rs
@@ -34,6 +34,8 @@ fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitErr
             having,
             aggregates,
         } => apply_group_by(value, fields, having.as_ref(), aggregates),
+        Operation::Unique => apply_unique(value),
+        Operation::UniqueBy { field } => apply_unique_by(value, field),
     }
 }
 
@@ -389,6 +391,54 @@ fn apply_distinct(value: Value, field: &str) -> Result<Value, DkitError> {
         }
         _ => Err(DkitError::QueryError(
             "distinct requires an array input".to_string(),
+        )),
+    }
+}
+
+/// unique: 전체 레코드 동일성 기준으로 중복 제거 (첫 번째 등장 유지)
+fn apply_unique(value: Value) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut seen: Vec<Value> = Vec::new();
+            let mut result = Vec::new();
+            for item in arr {
+                if !seen.contains(&item) {
+                    seen.push(item.clone());
+                    result.push(item);
+                }
+            }
+            Ok(Value::Array(result))
+        }
+        _ => Err(DkitError::QueryError(
+            "unique requires an array input".to_string(),
+        )),
+    }
+}
+
+/// unique_by: 특정 필드 기준으로 중복 제거 (첫 번째 등장 레코드 유지)
+fn apply_unique_by(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut seen: Vec<Value> = Vec::new();
+            let mut result = Vec::new();
+            for item in arr {
+                let key = match &item {
+                    Value::Object(map) => map.get(field).cloned().unwrap_or(Value::Null),
+                    _ => {
+                        return Err(DkitError::QueryError(
+                            "unique-by requires an array of objects".to_string(),
+                        ));
+                    }
+                };
+                if !seen.contains(&key) {
+                    seen.push(key);
+                    result.push(item);
+                }
+            }
+            Ok(Value::Array(result))
+        }
+        _ => Err(DkitError::QueryError(
+            "unique-by requires an array input".to_string(),
         )),
     }
 }
@@ -2028,5 +2078,131 @@ mod tests {
         } else {
             panic!("expected array");
         }
+    }
+
+    // --- unique 테스트 ---
+
+    #[test]
+    fn test_unique_removes_exact_duplicates() {
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Alice".to_string()));
+                m.insert("city".to_string(), Value::String("Seoul".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Bob".to_string()));
+                m.insert("city".to_string(), Value::String("Tokyo".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Alice".to_string()));
+                m.insert("city".to_string(), Value::String("Seoul".to_string()));
+                Value::Object(m)
+            },
+        ]);
+        let result = apply_unique(data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Bob".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_unique_no_duplicates() {
+        let data = sample_users();
+        let result = apply_unique(data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_unique_with_primitives() {
+        let data = Value::Array(vec![
+            Value::Integer(1),
+            Value::Integer(2),
+            Value::Integer(1),
+            Value::Integer(3),
+            Value::Integer(2),
+        ]);
+        let result = apply_unique(data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0], Value::Integer(1));
+        assert_eq!(arr[1], Value::Integer(2));
+        assert_eq!(arr[2], Value::Integer(3));
+    }
+
+    #[test]
+    fn test_unique_non_array_error() {
+        let data = Value::String("hello".to_string());
+        assert!(apply_unique(data).is_err());
+    }
+
+    // --- unique_by 테스트 ---
+
+    #[test]
+    fn test_unique_by_field() {
+        let data = sample_users(); // Alice(Seoul), Bob(Busan), Charlie(Seoul)
+        let result = apply_unique_by(data, "city").unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // Alice(Seoul), Bob(Busan) — Charlie dropped
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Bob".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_unique_by_all_different() {
+        let data = sample_users();
+        let result = apply_unique_by(data, "name").unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // all unique names
+    }
+
+    #[test]
+    fn test_unique_by_missing_field() {
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Alice".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Bob".to_string()));
+                Value::Object(m)
+            },
+        ]);
+        let result = apply_unique_by(data, "nonexistent").unwrap();
+        let arr = result.as_array().unwrap();
+        // Both have Null for the key, so only the first is kept
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn test_unique_by_non_array_error() {
+        let data = Value::String("hello".to_string());
+        assert!(apply_unique_by(data, "field").is_err());
+    }
+
+    #[test]
+    fn test_unique_by_non_object_elements_error() {
+        let data = Value::Array(vec![Value::Integer(1), Value::Integer(2)]);
+        assert!(apply_unique_by(data, "field").is_err());
     }
 }

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -58,6 +58,10 @@ pub enum Operation {
         having: Option<Condition>,
         aggregates: Vec<GroupAggregate>,
     },
+    /// 전체 레코드 동일성 기준 중복 제거
+    Unique,
+    /// 특정 필드 기준 중복 제거 (첫 번째 등장 레코드 유지)
+    UniqueBy { field: String },
 }
 
 /// GROUP BY 집계 연산 정의


### PR DESCRIPTION
## Summary
- `convert` 및 `view` 서브커맨드에 `--unique` / `--unique-by` 플래그를 추가하여 중복 레코드를 제거할 수 있게 함
- `--unique`: 전체 레코드 동일성 기준 중복 제거
- `--unique-by <field>`: 특정 필드 기준 중복 제거 (첫 번째 등장 레코드 유지)
- `--filter`, `--sort-by`, `--select` 등 기존 플래그와 조합 가능

## Test plan
- [x] `apply_unique` 단위 테스트 (중복 제거, 중복 없음, 프리미티브, 비배열 에러)
- [x] `apply_unique_by` 단위 테스트 (필드 기준, 전부 다른 경우, 누락 필드, 비배열/비오브젝트 에러)
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과
- [x] 전체 테스트 스위트 통과 (467+ 단위 테스트, 통합 테스트 포함)

Closes #187

https://claude.ai/code/session_01Dw2zJrz3SzXqS89qq8FtA5