### PR TITLE
feat: add array slicing & wildcard in query paths

### DIFF
--- a/dkit-core/src/query/evaluator.rs
+++ b/dkit-core/src/query/evaluator.rs
@@ -40,13 +40,24 @@ pub fn evaluate_path(value: &Value, path: &Path) -> Result<Value, DkitError> {
                         )));
                     }
                 },
-                Segment::Iterate => match val {
+                Segment::Iterate | Segment::Wildcard => match val {
                     Value::Array(arr) => {
                         next_results.extend(arr.iter().cloned());
                     }
                     _ => {
                         return Err(DkitError::PathNotFound(
                             "cannot iterate over non-array value".to_string(),
+                        ));
+                    }
+                },
+                Segment::Slice { start, end, step } => match val {
+                    Value::Array(arr) => {
+                        let sliced = apply_slice(arr, *start, *end, *step)?;
+                        next_results.extend(sliced);
+                    }
+                    _ => {
+                        return Err(DkitError::PathNotFound(
+                            "cannot slice non-array value".to_string(),
                         ));
                     }
                 },
@@ -57,7 +68,12 @@ pub fn evaluate_path(value: &Value, path: &Path) -> Result<Value, DkitError> {
     }
 
     // 이터레이션이 있었으면 배열로 반환, 아니면 단일 값
-    let has_iterate = path.segments.iter().any(|s| matches!(s, Segment::Iterate));
+    let has_iterate = path.segments.iter().any(|s| {
+        matches!(
+            s,
+            Segment::Iterate | Segment::Wildcard | Segment::Slice { .. }
+        )
+    });
     if has_iterate {
         Ok(Value::Array(results))
     } else {
@@ -68,6 +84,81 @@ pub fn evaluate_path(value: &Value, path: &Path) -> Result<Value, DkitError> {
             _ => Ok(Value::Array(results)),
         }
     }
+}
+
+/// Python 스타일 배열 슬라이싱 적용
+fn apply_slice(
+    arr: &[Value],
+    start: Option<i64>,
+    end: Option<i64>,
+    step: Option<i64>,
+) -> Result<Vec<Value>, DkitError> {
+    let len = arr.len() as i64;
+    let step = step.unwrap_or(1);
+
+    if step == 0 {
+        return Err(DkitError::QueryError(
+            "slice step cannot be zero".to_string(),
+        ));
+    }
+
+    // Python 스타일 인덱스 클램핑
+    let clamp = |idx: i64| -> i64 {
+        if idx < 0 {
+            let resolved = len + idx;
+            if resolved < 0 {
+                0
+            } else {
+                resolved
+            }
+        } else if idx > len {
+            len
+        } else {
+            idx
+        }
+    };
+
+    let (start_idx, end_idx) = if step > 0 {
+        let s = match start {
+            Some(v) => clamp(v),
+            None => 0,
+        };
+        let e = match end {
+            Some(v) => clamp(v),
+            None => len,
+        };
+        (s, e)
+    } else {
+        let s = match start {
+            Some(v) => clamp(v),
+            None => len - 1,
+        };
+        let e = match end {
+            Some(v) => clamp(v),
+            None => -1,
+        };
+        (s, e)
+    };
+
+    let mut result = Vec::new();
+    let mut i = start_idx;
+    if step > 0 {
+        while i < end_idx {
+            if i >= 0 && i < len {
+                result.push(arr[i as usize].clone());
+            }
+            i += step;
+        }
+    } else {
+        while i > end_idx {
+            if i >= 0 && i < len {
+                result.push(arr[i as usize].clone());
+            }
+            i += step;
+        }
+    }
+
+    Ok(result)
 }
 
 /// 음수 인덱스를 양수로 변환
