### PR TITLE
test: add v1.2.0 integration tests and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ dkit completions powershell > dkit.ps1 && . ./dkit.ps1
 | Parquet     | `.parquet`             |  ✓   |   ✓   | Snappy / Gzip / Zstd compression |
 | Excel       | `.xlsx`                |  ✓   |   —   | Sheet selection, input-only    |
 | SQLite      | `.db`, `.sqlite`       |  ✓   |   —   | Custom SQL queries, input-only |
+| INI/CFG     | `.ini`, `.cfg`         |  ✓   |   ✓   | Section-based config files     |
+| .properties | `.properties`          |  ✓   |   ✓   | Java properties files          |
 | .env        | `.env`                 |  ✓   |   ✓   | Environment variable files     |
 | Markdown    | `.md`                  |  —   |   ✓   | GFM table, output-only         |
 | HTML        | `.html`                |  —   |   ✓   | Styled tables, output-only     |
@@ -124,6 +126,8 @@ cat data.json | dkit convert --from json --to csv
 
 # Format-specific options
 dkit convert data.json --to json --compact           # Minified JSON
+dkit convert data.json --to json --indent 4          # 4-space indentation
+dkit convert data.json --to json --sort-keys         # Alphabetically sorted keys
 dkit convert data.csv --to json --no-header           # CSV without header row
 dkit convert data.json --to xml --root-element items  # Custom XML root
 dkit convert data.json --to html --styled --full-html # Styled HTML document
@@ -142,6 +146,14 @@ dkit convert data.csv --to json --detect-encoding
 # Streaming for large files
 dkit convert large.jsonl --from jsonl -f csv --chunk-size 1000 -o out.csv
 
+# Deduplication
+dkit convert data.json --to csv --unique             # Remove duplicate records
+dkit convert data.json --to csv --unique-by email    # Deduplicate by field
+
+# Computed fields and transformations
+dkit convert data.json --to json --add-field 'total = price * qty'
+dkit convert data.json --to json --map 'name = upper(name)'
+
 # Column selection and aggregation
 dkit convert data.json --to csv --select 'name, email'
 dkit convert sales.csv --to json --group-by category --agg 'count(), sum(amount)'
@@ -149,6 +161,10 @@ dkit convert data.json --to csv --select 'name, age' --filter 'age > 30' --sort-
 
 # Dry-run (preview without writing)
 dkit convert huge.json --to csv -o output.csv --dry-run
+
+# INI / .properties format
+dkit convert config.ini --to json                    # INI → JSON
+dkit convert app.properties --to yaml                # Properties → YAML
 
 # .env format
 dkit convert .env --to json                         # .env → JSON
@@ -170,6 +186,15 @@ dkit query data.json '.users[0].name'
 dkit query data.json '.users[] | where age > 20 | select name, email'
 dkit query data.json '.items[] | sort price desc | limit 5'
 dkit query data.json '.users[] | where name contains "Kim"'
+
+# Array slicing and wildcards
+dkit query data.json '.[0:3]'                        # First 3 elements
+dkit query data.json '.[-2:]'                        # Last 2 elements
+dkit query data.json '.[*].name'                     # All names (wildcard)
+
+# IN / NOT IN, matches operators
+dkit query data.json '.[] | where status in ("active", "pending")'
+dkit query data.json '.[] | where name matches "^[A-C]"'
 
 # Aggregate functions
 dkit query data.csv '.[] | count'
@@ -196,8 +221,12 @@ dkit query data.json '.users[]' --to csv -o users.csv
 | `.field.sub` | Nested field access |
 | `.[0]`, `.[-1]` | Array index (0-based, negative from end) |
 | `.[]` | Iterate all elements |
+| `.[*]` | Wildcard (same as `[]`) |
+| `.[0:3]`, `.[-2:]`, `.[::2]` | Array slicing (start:end:step) |
 | `where .field == value` | Filter (`==`, `!=`, `>`, `<`, `>=`, `<=`) |
 | `where .field contains "str"` | String filter (`contains`, `starts_with`, `ends_with`) |
+| `where .field in ("a", "b")` | Membership filter (`in`, `not in`) |
+| `where .field matches "regex"` | Regex filter (`matches`, `not matches`) |
 | `select .f1, .f2` | Select specific fields |
 | `sort .field [desc]` | Sort ascending/descending |
 | `limit N` | Limit results |
@@ -207,7 +236,7 @@ dkit query data.json '.users[]' --to csv -o users.csv
 
 | Category | Functions |
 |----------|-----------|
-| String   | `upper`, `lower`, `trim`, `ltrim`, `rtrim`, `length`, `substr`, `concat`, `replace`, `split` |
+| String   | `upper`, `lower`, `trim`, `ltrim`, `rtrim`, `length`, `substr`, `concat`, `replace`, `split`, `index_of`, `rindex_of`, `starts_with`, `ends_with`, `reverse`, `repeat`, `pad_left`, `pad_right` |
 | Math     | `round`, `ceil`, `floor`, `abs`, `sqrt`, `pow` |
 | Date     | `now`, `date`, `year`, `month`, `day` |
 | Type     | `to_int`, `to_float`, `to_string`, `to_bool` |
