### PR TITLE
feat: add --add-field flag for computed columns

### DIFF
--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -159,6 +159,10 @@ pub enum Commands {
         #[arg(long, value_name = "FIELD")]
         unique_by: Option<String>,
 
+        /// Add a computed field (e.g. 'total = amount * quantity'). Can be used multiple times
+        #[arg(long = "add-field", value_name = "EXPR")]
+        add_field: Vec<String>,
+
         /// Parquet compression codec (none, snappy, gzip, zstd)
         #[arg(long, value_name = "CODEC", default_value = "none")]
         compression: String,
@@ -370,6 +374,10 @@ pub enum Commands {
         /// Remove duplicate records based on a specific field (keeps first occurrence)
         #[arg(long, value_name = "FIELD")]
         unique_by: Option<String>,
+
+        /// Add a computed field (e.g. 'total = amount * quantity'). Can be used multiple times
+        #[arg(long = "add-field", value_name = "EXPR")]
+        add_field: Vec<String>,
 
         /// Watch input file for changes and auto re-run
         #[arg(long)]

--- a/dkit-cli/src/commands/mod.rs
+++ b/dkit-cli/src/commands/mod.rs
@@ -246,6 +246,8 @@ pub struct DataFilterOptions {
     pub unique: bool,
     /// 특정 필드 기준 중복 제거
     pub unique_by: Option<String>,
+    /// 계산 필드 추가 표현식 목록 (예: "total = amount * quantity")
+    pub add_field: Vec<String>,
 }
 
 /// --agg 문자열을 GroupAggregate 벡터로 파싱한다.
@@ -380,7 +382,17 @@ pub fn apply_data_filters(
         operations.push(Operation::Where(condition));
     }
 
-    // 2. unique / unique-by (중복 제거)
+    // 2. add-field (계산 필드 추가)
+    for expr_str in &opts.add_field {
+        let (name, expr) = dkit_core::query::parser::parse_add_field_expr(expr_str).map_err(|e| {
+            anyhow::anyhow!(
+                "Invalid --add-field expression: {e}\n  Hint: use format like 'total = amount * quantity'"
+            )
+        })?;
+        operations.push(Operation::AddField { name, expr });
+    }
+
+    // 3. unique / unique-by (중복 제거)
     if opts.unique {
         operations.push(Operation::Unique);
     }
@@ -390,7 +402,7 @@ pub fn apply_data_filters(
         });
     }
 
-    // 3. group_by + agg (집계)
+    // 4. group_by + agg (집계)
     if let Some(ref group_fields) = opts.group_by {
         let fields: Vec<String> = group_fields
             .split(',')
@@ -416,13 +428,13 @@ pub fn apply_data_filters(
         anyhow::bail!("--agg requires --group-by\n  Hint: use --group-by 'field' --agg 'count(), sum(amount)'");
     }
 
-    // 4. select (컬럼 선택)
+    // 5. select (컬럼 선택)
     if let Some(ref fields) = opts.select {
         let select_exprs = parse_select_fields(fields)?;
         operations.push(Operation::Select(select_exprs));
     }
 
-    // 5. sort
+    // 6. sort
     if let Some(ref field) = opts.sort_by {
         operations.push(Operation::Sort {
             field: field.clone(),
@@ -430,7 +442,7 @@ pub fn apply_data_filters(
         });
     }
 
-    // 6. head (= limit)
+    // 7. head (= limit)
     if let Some(n) = opts.head {
         operations.push(Operation::Limit(n));
     }

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -319,6 +319,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             agg,
             unique,
             unique_by,
+            add_field,
             compression,
             row_group_size,
             chunk_size,
@@ -368,6 +369,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         agg: agg.clone(),
                         unique,
                         unique_by: unique_by.clone(),
+                        add_field: add_field.clone(),
                     },
                     parquet_opts: ParquetWriteOptions {
                         compression: compression.clone(),
@@ -448,6 +450,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             agg,
             unique,
             unique_by,
+            add_field,
             watch,
             watch_paths,
         } => {
@@ -491,6 +494,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         agg: agg.clone(),
                         unique,
                         unique_by: unique_by.clone(),
+                        add_field: add_field.clone(),
                     },
                 })
             };

