### PR TITLE
feat: add --map flag for value transformation

### DIFF
--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -163,6 +163,10 @@ pub enum Commands {
         #[arg(long = "add-field", value_name = "EXPR")]
         add_field: Vec<String>,
 
+        /// Transform an existing field's value (e.g. 'name = upper(name)'). Can be used multiple times
+        #[arg(long = "map", value_name = "EXPR")]
+        map_field: Vec<String>,
+
         /// Parquet compression codec (none, snappy, gzip, zstd)
         #[arg(long, value_name = "CODEC", default_value = "none")]
         compression: String,
@@ -378,6 +382,10 @@ pub enum Commands {
         /// Add a computed field (e.g. 'total = amount * quantity'). Can be used multiple times
         #[arg(long = "add-field", value_name = "EXPR")]
         add_field: Vec<String>,
+
+        /// Transform an existing field's value (e.g. 'name = upper(name)'). Can be used multiple times
+        #[arg(long = "map", value_name = "EXPR")]
+        map_field: Vec<String>,
 
         /// Watch input file for changes and auto re-run
         #[arg(long)]

--- a/dkit-cli/src/commands/mod.rs
+++ b/dkit-cli/src/commands/mod.rs
@@ -248,6 +248,8 @@ pub struct DataFilterOptions {
     pub unique_by: Option<String>,
     /// 계산 필드 추가 표현식 목록 (예: "total = amount * quantity")
     pub add_field: Vec<String>,
+    /// 기존 필드 값 변환 표현식 목록 (예: "name = upper(name)")
+    pub map_field: Vec<String>,
 }
 
 /// --agg 문자열을 GroupAggregate 벡터로 파싱한다.
@@ -390,6 +392,17 @@ pub fn apply_data_filters(
             )
         })?;
         operations.push(Operation::AddField { name, expr });
+    }
+
+    // 2b. map (기존 필드 값 변환)
+    for expr_str in &opts.map_field {
+        let (name, expr) =
+            dkit_core::query::parser::parse_add_field_expr(expr_str).map_err(|e| {
+                anyhow::anyhow!(
+                    "Invalid --map expression: {e}\n  Hint: use format like 'name = upper(name)'"
+                )
+            })?;
+        operations.push(Operation::MapField { name, expr });
     }
 
     // 3. unique / unique-by (중복 제거)

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -320,6 +320,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             unique,
             unique_by,
             add_field,
+            map_field,
             compression,
             row_group_size,
             chunk_size,
@@ -370,6 +371,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         unique,
                         unique_by: unique_by.clone(),
                         add_field: add_field.clone(),
+                        map_field: map_field.clone(),
                     },
                     parquet_opts: ParquetWriteOptions {
                         compression: compression.clone(),
@@ -451,6 +453,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             unique,
             unique_by,
             add_field,
+            map_field,
             watch,
             watch_paths,
         } => {
@@ -495,6 +498,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         unique,
                         unique_by: unique_by.clone(),
                         add_field: add_field.clone(),
+                        map_field: map_field.clone(),
                     },
                 })
             };

--- a/dkit-cli/tests/map_field_test.rs
+++ b/dkit-cli/tests/map_field_test.rs
@@ -1,0 +1,339 @@
+/// Integration tests for --map flag
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// ============================================================
+// --map with convert
+// ============================================================
+
+#[test]
+fn map_field_upper() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "name = upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("BOB"))
+        .stdout(predicate::str::contains("CHARLIE"));
+}
+
+#[test]
+fn map_field_lower() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "city = lower(city)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("seoul"))
+        .stdout(predicate::str::contains("busan"))
+        .stdout(predicate::str::contains("incheon"));
+}
+
+#[test]
+fn map_field_arithmetic_increment() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "age = age + 1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("31")) // Alice: 30 + 1
+        .stdout(predicate::str::contains("26")) // Bob: 25 + 1
+        .stdout(predicate::str::contains("36")); // Charlie: 35 + 1
+}
+
+#[test]
+fn map_field_arithmetic_multiply() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "score = score * 2",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("170")) // Alice: 85 * 2
+        .stdout(predicate::str::contains("184")) // Bob: 92 * 2
+        .stdout(predicate::str::contains("156")); // Charlie: 78 * 2
+}
+
+#[test]
+fn map_field_multiple_flags() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "name = upper(name)",
+            "--map",
+            "city = lower(city)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("seoul"));
+}
+
+#[test]
+fn map_field_with_function_round() {
+    // score / 3 produces a float; round it
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "score = round(score / 3, 1)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("28.3")); // Alice: 85/3 ≈ 28.333
+}
+
+#[test]
+fn map_field_string_concat() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "name = name + \" (\" + role + \")\"",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice (engineer)"))
+        .stdout(predicate::str::contains("Bob (designer)"));
+}
+
+#[test]
+fn map_field_trim() {
+    // Create input with whitespace in names
+    let input = r#"[{"name": "  Alice  "}, {"name": " Bob "}]"#;
+    dkit()
+        .args(&[
+            "convert",
+            "-",
+            "-f",
+            "json",
+            "--from",
+            "json",
+            "--map",
+            "name = trim(name)",
+        ])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"Alice\""))
+        .stdout(predicate::str::contains("\"Bob\""));
+}
+
+#[test]
+fn map_field_abs() {
+    let input = r#"[{"val": -10}, {"val": 5}, {"val": -3}]"#;
+    dkit()
+        .args(&[
+            "convert",
+            "-",
+            "-f",
+            "json",
+            "--from",
+            "json",
+            "--map",
+            "val = abs(val)",
+        ])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("10"))
+        .stdout(predicate::str::contains("5"))
+        .stdout(predicate::str::contains("3"));
+}
+
+#[test]
+fn map_field_length() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "name = length(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("5")) // Alice = 5
+        .stdout(predicate::str::contains("3")) // Bob = 3
+        .stdout(predicate::str::contains("7")); // Charlie = 7
+}
+
+// ============================================================
+// --map with view
+// ============================================================
+
+#[test]
+fn map_field_view_upper() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/employees.json",
+            "--map",
+            "name = upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("BOB"));
+}
+
+#[test]
+fn map_field_view_arithmetic() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/employees.json",
+            "--map",
+            "age = age + 10",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("40")) // Alice: 30 + 10
+        .stdout(predicate::str::contains("35")); // Bob: 25 + 10
+}
+
+// ============================================================
+// --map combined with other flags
+// ============================================================
+
+#[test]
+fn map_field_combined_with_filter() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--filter",
+            "age > 28",
+            "--map",
+            "name = upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("CHARLIE"))
+        .stdout(predicate::str::contains("EVE"))
+        // Bob (25) and Diana (28) should be filtered out
+        .stdout(predicate::str::contains("BOB").not());
+}
+
+#[test]
+fn map_field_combined_with_add_field() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "name_len = length(name)",
+            "--map",
+            "name = upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("name_len"));
+}
+
+#[test]
+fn map_field_combined_with_select() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "name = upper(name)",
+            "--select",
+            "name, age",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("30"))
+        // city should not be in output due to --select
+        .stdout(predicate::str::contains("Seoul").not());
+}
+
+// ============================================================
+// --map error handling
+// ============================================================
+
+#[test]
+fn map_field_invalid_expression() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "invalid expression without equals",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid --map expression"));
+}
+
+// ============================================================
+// --map on CSV format
+// ============================================================
+
+#[test]
+fn map_field_csv_output() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "csv",
+            "--map",
+            "name = upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("BOB"));
+}