@@ -333,6 +362,7 @@ dkit y2j config.yaml                # YAML → JSON
 | Parquet | ✓ | — | — | — |
 | Excel (.xlsx) input | ✓ | — | — | — |
 | SQLite input | ✓ | — | — | — |
+| INI / .properties | ✓ | — | — | — |
 | .env files | ✓ | — | — | — |
 | Cross-format convert | ✓ | — | Partial | Partial |
 | Query (where/select/sort) | ✓ | ✓ | ✓ | ✓ |

--- a/dkit-cli/tests/v120_integration_test.rs
+++ b/dkit-cli/tests/v120_integration_test.rs
@@ -1,0 +1,1136 @@
+/// v1.2.0 Integration Tests
+///
+/// Comprehensive integration tests for v1.2.0 features:
+/// - `--unique` / `--unique-by` flags (deduplication)
+/// - `--add-field` with arithmetic and string concatenation
+/// - `--map` with built-in functions and value transformation
+/// - Array slicing and wildcard query
+/// - `.ini` / `.cfg` format Reader/Writer
+/// - `.properties` format Reader/Writer
+/// - `IN` / `NOT IN` operators
+/// - `matches` regex operator
+/// - `--indent`, `--sort-keys`, `--compact` JSON output options
+/// - New string functions (index_of, starts_with, pad, reverse, etc.)
+/// - Combined feature tests
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// ============================================================
+// --unique / --unique-by tests
+// ============================================================
+
+#[test]
+fn unique_removes_duplicate_records() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("dupes.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "age": 30},
+          {"name": "Bob", "age": 25},
+          {"name": "Alice", "age": 30},
+          {"name": "Charlie", "age": 35},
+          {"name": "Bob", "age": 25}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "json", "--unique"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(stdout.matches("Alice").count(), 1);
+    assert_eq!(stdout.matches("Bob").count(), 1);
+    assert_eq!(stdout.matches("Charlie").count(), 1);
+}
+
+#[test]
+fn unique_by_field_keeps_first_occurrence() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("dupes.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "city": "Seoul"},
+          {"name": "Bob", "city": "Busan"},
+          {"name": "Charlie", "city": "Seoul"},
+          {"name": "Diana", "city": "Busan"}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--unique-by",
+            "city",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should keep Alice (first Seoul) and Bob (first Busan)
+    assert!(stdout.contains("Alice"));
+    assert!(stdout.contains("Bob"));
+    // Charlie and Diana are duplicates by city
+    assert!(!stdout.contains("Charlie"));
+    assert!(!stdout.contains("Diana"));
+}
+
+#[test]
+fn unique_with_csv_output() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("dupes.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "age": 30},
+          {"name": "Alice", "age": 30},
+          {"name": "Bob", "age": 25}
+        ]"#,
+    )
+    .unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "csv", "--unique"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+#[test]
+fn unique_by_with_view_command() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/employees.json",
+            "--unique-by",
+            "city",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("Busan"));
+}
+
+// ============================================================
+// --add-field integration tests (arithmetic, string concat)
+// ============================================================
+
+#[test]
+fn add_field_subtraction() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "remaining = 100 - score",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("remaining"))
+        .stdout(predicate::str::contains("15")); // Alice: 100 - 85
+}
+
+#[test]
+fn add_field_division() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "half_age = age / 2",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("half_age"));
+}
+
+#[test]
+fn add_field_multiple_fields() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "double_age = age * 2",
+            "--add-field",
+            "label = name + \" (\" + role + \")\"",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("double_age"))
+        .stdout(predicate::str::contains("label"));
+}
+
+#[test]
+fn add_field_with_filter_and_sort() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "double_score = score * 2",
+            "--filter",
+            "age > 28",
+            "--sort-by",
+            "score",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("double_score"));
+}
+
+// ============================================================
+// --map integration tests (built-in functions, value transformation)
+// ============================================================
+
+#[test]
+fn map_field_trim() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("spaces.json");
+    fs::write(&input, r#"[{"name": "  Alice  "}, {"name": "  Bob  "}]"#).unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--map",
+            "name = trim(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"Alice\""))
+        .stdout(predicate::str::contains("\"Bob\""));
+}
+
+#[test]
+fn map_field_replace() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "city = replace(city, \"Seoul\", \"서울\")",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("서울"));
+}
+
+#[test]
+fn map_field_multiple_transforms() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "name = upper(name)",
+            "--map",
+            "city = lower(city)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("seoul"));
+}
+
+#[test]
+fn map_field_with_view() {
+    dkit()
+        .args(&[
+            "view",
+            "tests/fixtures/employees.json",
+            "--map",
+            "name = upper(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"));
+}
+
+// ============================================================
+// Array slicing and wildcard query tests
+// ============================================================
+
+#[test]
+fn query_array_wildcard() {
+    dkit()
+        .args(&["query", "tests/fixtures/employees.json", ".[*].name"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"))
+        .stdout(predicate::str::contains("Charlie"));
+}
+
+#[test]
+fn query_array_slice_basic() {
+    dkit()
+        .args(&["query", "tests/fixtures/employees.json", ".[0:2]"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+#[test]
+fn query_array_slice_negative() {
+    dkit()
+        .args(&["query", "tests/fixtures/employees.json", ".[-2:]"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Diana"))
+        .stdout(predicate::str::contains("Eve"));
+}
+
+#[test]
+fn query_array_slice_with_step() {
+    dkit()
+        .args(&["query", "tests/fixtures/employees.json", ".[::2]"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Charlie"))
+        .stdout(predicate::str::contains("Eve"));
+}
+
+#[test]
+fn query_wildcard_with_field_access() {
+    dkit()
+        .args(&["query", "tests/fixtures/employees.json", ".[*].city"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("Busan"))
+        .stdout(predicate::str::contains("Incheon"));
+}
+
+// ============================================================
+// .ini / .cfg format tests
+// ============================================================
+
+#[test]
+fn ini_to_json_conversion() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.ini");
+    fs::write(
+        &input,
+        "[database]\nhost = localhost\nport = 5432\n\n[server]\ndebug = true\n",
+    )
+    .unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("database"))
+        .stdout(predicate::str::contains("localhost"))
+        .stdout(predicate::str::contains("5432"))
+        .stdout(predicate::str::contains("server"))
+        .stdout(predicate::str::contains("debug"));
+}
+
+#[test]
+fn json_to_ini_conversion() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.json");
+    fs::write(
+        &input,
+        r#"{"database": {"host": "localhost", "port": "5432"}, "server": {"debug": "true"}}"#,
+    )
+    .unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "ini"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[database]"))
+        .stdout(
+            predicate::str::contains("host=localhost")
+                .or(predicate::str::contains("host = localhost")),
+        );
+}
+
+#[test]
+fn ini_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.ini");
+    let intermediate = tmp.path().join("config.json");
+    let output = tmp.path().join("config_out.ini");
+
+    fs::write(&input, "[section]\nkey1 = value1\nkey2 = value2\n").unwrap();
+
+    // INI → JSON
+    dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "-o",
+            intermediate.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // JSON → INI
+    dkit()
+        .args(&[
+            "convert",
+            intermediate.to_str().unwrap(),
+            "-f",
+            "ini",
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let result = fs::read_to_string(&output).unwrap();
+    assert!(result.contains("[section]"));
+    assert!(result.contains("key1"));
+    assert!(result.contains("value1"));
+}
+
+#[test]
+fn ini_query() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.ini");
+    fs::write(&input, "[database]\nhost = localhost\nport = 5432\n").unwrap();
+
+    dkit()
+        .args(&["query", input.to_str().unwrap(), ".database.host"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("localhost"));
+}
+
+#[test]
+fn ini_view() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.ini");
+    fs::write(
+        &input,
+        "[app]\nname = myapp\nversion = 1.0\n\n[db]\nhost = localhost\n",
+    )
+    .unwrap();
+
+    dkit()
+        .args(&["view", input.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("app"))
+        .stdout(predicate::str::contains("db"));
+}
+
+#[test]
+fn cfg_extension_detected_as_ini() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.cfg");
+    fs::write(&input, "[settings]\ntheme = dark\nlanguage = ko\n").unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("settings"))
+        .stdout(predicate::str::contains("dark"));
+}
+
+// ============================================================
+// .properties format tests
+// ============================================================
+
+#[test]
+fn properties_to_json_conversion() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("app.properties");
+    fs::write(
+        &input,
+        "app.name=MyApp\napp.version=1.0\ndb.host=localhost\ndb.port=5432\n",
+    )
+    .unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("app.name"))
+        .stdout(predicate::str::contains("MyApp"))
+        .stdout(predicate::str::contains("db.host"))
+        .stdout(predicate::str::contains("localhost"));
+}
+
+#[test]
+fn json_to_properties_conversion() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.json");
+    fs::write(&input, r#"{"app.name": "MyApp", "db.host": "localhost"}"#).unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "properties"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("app.name"))
+        .stdout(predicate::str::contains("MyApp"));
+}
+
+#[test]
+fn properties_with_comments_and_special_chars() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("app.properties");
+    fs::write(
+        &input,
+        "# This is a comment\n! Another comment\nkey1=value1\nkey2 = value with spaces\nkey3=\n",
+    )
+    .unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("key1"))
+        .stdout(predicate::str::contains("value1"))
+        .stdout(predicate::str::contains("key2"))
+        .stdout(predicate::str::contains("value with spaces"));
+}
+
+#[test]
+fn properties_query() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("app.properties");
+    fs::write(&input, "host=localhost\nport=5432\n").unwrap();
+
+    dkit()
+        .args(&["query", input.to_str().unwrap(), ".host"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("localhost"));
+}
+
+#[test]
+fn properties_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("app.properties");
+    let intermediate = tmp.path().join("config.json");
+    let output = tmp.path().join("app_out.properties");
+
+    fs::write(&input, "name=Alice\nage=30\ncity=Seoul\n").unwrap();
+
+    // properties → JSON
+    dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "-o",
+            intermediate.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // JSON → properties
+    dkit()
+        .args(&[
+            "convert",
+            intermediate.to_str().unwrap(),
+            "-f",
+            "properties",
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let result = fs::read_to_string(&output).unwrap();
+    assert!(result.contains("name"));
+    assert!(result.contains("Alice"));
+}
+
+// ============================================================
+// IN / NOT IN operator tests
+// ============================================================
+
+#[test]
+fn query_where_in_operator() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where city in (\"Seoul\", \"Busan\") | select name, city",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"))
+        .stdout(predicate::str::contains("Charlie"))
+        .stdout(predicate::str::contains("Incheon").not());
+}
+
+#[test]
+fn query_where_not_in_operator() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where city not in (\"Seoul\") | select name, city",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Bob"))
+        .stdout(predicate::str::contains("Diana"))
+        .stdout(predicate::str::contains("Alice").not());
+}
+
+#[test]
+fn filter_flag_in_operator() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--filter",
+            "role in (\"engineer\", \"manager\")",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Charlie"))
+        .stdout(predicate::str::contains("designer").not());
+}
+
+#[test]
+fn in_operator_with_numbers() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where age in (25, 30) | select name",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+// ============================================================
+// matches regex operator tests
+// ============================================================
+
+#[test]
+fn query_where_matches_regex() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name matches \"^[A-C]\" | select name",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"))
+        .stdout(predicate::str::contains("Charlie"))
+        .stdout(predicate::str::contains("Diana").not())
+        .stdout(predicate::str::contains("Eve").not());
+}
+
+#[test]
+fn query_where_not_matches() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name not matches \"^[A-C]\" | select name",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Diana"))
+        .stdout(predicate::str::contains("Eve"))
+        .stdout(predicate::str::contains("Alice").not());
+}
+
+#[test]
+fn filter_flag_matches_operator() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--filter",
+            "city matches \"^S\"",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Seoul"))
+        .stdout(predicate::str::contains("Busan").not());
+}
+
+// ============================================================
+// --indent, --sort-keys, --compact JSON output tests
+// ============================================================
+
+#[test]
+fn json_compact_output() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--compact",
+            "--head",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\n  ").not());
+}
+
+#[test]
+fn json_indent_2_spaces() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--indent",
+            "2",
+            "--head",
+            "1",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should have 2-space indentation
+    assert!(stdout.contains("  \"name\"") || stdout.contains("  \"age\""));
+}
+
+#[test]
+fn json_indent_4_spaces() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--indent",
+            "4",
+            "--head",
+            "1",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("    \"name\"") || stdout.contains("    \"age\""));
+}
+
+#[test]
+fn json_indent_tab() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--indent",
+            "tab",
+            "--head",
+            "1",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("\t\"name\"") || stdout.contains("\t\"age\""));
+}
+
+#[test]
+fn json_sort_keys() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--sort-keys",
+            "--head",
+            "1",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // With sort-keys, "age" should come before "city" and "name"
+    let age_pos = stdout.find("\"age\"").unwrap_or(usize::MAX);
+    let city_pos = stdout.find("\"city\"").unwrap_or(usize::MAX);
+    let name_pos = stdout.find("\"name\"").unwrap_or(usize::MAX);
+    assert!(age_pos < city_pos);
+    assert!(city_pos < name_pos);
+}
+
+#[test]
+fn json_compact_with_sort_keys() {
+    let output = dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--compact",
+            "--sort-keys",
+            "--head",
+            "1",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should be compact (no pretty-printing) with sorted keys
+    assert!(stdout.contains("\"age\""));
+    assert!(!stdout.contains("  \"age\""));
+}
+
+// ============================================================
+// New string function tests (index_of, starts_with, pad, reverse, etc.)
+// ============================================================
+
+#[test]
+fn query_function_index_of() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | select name, index_of(name, \"li\") as pos",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pos"));
+}
+
+#[test]
+fn query_function_starts_with() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | select name, starts_with(name, \"A\") as starts_a",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("starts_a"));
+}
+
+#[test]
+fn query_function_ends_with() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | select name, ends_with(name, \"e\") as ends_e",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ends_e"));
+}
+
+#[test]
+fn query_function_reverse() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | select reverse(name) as reversed | limit 1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ecilA"));
+}
+
+#[test]
+fn query_function_repeat() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | select repeat(\"*\", 3) as stars | limit 1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("***"));
+}
+
+#[test]
+fn query_function_pad_left() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | select pad_left(to_string(age), 5, \"0\") as padded | limit 1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("00030"));
+}
+
+#[test]
+fn query_function_pad_right() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | select pad_right(name, 10, \".\") as padded | limit 1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice....."));
+}
+
+#[test]
+fn query_function_rindex_of() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(&input, r#"[{"text": "hello world hello"}]"#).unwrap();
+
+    dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | select rindex_of(text, \"hello\") as pos",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("12"));
+}
+
+// ============================================================
+// Combined feature tests
+// ============================================================
+
+#[test]
+fn unique_with_add_field_and_filter() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "age": 30, "city": "Seoul"},
+          {"name": "Bob", "age": 25, "city": "Busan"},
+          {"name": "Charlie", "age": 30, "city": "Seoul"},
+          {"name": "Diana", "age": 28, "city": "Incheon"}
+        ]"#,
+    )
+    .unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--unique-by",
+            "city",
+            "--add-field",
+            "double_age = age * 2",
+            "--filter",
+            "age >= 28",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("double_age"));
+}
+
+#[test]
+fn map_with_select_and_sort() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--map",
+            "name = upper(name)",
+            "--select",
+            "name, age",
+            "--sort-by",
+            "age",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("BOB"));
+}
+
+#[test]
+fn in_operator_with_sort_and_select() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where role in (\"engineer\") | select name, score | sort score desc",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Diana"))
+        .stdout(predicate::str::contains("Alice"));
+}
+
+#[test]
+fn ini_to_yaml_conversion() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.ini");
+    fs::write(&input, "[app]\nname = myapp\nversion = 1.0\n").unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "yaml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("app"))
+        .stdout(predicate::str::contains("myapp"));
+}
+
+#[test]
+fn properties_to_yaml_conversion() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("config.properties");
+    fs::write(&input, "key1=value1\nkey2=value2\n").unwrap();
+
+    dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "yaml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("key1"))
+        .stdout(predicate::str::contains("value1"));
+}
+
+#[test]
+fn matches_with_in_operator_combined() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name matches \"^[A-B]\" and role in (\"engineer\", \"designer\") | select name, role",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+#[test]
+fn json_output_options_with_filter() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--sort-keys",
+            "--indent",
+            "2",
+            "--filter",
+            "age > 30",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Charlie"));
+}
+
+#[test]
+fn string_functions_in_where_with_starts_with_operator() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[] | where name starts_with \"A\" | select name",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob").not());
+}
+
+#[test]
+fn add_field_with_string_functions() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/employees.json",
+            "-f",
+            "json",
+            "--add-field",
+            "upper_name = upper(name)",
+            "--add-field",
+            "name_len = length(name)",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("upper_name"))
+        .stdout(predicate::str::contains("ALICE"))
+        .stdout(predicate::str::contains("name_len"));
+}
+
+#[test]
+fn unique_with_csv_to_json_conversion() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.csv");
+    fs::write(
+        &input,
+        "name,city\nAlice,Seoul\nBob,Busan\nAlice,Seoul\nCharlie,Seoul\n",
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["convert", input.to_str().unwrap(), "-f", "json", "--unique"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(stdout.matches("Alice").count(), 1);
+}
+
+#[test]
+fn slice_with_filter_pipeline() {
+    dkit()
+        .args(&[
+            "query",
+            "tests/fixtures/employees.json",
+            ".[0:3] | where age > 25 | select name",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Charlie"));
+}

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -60,6 +60,12 @@ dkit convert --from <FORMAT> --to <FORMAT>  # stdin 사용 시
 | `--sort-order <ORDER>` | | 정렬 방향 (`asc`, `desc`) | `asc` |
 | `--head <N>` | | 처음 N개 레코드만 출력 | |
 | `--tail <N>` | | 마지막 N개 레코드만 출력 | |
+| `--unique` | | 전체 레코드 기준 중복 제거 | false |
+| `--unique-by <FIELD>` | | 특정 필드 기준 중복 제거 (첫 번째 유지) | |
+| `--add-field <EXPR>` | | 계산 필드 추가 (여러 번 사용 가능, e.g. `total = price * qty`) | |
+| `--map <EXPR>` | | 기존 필드 값 변환 (여러 번 사용 가능, e.g. `name = upper(name)`) | |
+| `--indent <INDENT>` | | JSON 들여쓰기 (숫자: 스페이스 수, `tab`: 탭 문자) | 2 |
+| `--sort-keys` | | JSON 객체 키를 알파벳순으로 정렬 | false |
 | `--dry-run` | | 미리보기 모드 (파일 생성 없이 stdout으로 출력) | false |
 | `--dry-run-limit <N>` | | 미리보기 시 출력 레코드 수 | 10 |
 
@@ -146,6 +152,34 @@ dkit convert data.csv --to json --filter 'status == "active"' --head 10
 dkit convert huge.json --to csv -o output.csv --dry-run         # 파일 생성 없이 미리보기
 dkit convert data.json --to csv --dry-run --dry-run-limit 5     # 처음 5개 레코드만 미리보기
 
+# 중복 제거
+dkit convert data.json --to csv --unique                 # 전체 레코드 기준 중복 제거
+dkit convert data.json --to csv --unique-by email        # email 기준 중복 제거
+
+# 계산 필드 추가 (--add-field)
+dkit convert data.json --to json --add-field 'total = price * quantity'
+dkit convert data.csv --to json --add-field 'greeting = name + " from " + city'
+dkit convert data.json --to csv --add-field 'double_age = age * 2' --add-field 'label = upper(name)'
+
+# 필드 값 변환 (--map)
+dkit convert data.json --to json --map 'name = upper(name)'
+dkit convert data.csv --to json --map 'email = lower(email)' --map 'name = trim(name)'
+
+# JSON 출력 옵션
+dkit convert data.csv --to json --indent 4               # 4-스페이스 들여쓰기
+dkit convert data.csv --to json --indent tab              # 탭 들여쓰기
+dkit convert data.csv --to json --sort-keys               # 키 알파벳순 정렬
+dkit convert data.csv --to json --compact --sort-keys      # 한 줄 + 키 정렬
+
+# .ini / .cfg 포맷 변환
+dkit convert config.ini --to json                        # INI → JSON
+dkit convert config.json --to ini -o config.ini          # JSON → INI
+dkit convert config.cfg --to yaml                        # CFG → YAML
+
+# .properties 포맷 변환
+dkit convert app.properties --to json                    # properties → JSON
+dkit convert config.json --to properties -o app.properties  # JSON → properties
+
 # .env 포맷 변환
 dkit convert .env --to json                              # .env → JSON
 dkit convert config.json --to env -o .env                # JSON → .env
@@ -197,6 +231,8 @@ dkit query <INPUT> '<QUERY>' [OPTIONS]
 |------|-----------|
 | 비교 | `==`, `!=`, `>`, `<`, `>=`, `<=` |
 | 문자열 | `contains`, `starts_with`, `ends_with` |
+| 멤버십 | `in (v1, v2, ...)`, `not in (v1, v2, ...)` |
+| 정규식 | `matches "pattern"`, `not matches "pattern"` |
 | 논리 | `and`, `or` |
 
 ### Options
@@ -214,6 +250,20 @@ dkit query data.json '.users[0].name'
 dkit query data.json '.users[] | where age > 30'
 dkit query data.json '.users[] | where age > 30 | select name, email'
 dkit query users.csv '.rows[] | where age > 30' --to json -o filtered.json
+
+# 배열 슬라이싱 / 와일드카드
+dkit query data.json '.[0:3]'                    # 처음 3개 요소
+dkit query data.json '.[-2:]'                    # 마지막 2개 요소
+dkit query data.json '.[::2]'                    # 짝수 인덱스 요소
+dkit query data.json '.[*].name'                 # 모든 요소의 name 필드
+
+# IN / NOT IN 연산자
+dkit query data.json '.[] | where status in ("active", "pending")'
+dkit query data.json '.[] | where category not in ("deleted", "archived")'
+
+# matches 정규식 연산자
+dkit query data.json '.[] | where name matches "^[A-C]"'
+dkit query data.json '.[] | where email not matches "@test\\.com$"'
 ```
 
 ## view
@@ -250,6 +300,12 @@ dkit view <INPUT> [OPTIONS]
 | `--agg <EXPR>` | 집계 함수 | |
 | `--filter <EXPR>` | 필터 표현식 | |
 | `--sort-by <FIELD>` | 정렬 기준 필드 | |
+| `--head <N>` | 처음 N개 레코드만 출력 | |
+| `--tail <N>` | 마지막 N개 레코드만 출력 | |
+| `--unique` | 전체 레코드 기준 중복 제거 | false |
+| `--unique-by <FIELD>` | 특정 필드 기준 중복 제거 | |
+| `--add-field <EXPR>` | 계산 필드 추가 (여러 번 사용 가능) | |
+| `--map <EXPR>` | 필드 값 변환 (여러 번 사용 가능) | |
 
 ### Examples
 
@@ -286,8 +342,19 @@ dkit view data.json --select 'name, email'       # 특정 필드만 표시
 dkit view sales.csv --group-by category --agg 'count(), sum(amount)'  # 집계 테이블
 dkit view data.csv --select 'name, score' --filter 'score > 80' --sort-by score
 
+# 중복 제거
+dkit view data.csv --unique-by email             # email 기준 유니크 행만 표시
+
+# 필드 추가/변환
+dkit view data.json --add-field 'total = price * qty'    # 계산 필드 추가
+dkit view data.csv --map 'name = upper(name)'            # 필드 값 변환
+
 # .env 파일 보기
 dkit view .env                                   # .env 파일 테이블로 보기
+
+# .ini / .properties 파일 보기
+dkit view config.ini                             # INI 파일 보기
+dkit view app.properties                         # Properties 파일 보기
 ```
 
 ## stats

--- a/docs/query-syntax.md
+++ b/docs/query-syntax.md
@@ -19,6 +19,17 @@ dkit query data.json '.users[0].name'    # 배열 요소의 필드
 # 배열 이터레이션 (모든 요소)
 dkit query data.json '.users[]'
 dkit query data.json '.users[].name'     # 모든 요소의 name 필드
+
+# 배열 와일드카드
+dkit query data.json '.[*].name'         # [*]는 []와 동일
+
+# 배열 슬라이싱
+dkit query data.json '.[0:3]'            # 처음 3개 요소 (인덱스 0, 1, 2)
+dkit query data.json '.[2:]'             # 인덱스 2부터 끝까지
+dkit query data.json '.[:5]'             # 처음 5개 요소
+dkit query data.json '.[-2:]'            # 마지막 2개 요소
+dkit query data.json '.[::2]'            # 짝수 인덱스 요소 (step=2)
+dkit query data.json '.[1:5:2]'          # 인덱스 1~4 중 step=2
 ```
 
 ## Pipeline
@@ -52,6 +63,32 @@ dkit query data.json '.users[] | where age > 30 | select name, email | sort name
 | `starts_with` | ~로 시작 | `where name starts_with "A"` |
 | `ends_with` | ~로 끝남 | `where file ends_with ".json"` |
 
+### Membership Operators (IN / NOT IN)
+
+값이 목록에 포함되는지 확인한다.
+
+```bash
+# IN — 값이 목록에 포함
+dkit query data.json '.users[] | where city in ("Seoul", "Busan")'
+dkit query data.json '.[] | where status in ("active", "pending", "done")'
+
+# NOT IN — 값이 목록에 미포함
+dkit query data.json '.users[] | where status not in ("deleted", "archived")'
+```
+
+### Regex Operator (matches)
+
+정규식 패턴으로 문자열을 매칭한다.
+
+```bash
+# matches — 정규식 매칭
+dkit query data.json '.users[] | where name matches "^[A-C]"'
+dkit query data.json '.[] | where email matches "@gmail\\.com$"'
+
+# not matches — 정규식 비매칭
+dkit query data.json '.users[] | where name not matches "^test"'
+```
+
 ### Logical Operators
 
 ```bash
@@ -60,6 +97,10 @@ dkit query data.json '.users[] | where age > 25 and city == "Seoul"'
 
 # OR
 dkit query data.json '.users[] | where role == "admin" or role == "manager"'
+
+# 복합 조합
+dkit query data.json '.users[] | where city in ("Seoul", "Busan") and age > 25'
+dkit query data.json '.users[] | where name matches "^A" and role in ("engineer", "manager")'
 ```
 
 ## select — Column Selection
@@ -240,6 +281,14 @@ dkit query data.csv '.[] | select upper(name) as NAME, round(price, 2) as price_
 | `concat(a, b, ...)` | 문자열 합치기 | `concat(first, " ", last)` |
 | `replace(s, from, to)` | 문자열 치환 | `replace(name, "old", "new")` |
 | `split(s, sep)` | 문자열 분리 (배열 반환) | `split(tags, ",")` |
+| `index_of(s, substr)` | 부분 문자열 위치 반환 (-1 if not found) | `index_of(email, "@")` |
+| `rindex_of(s, substr)` | 마지막 위치 반환 | `rindex_of(path, "/")` |
+| `starts_with(s, prefix)` | 접두사 확인 (Boolean) | `starts_with(name, "Dr.")` |
+| `ends_with(s, suffix)` | 접미사 확인 (Boolean) | `ends_with(file, ".json")` |
+| `reverse(s)` | 문자열 뒤집기 | `reverse(name)` |
+| `repeat(s, n)` | 문자열 반복 | `repeat("*", 5)` |
+| `pad_left(s, width, char)` | 왼쪽 패딩 | `pad_left(to_string(id), 5, "0")` |
+| `pad_right(s, width, char)` | 오른쪽 패딩 | `pad_right(name, 10, ".")` |
 
 ### 수학 함수
 
@@ -318,10 +367,12 @@ dkit query sales.csv '.rows[] | where region == "KR"' --to json -o korea.json
 ```
 query       = path ( "|" operation )*
 path        = "." segment*
-segment     = field_access | index_access | iterate
+segment     = field_access | index_access | iterate | wildcard | slice
 field_access = IDENTIFIER ( "." IDENTIFIER )*
 index_access = "[" INTEGER "]"
 iterate     = "[" "]"
+wildcard    = "[" "*" "]"
+slice       = "[" [ INTEGER ] ":" [ INTEGER ] [ ":" INTEGER ] "]"
 
 operation   = where_op | select_op | sort_op | limit_op
             | count_op | sum_op | avg_op | min_op | max_op | distinct_op
@@ -346,9 +397,14 @@ agg_func    = "count" | "sum" | "avg" | "min" | "max"
 condition   = comparison ( logic_op comparison )*
 comparison  = IDENTIFIER compare_op value
             | IDENTIFIER string_op STRING
+            | IDENTIFIER "in" "(" value_list ")"
+            | IDENTIFIER "not" "in" "(" value_list ")"
+            | IDENTIFIER "matches" STRING
+            | IDENTIFIER "not" "matches" STRING
 compare_op  = "==" | "!=" | ">" | "<" | ">=" | "<="
 string_op   = "contains" | "starts_with" | "ends_with"
 logic_op    = "and" | "or"
+value_list  = value ( "," value )*
 
 value       = STRING | NUMBER | "true" | "false" | "null"
 ```

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -104,6 +104,8 @@ pub struct FormatOptions {
     pub no_header: bool,              // CSV without header
     pub pretty: bool,                 // Pretty-print output
     pub compact: bool,                // Compact output (JSON)
+    pub indent: Option<String>,       // JSON indentation ("2", "4", "tab")
+    pub sort_keys: bool,              // Sort JSON object keys alphabetically
     pub flow_style: bool,             // YAML inline style
     pub root_element: Option<String>, // XML root element name
 }
@@ -207,6 +209,30 @@ pub struct FormatOptions {
 - `list_tables()`: 테이블 이름 목록 반환
 - **제한**: 입력 전용 (쓰기 불가)
 
+### INI/CFG ↔ Value
+
+- `ini` 크레이트 기반 파서 사용
+- 섹션 기반 구조: `[section]` → 중첩 `Object`
+- 데이터 모델: `Value::Object(IndexMap<String, Value::Object>)` (섹션 → 키-값)
+- 섹션 없는 키는 최상위 Object에 포함
+- 주석: `;` 또는 `#`으로 시작하는 줄 (무시)
+- 읽기: 섹션명이 최상위 키, 각 섹션 내 키-값이 중첩 Object
+- 쓰기: 중첩 Object → `[section]` + `key=value` 형식
+- 포맷 자동 감지: `.ini`, `.cfg` 확장자
+
+### .properties ↔ Value
+
+- Java `.properties` 파일 포맷 지원
+- `key=value` 또는 `key: value` 또는 `key value` 형식
+- 주석: `#` 또는 `!`로 시작하는 줄 (무시)
+- `\` 줄 연속 (multiline value) 지원
+- 데이터 모델: flat `Value::Object` (모든 값은 `Value::String`)
+- 키의 `.` 구분자는 그대로 유지 (flat key)
+- 읽기: `Value::Object(IndexMap<String, Value>)` 반환
+- 쓰기: `key=value` 형식 출력, 특수문자 포함 시 이스케이프
+- 포맷 자동 감지: `.properties` 확장자
+- **참고**: 키에 `.`이 포함된 경우 쿼리 시 중첩 구조로 해석되므로, `.` 없는 단순 키 사용 권장
+
 ### .env ↔ Value
 
 - `KEY=VALUE` 라인 기반 포맷 (환경 변수 설정 파일)
@@ -266,18 +292,25 @@ pub struct EncodingOptions {
 ```
 query       = path ("|" operation)*
 path        = "." segment*
-segment     = field | index | iterate
+segment     = field | index | iterate | wildcard | slice
 field       = identifier
 index       = "[" integer "]"
 iterate     = "[]"
+wildcard    = "[" "*" "]"
+slice       = "[" [integer] ":" [integer] [":" integer] "]"
 operation   = where | select | sort | limit
 where       = "where" condition
 condition   = expr compare_op expr (logic_op expr compare_op expr)*
+            | expr "in" "(" value_list ")"
+            | expr "not" "in" "(" value_list ")"
+            | expr "matches" string_literal
+            | expr "not" "matches" string_literal
 select      = "select" field ("," field)*
 sort        = "sort" field ["desc"]
 limit       = "limit" integer
 compare_op  = "==" | "!=" | ">" | "<" | ">=" | "<="
 logic_op    = "and" | "or"
+value_list  = value ("," value)*
 expr        = path | string_literal | number_literal
 ```
 


### PR DESCRIPTION
## Summary
- Add 60 integration tests covering all v1.2.0 features: `--unique`/`--unique-by`, `--add-field`, `--map`, array slicing/wildcard queries, INI/properties formats, `IN`/`NOT IN` operators, `matches` regex operator, JSON output options (`--indent`, `--sort-keys`, `--compact`), and new string functions
- Update documentation (README.md, cli-spec.md, query-syntax.md, technical-spec.md) with new formats, operators, functions, and EBNF grammar

Closes #200

## Test plan
- [x] All 60 new integration tests pass (`cargo test --test v120_integration_test`)
- [x] Full test suite passes (`cargo test` — 633+ tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

https://claude.ai/code/session_01BjDXEy3SfnKbCjgJxP9nxU