--- a/dkit-cli/tests/add_field_test.rs
+++ b/dkit-cli/tests/add_field_test.rs
@@ -1,0 +1,235 @@
+/// Integration tests for --add-field flag
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// ============================================================
+// --add-field with convert
+// ============================================================
+
+#[test]
+fn add_field_arithmetic_multiply() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "double_age = age * 2",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("double_age"))
+        .stdout(predicate::str::contains("60")) // Alice: 30 * 2
+        .stdout(predicate::str::contains("50")); // Bob: 25 * 2
+}
+
+#[test]
+fn add_field_arithmetic_addition() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "age_plus_score = age + score",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("age_plus_score"))
+        .stdout(predicate::str::contains("115")); // Alice: 30 + 85
+}
+
+#[test]
+fn add_field_string_concat() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "greeting = name + \" from \" + city",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice from Seoul"))
+        .stdout(predicate::str::contains("Bob from Busan"));
+}
+
+#[test]
+fn add_field_with_literal() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "bonus = score * 10",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("bonus"))
+        .stdout(predicate::str::contains("850")); // Alice: 85 * 10
+}
+
+#[test]
+fn add_field_multiple_flags() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "double_age = age * 2",
+            "--add-field",
+            "name_upper = upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("double_age"))
+        .stdout(predicate::str::contains("name_upper"))
+        .stdout(predicate::str::contains("ALICE"));
+}
+
+#[test]
+fn add_field_with_function() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "name_lower = lower(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("alice"))
+        .stdout(predicate::str::contains("bob"));
+}
+
+// ============================================================
+// --add-field with view
+// ============================================================
+
+#[test]
+fn add_field_view_table() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/employees.json",
+            "--add-field",
+            "double_score = score * 2",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("double_score"))
+        .stdout(predicate::str::contains("170")); // Alice: 85 * 2
+}
+
+// ============================================================
+// --add-field combined with other flags
+// ============================================================
+
+#[test]
+fn add_field_with_filter() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--filter",
+            "age > 30",
+            "--add-field",
+            "senior = age - 30",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("senior"))
+        .stdout(predicate::str::contains("Charlie"))
+        .stdout(predicate::str::contains("Alice").not()); // age 30 not > 30
+}
+
+#[test]
+fn add_field_with_select() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "double_age = age * 2",
+            "--select",
+            "name, double_age",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name"))
+        .stdout(predicate::str::contains("double_age"))
+        .stdout(predicate::str::contains("city").not());
+}
+
+#[test]
+fn add_field_csv_output() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--add-field",
+            "bonus = score * 100",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("bonus"))
+        .stdout(predicate::str::contains("8500")); // Alice: 85 * 100
+}
+
+#[test]
+fn add_field_operator_precedence() {
+    // price + price * 0.1 should be price + (price * 0.1), not (price + price) * 0.1
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("data.json");
+    std::fs::write(&input, r#"[{"price": 100}]"#).unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--add-field",
+            "total = price + price * 0.1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("110")); // 100 + 100*0.1 = 110
+}
+
+#[test]
+fn add_field_invalid_expression_error() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "bad expression without equals",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--add-field"));
+}

--- a/dkit-core/src/query/filter.rs
+++ b/dkit-core/src/query/filter.rs
@@ -1,7 +1,7 @@
 use crate::error::DkitError;
 use crate::query::functions::{evaluate_expr, expr_default_key};
 use crate::query::parser::{
-    AggregateFunc, CompareOp, Comparison, Condition, GroupAggregate, LiteralValue, Operation,
+    AggregateFunc, CompareOp, Comparison, Condition, Expr, GroupAggregate, LiteralValue, Operation,
     SelectExpr,
 };
 use crate::value::Value;
@@ -36,6 +36,7 @@ fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitErr
         } => apply_group_by(value, fields, having.as_ref(), aggregates),
         Operation::Unique => apply_unique(value),
         Operation::UniqueBy { field } => apply_unique_by(value, field),
+        Operation::AddField { name, expr } => apply_add_field(value, name, expr),
     }
 }
 
