### PR TITLE
feat: add `matches` regex operator for query where clause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ dependencies = [
  "parquet",
  "quick-xml 0.37.5",
  "rand",
+ "regex",
  "rmp-serde",
  "rusqlite",
  "serde",

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -37,6 +37,7 @@ parquet-impl = { package = "parquet", version = "53", default-features = false, 
 bytes = { version = "1", optional = true }
 jsonschema = { version = "0.17", default-features = false }
 rand = "0.8"
+regex = "1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/dkit-core/src/query/filter.rs
+++ b/dkit-core/src/query/filter.rs
@@ -817,6 +817,18 @@ fn compare_values(
             CompareOp::Contains => Ok(a.contains(b.as_str())),
             CompareOp::StartsWith => Ok(a.starts_with(b.as_str())),
             CompareOp::EndsWith => Ok(a.ends_with(b.as_str())),
+            CompareOp::Matches => {
+                let re = regex::Regex::new(b).map_err(|e| {
+                    DkitError::QueryError(format!("invalid regex pattern '{}': {}", b, e))
+                })?;
+                Ok(re.is_match(a))
+            }
+            CompareOp::NotMatches => {
+                let re = regex::Regex::new(b).map_err(|e| {
+                    DkitError::QueryError(format!("invalid regex pattern '{}': {}", b, e))
+                })?;
+                Ok(!re.is_match(a))
+            }
             _ => Ok(apply_compare_op(a.as_str(), op, b.as_str())),
         },
         // 불리언: == 와 != 만 지원
@@ -861,6 +873,7 @@ fn apply_compare_op<T: PartialOrd>(a: T, op: &CompareOp, b: T) -> bool {
         CompareOp::Le => a <= b,
         CompareOp::Contains | CompareOp::StartsWith | CompareOp::EndsWith => false,
         CompareOp::In | CompareOp::NotIn => false,
+        CompareOp::Matches | CompareOp::NotMatches => false,
     }
 }
 
@@ -1229,6 +1242,64 @@ mod tests {
         );
         let result = run_where(&data, &cond).unwrap();
         assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_where_matches() {
+        let data = sample_files();
+        let cond = make_condition(
+            "email",
+            CompareOp::Matches,
+            LiteralValue::String(".*@gmail\\.com$".to_string()),
+        );
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 2); // alice@gmail.com, charlie@gmail.com
+    }
+
+    #[test]
+    fn test_where_matches_pattern() {
+        let data = sample_files();
+        let cond = make_condition(
+            "name",
+            CompareOp::Matches,
+            LiteralValue::String("^.*\\.json$".to_string()),
+        );
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 2); // config.json, data.json
+    }
+
+    #[test]
+    fn test_where_not_matches() {
+        let data = sample_files();
+        let cond = make_condition(
+            "email",
+            CompareOp::NotMatches,
+            LiteralValue::String(".*@gmail\\.com$".to_string()),
+        );
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 1); // bob@yahoo.com
+    }
+
+    #[test]
+    fn test_where_matches_no_match() {
+        let data = sample_files();
+        let cond = make_condition(
+            "email",
+            CompareOp::Matches,
+            LiteralValue::String("^admin@".to_string()),
+        );
+        let result = run_where(&data, &cond).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_where_matches_invalid_regex() {
+        let result = compare_values(
+            &Value::String("test@example.com".to_string()),
+            &CompareOp::Matches,
+            &LiteralValue::String("[invalid".to_string()),
+        );
+        assert!(result.is_err());
     }
 
     // --- 논리 연산자 ---

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -130,6 +130,8 @@ pub enum CompareOp {
     EndsWith,   // ends_with
     In,         // in
     NotIn,      // not in
+    Matches,    // matches (regex)
+    NotMatches, // not matches (regex)
 }
 
 /// Literal value used as a comparison operand or in expressions.
@@ -883,6 +885,14 @@ impl Parser {
                                 op: CompareOp::NotIn,
                                 value: LiteralValue::List(list),
                             });
+                        } else if kw2 == "matches" {
+                            self.skip_whitespace();
+                            let value = self.parse_literal_value()?;
+                            return Ok(Comparison {
+                                field,
+                                op: CompareOp::NotMatches,
+                                value,
+                            });
                         }
                     }
                     self.pos = saved_pos2;
@@ -981,6 +991,7 @@ impl Parser {
                     "contains" => Ok(CompareOp::Contains),
                     "starts_with" => Ok(CompareOp::StartsWith),
                     "ends_with" => Ok(CompareOp::EndsWith),
+                    "matches" => Ok(CompareOp::Matches),
                     _ => {
                         self.pos = saved_pos;
                         Err(DkitError::QueryError(format!(
@@ -1809,6 +1820,31 @@ mod tests {
         assert_eq!(cmp.field, "file");
         assert_eq!(cmp.op, CompareOp::EndsWith);
         assert_eq!(cmp.value, LiteralValue::String(".json".to_string()));
+    }
+
+    #[test]
+    fn test_where_matches() {
+        let q = parse_query(".[] | where email matches \".*@gmail\\.com$\"").unwrap();
+        let Operation::Where(Condition::Comparison(cmp)) = &q.operations[0] else {
+            panic!("expected Comparison");
+        };
+        assert_eq!(cmp.field, "email");
+        assert_eq!(cmp.op, CompareOp::Matches);
+        assert_eq!(
+            cmp.value,
+            LiteralValue::String(".*@gmail\\.com$".to_string())
+        );
+    }
+
+    #[test]
+    fn test_where_not_matches() {
+        let q = parse_query(".[] | where name not matches \"^test_\"").unwrap();
+        let Operation::Where(Condition::Comparison(cmp)) = &q.operations[0] else {
+            panic!("expected Comparison");
+        };
+        assert_eq!(cmp.field, "name");
+        assert_eq!(cmp.op, CompareOp::NotMatches);
+        assert_eq!(cmp.value, LiteralValue::String("^test_".to_string()));
     }
 
     // --- 논리 연산자 파싱 ---


### PR DESCRIPTION
## Summary
- Add `matches` and `not matches` operators to the query where clause for regex pattern matching on string fields
- Add `regex` crate dependency to dkit-core
- Supports use in both `where` clause (`select * where email matches ".*@gmail\\.com$"`) and `--filter` flag

## Test plan
- [x] Parser test: `matches` operator parsing
- [x] Parser test: `not matches` operator parsing
- [x] Filter test: regex matching (gmail pattern)
- [x] Filter test: file extension pattern matching
- [x] Filter test: `not matches` negation
- [x] Filter test: no match scenario
- [x] Filter test: invalid regex returns error
- [x] All 609 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #209

https://claude.ai/code/session_01RGQCN8Sy28BrfpXmiymWSB