@@ -389,5 +480,233 @@ mod tests {
         let data = Value::Null;
         let result = eval(&data, ".").unwrap();
         assert_eq!(result, Value::Null);
+    }
+
+    // --- 배열 와일드카드 ---
+
+    #[test]
+    fn test_wildcard_basic() {
+        let data = sample_data();
+        let result = eval(&data, ".users[*]").unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_wildcard_with_field() {
+        let data = sample_data();
+        let result = eval(&data, ".users[*].name").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::String("Alice".to_string()),
+                Value::String("Bob".to_string()),
+                Value::String("Charlie".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_wildcard_on_non_array() {
+        let data = sample_data();
+        let err = eval(&data, ".name[*]").unwrap_err();
+        assert!(matches!(err, DkitError::PathNotFound(_)));
+    }
+
+    // --- 배열 슬라이싱 ---
+
+    #[test]
+    fn test_slice_basic() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+            Value::Integer(40),
+            Value::Integer(50),
+        ]);
+        let result = eval(&data, ".[0:3]").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::Integer(10),
+                Value::Integer(20),
+                Value::Integer(30),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_slice_open_end() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+            Value::Integer(40),
+            Value::Integer(50),
+        ]);
+        let result = eval(&data, ".[2:]").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::Integer(30),
+                Value::Integer(40),
+                Value::Integer(50),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_slice_open_start() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+            Value::Integer(40),
+            Value::Integer(50),
+        ]);
+        let result = eval(&data, ".[:2]").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![Value::Integer(10), Value::Integer(20),])
+        );
+    }
+
+    #[test]
+    fn test_slice_negative_start() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+            Value::Integer(40),
+            Value::Integer(50),
+        ]);
+        let result = eval(&data, ".[-2:]").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![Value::Integer(40), Value::Integer(50),])
+        );
+    }
+
+    #[test]
+    fn test_slice_negative_end() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+            Value::Integer(40),
+            Value::Integer(50),
+        ]);
+        let result = eval(&data, ".[1:-1]").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::Integer(20),
+                Value::Integer(30),
+                Value::Integer(40),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_slice_with_step() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+            Value::Integer(40),
+            Value::Integer(50),
+        ]);
+        let result = eval(&data, ".[0:5:2]").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::Integer(10),
+                Value::Integer(30),
+                Value::Integer(50),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_slice_reverse() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+        ]);
+        let result = eval(&data, ".[::-1]").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::Integer(30),
+                Value::Integer(20),
+                Value::Integer(10),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_slice_empty_result() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+        ]);
+        let result = eval(&data, ".[5:10]").unwrap();
+        assert_eq!(result, Value::Array(vec![]));
+    }
+
+    #[test]
+    fn test_slice_on_nested_field() {
+        let data = sample_data();
+        let result = eval(&data, ".users[0:2]").unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap().get("name"),
+            Some(&Value::String("Bob".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_slice_with_field_after() {
+        let data = sample_data();
+        let result = eval(&data, ".users[0:2].name").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::String("Alice".to_string()),
+                Value::String("Bob".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_slice_on_non_array() {
+        let data = sample_data();
+        let err = eval(&data, ".name[0:2]").unwrap_err();
+        assert!(matches!(err, DkitError::PathNotFound(_)));
+    }
+
+    #[test]
+    fn test_slice_step_zero_error() {
+        let data = Value::Array(vec![Value::Integer(10)]);
+        let err = eval(&data, ".[::0]").unwrap_err();
+        assert!(matches!(err, DkitError::QueryError(_)));
+    }
+
+    #[test]
+    fn test_slice_full_open() {
+        let data = Value::Array(vec![
+            Value::Integer(10),
+            Value::Integer(20),
+            Value::Integer(30),
+        ]);
+        let result = eval(&data, ".[:]").unwrap();
+        assert_eq!(result, data);
     }
 }

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -25,6 +25,14 @@ pub enum Segment {
     Index(i64),
     /// 배열 이터레이션 (`[]`)
     Iterate,
+    /// 배열 슬라이싱 (`[0:3]`, `[-2:]`, `[::2]`)
+    Slice {
+        start: Option<i64>,
+        end: Option<i64>,
+        step: Option<i64>,
+    },
+    /// 배열 와일드카드 (`[*]`) — Iterate와 동일 의미
+    Wildcard,
 }
 
 /// Pipeline operation applied after path navigation (e.g., `| where ...`, `| sort ...`).
@@ -274,7 +282,7 @@ impl Parser {
         Ok(Segment::Field(name))
     }
 
-    /// `[...]` 파싱: 인덱스 또는 이터레이션
+    /// `[...]` 파싱: 인덱스, 이터레이션, 슬라이스, 와일드카드
     fn parse_bracket(&mut self) -> Result<Segment, DkitError> {
         if !self.consume_char('[') {
             return Err(DkitError::QueryError(format!(
@@ -291,7 +299,25 @@ impl Parser {
             return Ok(Segment::Iterate);
         }
 
-        // `[N]` or `[-N]` — 인덱스
+        // `[*]` — 와일드카드
+        if self.peek() == Some('*') {
+            self.advance();
+            self.skip_whitespace();
+            if !self.consume_char(']') {
+                return Err(DkitError::QueryError(format!(
+                    "expected ']' after '*' at position {}",
+                    self.pos
+                )));
+            }
+            return Ok(Segment::Wildcard);
+        }
+
+        // `[:]` — 슬라이스 (콜론으로 시작)
+        if self.peek() == Some(':') {
+            return self.parse_slice(None);
+        }
+
+        // 숫자 파싱 (인덱스 또는 슬라이스의 start)
         let negative = self.consume_char('-');
         let start = self.pos;
         while !self.is_at_end() && self.input[self.pos].is_ascii_digit() {
@@ -305,9 +331,62 @@ impl Parser {
         }
 
         let num_str: String = self.input[start..self.pos].iter().collect();
-        let index: i64 = num_str.parse().map_err(|_| {
+        let num: i64 = num_str.parse().map_err(|_| {
             DkitError::QueryError(format!("invalid index '{}' at position {}", num_str, start))
         })?;
+        let num = if negative { -num } else { num };
+
+        self.skip_whitespace();
+
+        // `:` 이 나오면 슬라이스
+        if self.peek() == Some(':') {
+            return self.parse_slice(Some(num));
+        }
+
+        // `]` 이면 단일 인덱스
+        if !self.consume_char(']') {
+            return Err(DkitError::QueryError(format!(
+                "expected ']' or ':' at position {}",
+                self.pos
+            )));
+        }
+
+        Ok(Segment::Index(num))
+    }
+
+    /// 슬라이스 나머지 파싱: start는 이미 파싱됨, `:` 부터 시작
+    fn parse_slice(&mut self, start: Option<i64>) -> Result<Segment, DkitError> {
+        // consume first ':'
+        if !self.consume_char(':') {
+            return Err(DkitError::QueryError(format!(
+                "expected ':' at position {}",
+                self.pos
+            )));
+        }
+
+        self.skip_whitespace();
+
+        // end 파싱
+        let end = if self.peek() == Some(']') || self.peek() == Some(':') {
+            None
+        } else {
+            Some(self.parse_signed_integer()?)
+        };
+
+        self.skip_whitespace();
+
+        // step 파싱 (optional second ':')
+        let step = if self.peek() == Some(':') {
+            self.advance();
+            self.skip_whitespace();
+            if self.peek() == Some(']') {
+                None
+            } else {
+                Some(self.parse_signed_integer()?)
+            }
+        } else {
+            None
+        };
 
         self.skip_whitespace();
         if !self.consume_char(']') {
@@ -317,7 +396,30 @@ impl Parser {
             )));
         }
 
-        Ok(Segment::Index(if negative { -index } else { index }))
+        Ok(Segment::Slice { start, end, step })
+    }
+
+    /// 부호 있는 정수 파싱
+    fn parse_signed_integer(&mut self) -> Result<i64, DkitError> {
+        let negative = self.consume_char('-');
+        let start = self.pos;
+        while !self.is_at_end() && self.input[self.pos].is_ascii_digit() {
+            self.pos += 1;
+        }
+        if self.pos == start {
+            return Err(DkitError::QueryError(format!(
+                "expected integer at position {}",
+                self.pos
+            )));
+        }
+        let num_str: String = self.input[start..self.pos].iter().collect();
+        let num: i64 = num_str.parse().map_err(|_| {
+            DkitError::QueryError(format!(
+                "invalid integer '{}' at position {}",
+                num_str, start
+            ))
+        })?;
+        Ok(if negative { -num } else { num })
     }
 
     // --- 파이프라인 연산 파싱 ---
@@ -1194,6 +1296,137 @@ mod tests {
                 Segment::Iterate,
                 Segment::Field("name".to_string()),
             ]
+        );
+    }
+
+    // --- 배열 와일드카드 ---
+
+    #[test]
+    fn test_array_wildcard() {
+        let q = parse_query(".[*]").unwrap();
+        assert_eq!(q.path.segments, vec![Segment::Wildcard]);
+    }
+
+    #[test]
+    fn test_array_wildcard_with_field() {
+        let q = parse_query(".users[*].name").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![
+                Segment::Field("users".to_string()),
+                Segment::Wildcard,
+                Segment::Field("name".to_string()),
+            ]
+        );
+    }
+
+    // --- 배열 슬라이싱 ---
+
+    #[test]
+    fn test_array_slice_basic() {
+        let q = parse_query(".[0:3]").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::Slice {
+                start: Some(0),
+                end: Some(3),
+                step: None
+            }]
+        );
+    }
+
+    #[test]
+    fn test_array_slice_open_end() {
+        let q = parse_query(".[1:]").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::Slice {
+                start: Some(1),
+                end: None,
+                step: None
+            }]
+        );
+    }
+
+    #[test]
+    fn test_array_slice_open_start() {
+        let q = parse_query(".[:3]").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::Slice {
+                start: None,
+                end: Some(3),
+                step: None
+            }]
+        );
+    }
+
+    #[test]
+    fn test_array_slice_negative() {
+        let q = parse_query(".[-2:]").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::Slice {
+                start: Some(-2),
+                end: None,
+                step: None
+            }]
+        );
+    }
+
+    #[test]
+    fn test_array_slice_with_step() {
+        let q = parse_query(".[1:5:2]").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::Slice {
+                start: Some(1),
+                end: Some(5),
+                step: Some(2)
+            }]
+        );
+    }
+
+    #[test]
+    fn test_array_slice_full_open() {
+        let q = parse_query(".[:]").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::Slice {
+                start: None,
+                end: None,
+                step: None
+            }]
+        );
+    }
+
+    #[test]
+    fn test_array_slice_with_field() {
+        let q = parse_query(".users[0:3].name").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![
+                Segment::Field("users".to_string()),
+                Segment::Slice {
+                    start: Some(0),
+                    end: Some(3),
+                    step: None
+                },
+                Segment::Field("name".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_array_slice_reverse_step() {
+        let q = parse_query(".[::-1]").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::Slice {
+                start: None,
+                end: None,
+                step: Some(-1)
+            }]
         );
     }
 


### PR DESCRIPTION
## Summary
- Add Python-style array slicing syntax (`[start:end]`, `[start:end:step]`) to query path expressions
- Add wildcard syntax (`[*]`) as an explicit alternative to `[]` for array iteration
- Support negative indices, omitted boundaries, and step values in slices

## Examples
```bash
dkit query data.json '.users[0:3]'          # 처음 3개 요소
dkit query data.json '.users[-2:]'          # 마지막 2개 요소
dkit query data.json '.users[1:5:2]'        # 스텝 지원
dkit query data.json '.users[*].name'       # 와일드카드 — 모든 요소의 name
dkit query data.json '.items[*].tags[0]'    # 중첩 와일드카드
dkit query data.json '.[::-1]'              # 배열 역순
```

## Test plan
- [x] Parser unit tests: wildcard, slice with various boundary combinations, step, negative indices
- [x] Evaluator unit tests: basic slice, open start/end, negative start/end, step, reverse, empty result, nested fields, error cases
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] Full test suite (514 tests) passes

Closes #190

https://claude.ai/code/session_01Pt1WkWbLg7HN8AyVGWw5pR