@@ -439,6 +440,37 @@ fn apply_unique_by(value: Value, field: &str) -> Result<Value, DkitError> {
         }
         _ => Err(DkitError::QueryError(
             "unique-by requires an array input".to_string(),
+        )),
+    }
+}
+
+/// add_field: 각 레코드에 새 필드를 추가 (computed column)
+fn apply_add_field(value: Value, name: &str, expr: &Expr) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut result = Vec::with_capacity(arr.len());
+            for item in arr {
+                match item {
+                    Value::Object(mut map) => {
+                        let computed = evaluate_expr(&Value::Object(map.clone()), expr)?;
+                        map.insert(name.to_string(), computed);
+                        result.push(Value::Object(map));
+                    }
+                    other => {
+                        // Non-object items are passed through unchanged
+                        result.push(other);
+                    }
+                }
+            }
+            Ok(Value::Array(result))
+        }
+        Value::Object(mut map) => {
+            let computed = evaluate_expr(&Value::Object(map.clone()), expr)?;
+            map.insert(name.to_string(), computed);
+            Ok(Value::Object(map))
+        }
+        _ => Err(DkitError::QueryError(
+            "add-field requires an array or object input".to_string(),
         )),
     }
 }
@@ -2204,5 +2236,136 @@ mod tests {
     fn test_unique_by_non_object_elements_error() {
         let data = Value::Array(vec![Value::Integer(1), Value::Integer(2)]);
         assert!(apply_unique_by(data, "field").is_err());
+    }
+
+    // --- add_field tests ---
+
+    #[test]
+    fn test_add_field_arithmetic() {
+        use crate::query::parser::parse_add_field_expr;
+
+        let data = Value::Array(vec![
+            Value::Object(IndexMap::from([
+                ("amount".to_string(), Value::Integer(10)),
+                ("quantity".to_string(), Value::Integer(3)),
+            ])),
+            Value::Object(IndexMap::from([
+                ("amount".to_string(), Value::Integer(20)),
+                ("quantity".to_string(), Value::Integer(5)),
+            ])),
+        ]);
+
+        let (name, expr) = parse_add_field_expr("total = amount * quantity").unwrap();
+        let result = apply_add_field(data, &name, &expr).unwrap();
+
+        if let Value::Array(arr) = result {
+            assert_eq!(arr.len(), 2);
+            if let Value::Object(map) = &arr[0] {
+                assert_eq!(map.get("total"), Some(&Value::Integer(30)));
+            } else {
+                panic!("expected object");
+            }
+            if let Value::Object(map) = &arr[1] {
+                assert_eq!(map.get("total"), Some(&Value::Integer(100)));
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_add_field_string_concat() {
+        use crate::query::parser::parse_add_field_expr;
+
+        let data = Value::Array(vec![Value::Object(IndexMap::from([
+            ("first".to_string(), Value::String("John".to_string())),
+            ("last".to_string(), Value::String("Doe".to_string())),
+        ]))]);
+
+        let (name, expr) = parse_add_field_expr("full = first + \" \" + last").unwrap();
+        let result = apply_add_field(data, &name, &expr).unwrap();
+
+        if let Value::Array(arr) = result {
+            if let Value::Object(map) = &arr[0] {
+                assert_eq!(
+                    map.get("full"),
+                    Some(&Value::String("John Doe".to_string()))
+                );
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_add_field_with_function() {
+        use crate::query::parser::parse_add_field_expr;
+
+        let data = Value::Array(vec![Value::Object(IndexMap::from([(
+            "name".to_string(),
+            Value::String("hello".to_string()),
+        )]))]);
+
+        let (name, expr) = parse_add_field_expr("upper_name = upper(name)").unwrap();
+        let result = apply_add_field(data, &name, &expr).unwrap();
+
+        if let Value::Array(arr) = result {
+            if let Value::Object(map) = &arr[0] {
+                assert_eq!(
+                    map.get("upper_name"),
+                    Some(&Value::String("HELLO".to_string()))
+                );
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
+    }
+
+    #[test]
+    fn test_add_field_on_single_object() {
+        use crate::query::parser::parse_add_field_expr;
+
+        let data = Value::Object(IndexMap::from([("price".to_string(), Value::Float(100.0))]));
+
+        let (name, expr) = parse_add_field_expr("tax = price * 0.1").unwrap();
+        let result = apply_add_field(data, &name, &expr).unwrap();
+
+        if let Value::Object(map) = result {
+            assert_eq!(map.get("tax"), Some(&Value::Float(10.0)));
+        } else {
+            panic!("expected object");
+        }
+    }
+
+    #[test]
+    fn test_add_field_preserves_existing_fields() {
+        use crate::query::parser::parse_add_field_expr;
+
+        let data = Value::Array(vec![Value::Object(IndexMap::from([
+            ("a".to_string(), Value::Integer(1)),
+            ("b".to_string(), Value::Integer(2)),
+        ]))]);
+
+        let (name, expr) = parse_add_field_expr("c = a + b").unwrap();
+        let result = apply_add_field(data, &name, &expr).unwrap();
+
+        if let Value::Array(arr) = result {
+            if let Value::Object(map) = &arr[0] {
+                assert_eq!(map.len(), 3);
+                assert_eq!(map.get("a"), Some(&Value::Integer(1)));
+                assert_eq!(map.get("b"), Some(&Value::Integer(2)));
+                assert_eq!(map.get("c"), Some(&Value::Integer(3)));
+            } else {
+                panic!("expected object");
+            }
+        } else {
+            panic!("expected array");
+        }
     }
 }

--- a/dkit-core/src/query/functions.rs
+++ b/dkit-core/src/query/functions.rs
@@ -1,5 +1,5 @@
 use crate::error::DkitError;
-use crate::query::parser::{Expr, LiteralValue};
+use crate::query::parser::{ArithmeticOp, Expr, LiteralValue};
 use crate::value::Value;
 
 /// 표현식을 주어진 레코드(행)에 대해 평가하여 Value를 반환
@@ -18,6 +18,97 @@ pub fn evaluate_expr(row: &Value, expr: &Expr) -> Result<Value, DkitError> {
                 args.iter().map(|a| evaluate_expr(row, a)).collect();
             call_function(name, evaluated?)
         }
+        Expr::BinaryOp { op, left, right } => {
+            let lv = evaluate_expr(row, left)?;
+            let rv = evaluate_expr(row, right)?;
+            evaluate_binary_op(op, &lv, &rv)
+        }
+    }
+}
+
+/// 이항 산술 연산 평가
+fn evaluate_binary_op(op: &ArithmeticOp, left: &Value, right: &Value) -> Result<Value, DkitError> {
+    // String concatenation with +
+    if matches!(op, ArithmeticOp::Add) {
+        if let (Value::String(a), Value::String(b)) = (left, right) {
+            return Ok(Value::String(format!("{}{}", a, b)));
+        }
+        // String + non-string or non-string + String → string concat
+        if matches!(left, Value::String(_)) || matches!(right, Value::String(_)) {
+            let a = value_to_display_string(left);
+            let b = value_to_display_string(right);
+            return Ok(Value::String(format!("{}{}", a, b)));
+        }
+    }
+
+    // Null propagation
+    if matches!(left, Value::Null) || matches!(right, Value::Null) {
+        return Ok(Value::Null);
+    }
+
+    // Numeric operations
+    let (lf, li) = to_numeric(left)?;
+    let (rf, ri) = to_numeric(right)?;
+
+    // Both integers → integer result (except division)
+    if let (Some(a), Some(b)) = (li, ri) {
+        return match op {
+            ArithmeticOp::Add => Ok(Value::Integer(a.wrapping_add(b))),
+            ArithmeticOp::Sub => Ok(Value::Integer(a.wrapping_sub(b))),
+            ArithmeticOp::Mul => Ok(Value::Integer(a.wrapping_mul(b))),
+            ArithmeticOp::Div => {
+                if b == 0 {
+                    return Err(DkitError::QueryError("division by zero".to_string()));
+                }
+                // Use float division if not evenly divisible
+                if a % b == 0 {
+                    Ok(Value::Integer(a / b))
+                } else {
+                    Ok(Value::Float(lf / rf))
+                }
+            }
+        };
+    }
+
+    // At least one float → float result
+    match op {
+        ArithmeticOp::Add => Ok(Value::Float(lf + rf)),
+        ArithmeticOp::Sub => Ok(Value::Float(lf - rf)),
+        ArithmeticOp::Mul => Ok(Value::Float(lf * rf)),
+        ArithmeticOp::Div => {
+            if rf == 0.0 {
+                return Err(DkitError::QueryError("division by zero".to_string()));
+            }
+            Ok(Value::Float(lf / rf))
+        }
+    }
+}
+
+/// Value를 (f64, Option<i64>) 로 변환. i64로 표현 가능하면 Some(i64).
+fn to_numeric(v: &Value) -> Result<(f64, Option<i64>), DkitError> {
+    match v {
+        Value::Integer(n) => Ok((*n as f64, Some(*n))),
+        Value::Float(f) => Ok((*f, None)),
+        Value::Bool(b) => {
+            let n = if *b { 1 } else { 0 };
+            Ok((n as f64, Some(n)))
+        }
+        _ => Err(DkitError::QueryError(format!(
+            "cannot perform arithmetic on {} value",
+            value_type_name(v)
+        ))),
+    }
+}
+
+/// Value를 문자열로 변환 (string concat용)
+fn value_to_display_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Integer(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Null => "null".to_string(),
+        _ => format!("{}", v),
     }
 }
 
@@ -33,6 +124,7 @@ pub fn expr_default_key(expr: &Expr) -> String {
                 name.clone()
             }
         }
+        Expr::BinaryOp { left, .. } => expr_default_key(left),
     }
 }
 
@@ -819,5 +911,122 @@ mod tests {
             }],
         };
         assert_eq!(expr_default_key(&expr), "upper_trim_name");