--- a/dkit-core/src/query/filter.rs
+++ b/dkit-core/src/query/filter.rs
@@ -37,6 +37,7 @@ fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitErr
         Operation::Unique => apply_unique(value),
         Operation::UniqueBy { field } => apply_unique_by(value, field),
         Operation::AddField { name, expr } => apply_add_field(value, name, expr),
+        Operation::MapField { name, expr } => apply_map_field(value, name, expr),
     }
 }
 
@@ -471,6 +472,36 @@ fn apply_add_field(value: Value, name: &str, expr: &Expr) -> Result<Value, DkitE
         }
         _ => Err(DkitError::QueryError(
             "add-field requires an array or object input".to_string(),
+        )),
+    }
+}
+
+/// map_field: 기존 필드의 값을 표현식 결과로 변환 (값 덮어쓰기)
+fn apply_map_field(value: Value, name: &str, expr: &Expr) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut result = Vec::with_capacity(arr.len());
+            for item in arr {
+                match item {
+                    Value::Object(mut map) => {
+                        let computed = evaluate_expr(&Value::Object(map.clone()), expr)?;
+                        map.insert(name.to_string(), computed);
+                        result.push(Value::Object(map));
+                    }
+                    other => {
+                        result.push(other);
+                    }
+                }
+            }
+            Ok(Value::Array(result))
+        }
+        Value::Object(mut map) => {
+            let computed = evaluate_expr(&Value::Object(map.clone()), expr)?;
+            map.insert(name.to_string(), computed);
+            Ok(Value::Object(map))
+        }
+        _ => Err(DkitError::QueryError(
+            "map requires an array or object input".to_string(),
         )),
     }
 }

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -64,6 +64,8 @@ pub enum Operation {
     UniqueBy { field: String },
     /// 새 필드 추가 (computed column): `--add-field 'total = amount * quantity'`
     AddField { name: String, expr: Expr },
+    /// 기존 필드 값 변환: `--map 'name = upper(name)'`
+    MapField { name: String, expr: Expr },
 }
 
 /// GROUP BY 집계 연산 정의


### PR DESCRIPTION
## Summary
- `convert` 및 `view` 서브커맨드에 `--map` 플래그 추가하여 기존 필드 값을 변환할 수 있게 함
- `--add-field`의 표현식 파서를 재활용하여 `--map 'field = expression'` 형식 지원
- 복수 `--map` 플래그 사용 가능, 모든 내장 함수(`upper`, `lower`, `trim`, `round`, `abs`, `len` 등) 및 산술 연산 지원
- 17개 통합 테스트 추가 (함수 변환, 산술, 복수 플래그, 다른 플래그와의 조합, 에러 처리)

## Test plan
- [x] `cargo test` 전체 통과 (488 + 17 신규 = 505 테스트)
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt -- --check` 통과
- [x] `--map 'name = upper(name)'` 동작 확인
- [x] `--map 'age = age + 1'` 산술 연산 확인
- [x] 복수 `--map` 플래그 동작 확인
- [x] `--filter`, `--add-field`, `--select` 등과의 조합 확인
- [x] 잘못된 표현식 에러 메시지 확인

Closes #189

https://claude.ai/code/session_0193SjFgjJYBVMZv6MR3jRwn