### PR TITLE
feat: add --explode flag for unnesting array fields into rows

### DIFF
--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -175,6 +175,10 @@ pub enum Commands {
         #[arg(long = "map", value_name = "EXPR")]
         map_field: Vec<String>,
 
+        /// Explode (unnest) an array field into individual rows. Can be used multiple times
+        #[arg(long, value_name = "FIELD")]
+        explode: Vec<String>,
+
         /// Parquet compression codec (none, snappy, gzip, zstd)
         #[arg(long, value_name = "CODEC", default_value = "none")]
         compression: String,
@@ -394,6 +398,10 @@ pub enum Commands {
         /// Transform an existing field's value (e.g. 'name = upper(name)'). Can be used multiple times
         #[arg(long = "map", value_name = "EXPR")]
         map_field: Vec<String>,
+
+        /// Explode (unnest) an array field into individual rows. Can be used multiple times
+        #[arg(long, value_name = "FIELD")]
+        explode: Vec<String>,
 
         /// Watch input file for changes and auto re-run
         #[arg(long)]

--- a/dkit-cli/src/commands/mod.rs
+++ b/dkit-cli/src/commands/mod.rs
@@ -250,6 +250,8 @@ pub struct DataFilterOptions {
     pub add_field: Vec<String>,
     /// 기존 필드 값 변환 표현식 목록 (예: "name = upper(name)")
     pub map_field: Vec<String>,
+    /// 배열 필드를 개별 행으로 펼침 (unnest/flatten)
+    pub explode: Vec<String>,
 }
 
 /// --agg 문자열을 GroupAggregate 벡터로 파싱한다.
@@ -382,6 +384,13 @@ pub fn apply_data_filters(
             )
         })?;
         operations.push(Operation::Where(condition));
+    }
+
+    // 1b. explode (배열 필드 펼침)
+    for field in &opts.explode {
+        operations.push(Operation::Explode {
+            field: field.clone(),
+        });
     }
 
     // 2. add-field (계산 필드 추가)

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -323,6 +323,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             unique_by,
             add_field,
             map_field,
+            explode,
             compression,
             row_group_size,
             chunk_size,
@@ -376,6 +377,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         unique_by: unique_by.clone(),
                         add_field: add_field.clone(),
                         map_field: map_field.clone(),
+                        explode: explode.clone(),
                     },
                     parquet_opts: ParquetWriteOptions {
                         compression: compression.clone(),
@@ -458,6 +460,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             unique_by,
             add_field,
             map_field,
+            explode,
             watch,
             watch_paths,
         } => {
@@ -503,6 +506,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                         unique_by: unique_by.clone(),
                         add_field: add_field.clone(),
                         map_field: map_field.clone(),
+                        explode: explode.clone(),
                     },
                 })
             };

--- a/dkit-core/src/query/filter.rs
+++ b/dkit-core/src/query/filter.rs
@@ -38,6 +38,7 @@ fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitErr
         Operation::UniqueBy { field } => apply_unique_by(value, field),
         Operation::AddField { name, expr } => apply_add_field(value, name, expr),
         Operation::MapField { name, expr } => apply_map_field(value, name, expr),
+        Operation::Explode { field } => apply_explode(value, field),
     }
 }
 
@@ -502,6 +503,51 @@ fn apply_map_field(value: Value, name: &str, expr: &Expr) -> Result<Value, DkitE
         }
         _ => Err(DkitError::QueryError(
             "map requires an array or object input".to_string(),
+        )),
+    }
+}
+
+/// explode: 배열 필드를 개별 행으로 펼침 (unnest/flatten)
+/// 예: [{name:"a", tags:["x","y"]}] → [{name:"a", tags:"x"}, {name:"a", tags:"y"}]
+/// 빈 배열인 경우 해당 레코드 제외
+fn apply_explode(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut result = Vec::new();
+            for item in arr {
+                match item {
+                    Value::Object(ref map) => {
+                        match map.get(field) {
+                            Some(Value::Array(elements)) => {
+                                if elements.is_empty() {
+                                    // 빈 배열: 해당 레코드 제외
+                                    continue;
+                                }
+                                for element in elements {
+                                    let mut new_map = map.clone();
+                                    new_map.insert(field.to_string(), element.clone());
+                                    result.push(Value::Object(new_map));
+                                }
+                            }
+                            Some(_) => {
+                                // 배열이 아닌 값: 그대로 유지
+                                result.push(item.clone());
+                            }
+                            None => {
+                                // 필드가 없는 경우: 해당 레코드 제외
+                                continue;
+                            }
+                        }
+                    }
+                    other => {
+                        result.push(other);
+                    }
+                }
+            }
+            Ok(Value::Array(result))
+        }
+        _ => Err(DkitError::QueryError(
+            "explode requires an array input".to_string(),
         )),
     }
 }