+    }
+
+    // --- BinaryOp evaluate tests ---
+
+    #[test]
+    fn test_binary_add_integers() {
+        let row = Value::Object(indexmap::IndexMap::from([
+            ("a".to_string(), Value::Integer(10)),
+            ("b".to_string(), Value::Integer(20)),
+        ]));
+        let expr = Expr::BinaryOp {
+            op: ArithmeticOp::Add,
+            left: Box::new(Expr::Field("a".to_string())),
+            right: Box::new(Expr::Field("b".to_string())),
+        };
+        assert_eq!(evaluate_expr(&row, &expr).unwrap(), Value::Integer(30));
+    }
+
+    #[test]
+    fn test_binary_mul_float() {
+        let row = Value::Object(indexmap::IndexMap::from([(
+            "price".to_string(),
+            Value::Float(100.0),
+        )]));
+        let expr = Expr::BinaryOp {
+            op: ArithmeticOp::Mul,
+            left: Box::new(Expr::Field("price".to_string())),
+            right: Box::new(Expr::Literal(LiteralValue::Float(0.1))),
+        };
+        let result = evaluate_expr(&row, &expr).unwrap();
+        if let Value::Float(f) = result {
+            assert!((f - 10.0).abs() < 0.001);
+        } else {
+            panic!("expected float");
+        }
+    }
+
+    #[test]
+    fn test_binary_string_concat() {
+        let row = Value::Object(indexmap::IndexMap::from([
+            ("first".to_string(), Value::String("Hello".to_string())),
+            ("last".to_string(), Value::String("World".to_string())),
+        ]));
+        let expr = Expr::BinaryOp {
+            op: ArithmeticOp::Add,
+            left: Box::new(Expr::Field("first".to_string())),
+            right: Box::new(Expr::BinaryOp {
+                op: ArithmeticOp::Add,
+                left: Box::new(Expr::Literal(LiteralValue::String(" ".to_string()))),
+                right: Box::new(Expr::Field("last".to_string())),
+            }),
+        };
+        assert_eq!(
+            evaluate_expr(&row, &expr).unwrap(),
+            Value::String("Hello World".to_string())
+        );
+    }
+
+    #[test]
+    fn test_binary_div_by_zero() {
+        let row = Value::Object(indexmap::IndexMap::from([
+            ("a".to_string(), Value::Integer(10)),
+            ("b".to_string(), Value::Integer(0)),
+        ]));
+        let expr = Expr::BinaryOp {
+            op: ArithmeticOp::Div,
+            left: Box::new(Expr::Field("a".to_string())),
+            right: Box::new(Expr::Field("b".to_string())),
+        };
+        assert!(evaluate_expr(&row, &expr).is_err());
+    }
+
+    #[test]
+    fn test_binary_null_propagation() {
+        let row = Value::Object(indexmap::IndexMap::from([
+            ("a".to_string(), Value::Integer(10)),
+            ("b".to_string(), Value::Null),
+        ]));
+        let expr = Expr::BinaryOp {
+            op: ArithmeticOp::Add,
+            left: Box::new(Expr::Field("a".to_string())),
+            right: Box::new(Expr::Field("b".to_string())),
+        };
+        assert_eq!(evaluate_expr(&row, &expr).unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn test_binary_int_div_non_exact() {
+        let row = Value::Object(indexmap::IndexMap::from([
+            ("a".to_string(), Value::Integer(10)),
+            ("b".to_string(), Value::Integer(3)),
+        ]));
+        let expr = Expr::BinaryOp {
+            op: ArithmeticOp::Div,
+            left: Box::new(Expr::Field("a".to_string())),
+            right: Box::new(Expr::Field("b".to_string())),
+        };
+        // 10 / 3 is not exact, should return float
+        let result = evaluate_expr(&row, &expr).unwrap();
+        assert!(matches!(result, Value::Float(_)));
+    }
+
+    #[test]
+    fn test_binary_mixed_string_number_concat() {
+        let row = Value::Object(indexmap::IndexMap::from([
+            ("name".to_string(), Value::String("Item".to_string())),
+            ("id".to_string(), Value::Integer(42)),
+        ]));
+        let expr = Expr::BinaryOp {
+            op: ArithmeticOp::Add,
+            left: Box::new(Expr::Field("name".to_string())),
+            right: Box::new(Expr::Field("id".to_string())),
+        };
+        assert_eq!(
+            evaluate_expr(&row, &expr).unwrap(),
+            Value::String("Item42".to_string())
+        );
     }
 }

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -62,6 +62,8 @@ pub enum Operation {
     Unique,
     /// 특정 필드 기준 중복 제거 (첫 번째 등장 레코드 유지)
     UniqueBy { field: String },
+    /// 새 필드 추가 (computed column): `--add-field 'total = amount * quantity'`
+    AddField { name: String, expr: Expr },
 }
 
 /// GROUP BY 집계 연산 정의
@@ -129,6 +131,15 @@ pub enum LiteralValue {
     Null,
 }
 
+/// Arithmetic binary operator.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ArithmeticOp {
+    Add, // +
+    Sub, // -
+    Mul, // *
+    Div, // /
+}
+
 /// Expression used in `select` clauses and function arguments.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
@@ -139,6 +150,12 @@ pub enum Expr {
     Literal(LiteralValue),
     /// 함수 호출: `upper(name)`, `round(price, 2)`, `upper(trim(name))`
     FuncCall { name: String, args: Vec<Expr> },
+    /// 이항 산술 연산: `amount * quantity`, `first_name + " " + last_name`
+    BinaryOp {
+        op: ArithmeticOp,
+        left: Box<Expr>,
+        right: Box<Expr>,
+    },
 }
 
 /// SELECT 절의 컬럼 표현식
@@ -511,9 +528,97 @@ impl Parser {
         Ok(SelectExpr { expr, alias })
     }
 
-    /// 표현식 파싱: 필드 참조, 리터럴, 함수 호출
+    /// 표현식 파싱: 산술 연산자 포함 (우선순위: +- < */)
     fn parse_expr(&mut self) -> Result<Expr, DkitError> {
+        self.parse_additive_expr()
+    }
+
+    /// 덧셈/뺄셈 수준 표현식: `term (('+' | '-') term)*`
+    fn parse_additive_expr(&mut self) -> Result<Expr, DkitError> {
+        let mut left = self.parse_multiplicative_expr()?;
+
+        loop {
+            self.skip_whitespace();
+            match self.peek() {
+                Some('+') => {
+                    self.advance();
+                    self.skip_whitespace();
+                    let right = self.parse_multiplicative_expr()?;
+                    left = Expr::BinaryOp {
+                        op: ArithmeticOp::Add,
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    };
+                }
+                Some('-') => {
+                    // Distinguish subtraction from negative number literal at end of expression
+                    // Only treat as subtraction if we've already parsed a left operand
+                    self.advance();
+                    self.skip_whitespace();
+                    let right = self.parse_multiplicative_expr()?;
+                    left = Expr::BinaryOp {
+                        op: ArithmeticOp::Sub,
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    };
+                }
+                _ => break,
+            }
+        }
+
+        Ok(left)
+    }
+
+    /// 곱셈/나눗셈 수준 표현식: `atom (('*' | '/') atom)*`
+    fn parse_multiplicative_expr(&mut self) -> Result<Expr, DkitError> {
+        let mut left = self.parse_atom_expr()?;
+
+        loop {
+            self.skip_whitespace();
+            match self.peek() {
+                Some('*') => {
+                    self.advance();
+                    self.skip_whitespace();
+                    let right = self.parse_atom_expr()?;
+                    left = Expr::BinaryOp {
+                        op: ArithmeticOp::Mul,
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    };
+                }
+                Some('/') => {
+                    self.advance();
+                    self.skip_whitespace();
+                    let right = self.parse_atom_expr()?;
+                    left = Expr::BinaryOp {
+                        op: ArithmeticOp::Div,
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    };
+                }
+                _ => break,
+            }
+        }
+
+        Ok(left)
+    }
+
+    /// 원자 표현식: 리터럴, 필드 참조, 함수 호출, 괄호
+    fn parse_atom_expr(&mut self) -> Result<Expr, DkitError> {
         match self.peek() {
+            Some('(') => {
+                self.advance(); // consume '('
+                self.skip_whitespace();
+                let expr = self.parse_expr()?;
+                self.skip_whitespace();
+                if !self.consume_char(')') {
+                    return Err(DkitError::QueryError(format!(
+                        "expected ')' at position {}",
+                        self.pos
+                    )));
+                }
+                Ok(expr)
+            }
             Some('"') => {
                 let lit = self.parse_string_literal()?;
                 Ok(Expr::Literal(lit))
@@ -926,6 +1031,34 @@ impl Parser {
 /// 편의 함수: 쿼리 문자열 → Query
 pub fn parse_query(input: &str) -> Result<Query, DkitError> {
     Parser::new(input).parse()
+}
+
+/// `--add-field` 표현식 파싱: `"name = expression"`
+/// 예: "total = amount * quantity", "full_name = first_name + \" \" + last_name"
+pub fn parse_add_field_expr(input: &str) -> Result<(String, Expr), DkitError> {
+    let mut parser = Parser::new(input);
+    parser.skip_whitespace();
+    let name = parser.parse_identifier().map_err(|_| {
+        DkitError::QueryError(format!(
+            "expected field name in --add-field expression: '{input}'"
+        ))
+    })?;
+    parser.skip_whitespace();
+    if !parser.consume_char('=') {
+        return Err(DkitError::QueryError(format!(
+            "expected '=' after field name in --add-field expression: '{input}'"
+        )));
+    }
+    parser.skip_whitespace();
+    let expr = parser.parse_expr()?;
+    parser.skip_whitespace();
+    if parser.pos != parser.input.len() {
+        return Err(DkitError::QueryError(format!(
+            "unexpected character '{}' at position {} in --add-field expression",
+            parser.input[parser.pos], parser.pos
+        )));
+    }
+    Ok((name, expr))
 }
 
 /// where 절의 조건식만 파싱하는 편의 함수
@@ -1812,5 +1945,114 @@ mod tests {
             }
         ));
         assert_eq!(q.operations[2], Operation::Limit(5));
+    }
+
+    // --- parse_add_field_expr tests ---
+
+    #[test]
+    fn test_add_field_simple_arithmetic() {
+        let (name, expr) = parse_add_field_expr("total = amount * quantity").unwrap();
+        assert_eq!(name, "total");
+        assert!(matches!(
+            expr,
+            Expr::BinaryOp {
+                op: ArithmeticOp::Mul,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_add_field_string_concat() {
+        let (name, expr) =
+            parse_add_field_expr("full_name = first_name + \" \" + last_name").unwrap();
+        assert_eq!(name, "full_name");
+        // Should be (first_name + " ") + last_name
+        assert!(matches!(
+            expr,
+            Expr::BinaryOp {
+                op: ArithmeticOp::Add,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_add_field_with_literal() {
+        let (name, expr) = parse_add_field_expr("tax = price * 0.1").unwrap();
+        assert_eq!(name, "tax");
+        assert!(matches!(
+            expr,
+            Expr::BinaryOp {
+                op: ArithmeticOp::Mul,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_add_field_complex_expr() {
+        let (name, expr) = parse_add_field_expr("total = price + price * 0.1").unwrap();
+        assert_eq!(name, "total");
+        // price + (price * 0.1) due to precedence
+        if let Expr::BinaryOp { op, left, right } = &expr {
+            assert_eq!(*op, ArithmeticOp::Add);
+            assert!(matches!(left.as_ref(), Expr::Field(f) if f == "price"));
+            assert!(matches!(
+                right.as_ref(),
+                Expr::BinaryOp {
+                    op: ArithmeticOp::Mul,
+                    ..
+                }
+            ));
+        } else {
+            panic!("expected BinaryOp");
+        }
+    }
+
+    #[test]
+    fn test_add_field_with_parens() {
+        let (name, expr) = parse_add_field_expr("total = (price + tax) * quantity").unwrap();
+        assert_eq!(name, "total");
+        if let Expr::BinaryOp { op, left, right } = &expr {
+            assert_eq!(*op, ArithmeticOp::Mul);
+            assert!(matches!(
+                left.as_ref(),
+                Expr::BinaryOp {
+                    op: ArithmeticOp::Add,
+                    ..
+                }
+            ));
+            assert!(matches!(right.as_ref(), Expr::Field(f) if f == "quantity"));
+        } else {
+            panic!("expected BinaryOp");
+        }
+    }
+
+    #[test]
+    fn test_add_field_with_function() {
+        let (name, expr) = parse_add_field_expr("name_upper = upper(name)").unwrap();
+        assert_eq!(name, "name_upper");
+        assert!(matches!(expr, Expr::FuncCall { .. }));
+    }
+
+    #[test]
+    fn test_add_field_missing_equals() {
+        let result = parse_add_field_expr("total amount * quantity");
+        assert!(result.is_err());
+    }
+
+    // --- Expr arithmetic tests ---
+
+    #[test]
+    fn test_expr_division() {
+        let q = parse_query(".items[] | select total / count as avg").unwrap();
+        assert_eq!(q.operations.len(), 1);
+    }
+
+    #[test]
+    fn test_expr_subtraction() {
+        let q = parse_query(".items[] | select price - discount as net").unwrap();
+        assert_eq!(q.operations.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- Add `--add-field` flag to `convert` and `view` subcommands for creating computed columns from expressions
- Support arithmetic operations (`+`, `-`, `*`, `/`) with proper operator precedence, string concatenation via `+`, function calls (e.g. `upper(name)`), and parenthesized expressions
- Multiple `--add-field` flags can be used to add several computed fields at once

## Examples
```bash
dkit convert sales.csv -f csv --add-field 'total = amount * quantity'
dkit convert data.json -f json --add-field 'full_name = first_name + " " + last_name'
dkit view orders.csv --add-field 'tax = price * 0.1' --add-field 'total = price + tax'
```

## Test plan
- [x] Unit tests for arithmetic expression parsing (parser.rs)
- [x] Unit tests for BinaryOp evaluation including int/float/string/null handling (functions.rs)
- [x] Unit tests for apply_add_field on arrays and single objects (filter.rs)
- [x] Integration tests for convert with arithmetic, string concat, functions, multiple flags
- [x] Integration tests for view with --add-field
- [x] Integration tests for --add-field combined with --filter and --select
- [x] Operator precedence test (`price + price * 0.1` = 110, not 20)
- [x] Error handling test for invalid expressions
- [x] `cargo test` — all pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

Closes #188

https://claude.ai/code/session_01Q7896N5FQuYthSqk4nrNcs