@@ -2631,5 +2677,109 @@ mod tests {
         .unwrap();
         let arr = result.as_array().unwrap();
         assert_eq!(arr.len(), 2); // Alice (30, Seoul), Charlie (35, Seoul)
+    }
+
+    // --- explode tests ---
+
+    fn sample_with_tags() -> Value {
+        Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Alice".to_string()));
+                m.insert(
+                    "tags".to_string(),
+                    Value::Array(vec![
+                        Value::String("x".to_string()),
+                        Value::String("y".to_string()),
+                    ]),
+                );
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Bob".to_string()));
+                m.insert(
+                    "tags".to_string(),
+                    Value::Array(vec![Value::String("z".to_string())]),
+                );
+                Value::Object(m)
+            },
+        ])
+    }
+
+    #[test]
+    fn test_explode_basic() {
+        let result = apply_explode(sample_with_tags(), "tags").unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(
+            arr[0].as_object().unwrap()["name"],
+            Value::String("Alice".to_string())
+        );
+        assert_eq!(
+            arr[0].as_object().unwrap()["tags"],
+            Value::String("x".to_string())
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap()["tags"],
+            Value::String("y".to_string())
+        );
+        assert_eq!(
+            arr[2].as_object().unwrap()["name"],
+            Value::String("Bob".to_string())
+        );
+        assert_eq!(
+            arr[2].as_object().unwrap()["tags"],
+            Value::String("z".to_string())
+        );
+    }
+
+    #[test]
+    fn test_explode_empty_array_excluded() {
+        let value = Value::Array(vec![{
+            let mut m = IndexMap::new();
+            m.insert("name".to_string(), Value::String("Alice".to_string()));
+            m.insert("tags".to_string(), Value::Array(vec![]));
+            Value::Object(m)
+        }]);
+        let result = apply_explode(value, "tags").unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_explode_missing_field_excluded() {
+        let value = Value::Array(vec![{
+            let mut m = IndexMap::new();
+            m.insert("name".to_string(), Value::String("Alice".to_string()));
+            Value::Object(m)
+        }]);
+        let result = apply_explode(value, "tags").unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_explode_non_array_field_kept() {
+        let value = Value::Array(vec![{
+            let mut m = IndexMap::new();
+            m.insert("name".to_string(), Value::String("Alice".to_string()));
+            m.insert("tags".to_string(), Value::String("single".to_string()));
+            Value::Object(m)
+        }]);
+        let result = apply_explode(value, "tags").unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(
+            arr[0].as_object().unwrap()["tags"],
+            Value::String("single".to_string())
+        );
+    }
+
+    #[test]
+    fn test_explode_non_array_input_error() {
+        let value = Value::String("not an array".to_string());
+        let result = apply_explode(value, "tags");
+        assert!(result.is_err());
     }
 }

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -74,6 +74,8 @@ pub enum Operation {
     AddField { name: String, expr: Expr },
     /// 기존 필드 값 변환: `--map 'name = upper(name)'`
     MapField { name: String, expr: Expr },
+    /// 배열 필드를 개별 행으로 펼침 (unnest/flatten): `--explode tags`
+    Explode { field: String },
 }
 
 /// GROUP BY 집계 연산 정의


### PR DESCRIPTION
## Summary
- Add `--explode` flag to `convert` and `view` subcommands that expands array fields into individual rows
- Each array element generates a new record with all other fields duplicated
- Multiple `--explode` flags can be chained for cross-product expansion
- Empty arrays and missing fields exclude the record; non-array fields are kept as-is

## Usage
```bash
# {name: "a", tags: ["x","y"]} → [{name:"a", tags:"x"}, {name:"a", tags:"y"}]
dkit convert data.json -f json --explode tags

# Multiple fields
dkit convert data.json -f csv --explode tags --explode categories
```

## Test plan
- [x] Unit tests for basic explode, empty array, missing field, non-array field, non-array input error
- [x] Manual E2E testing with JSON input/output
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] All 638+ tests pass

Closes #193

https://claude.ai/code/session_01136MaWRcWiTwTDgwKGcHVy