### PR TITLE
feat: add HCL format Reader/Writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,7 @@ dependencies = [
  "calamine",
  "criterion",
  "csv",
+ "hcl-rs",
  "indexmap",
  "jsonschema",
  "parquet",
@@ -1031,6 +1032,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1164,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hcl-edit"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e563477c1d5727912396fdca1ec56c33a12e2d4a4bd16702f8588348689a9e6"
+dependencies = [
+ "fnv",
+ "hcl-primitives",
+ "pratt",
+ "vecmap-rs",
+ "winnow",
+]
+
+[[package]]
+name = "hcl-primitives"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829a11d304c89e2cfe0dbb494a686bbe2b48ade17705c62cd1957b04aa4630f6"
+dependencies = [
+ "itoa",
+ "kstring",
+ "ryu",
+ "serde",
+ "unicode-ident",
+]
+
+[[package]]
+name = "hcl-rs"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a381780225f5991adbb268cac33939382ac44f98d6e8e639e06ba0ffe3378e5a"
+dependencies = [
+ "hcl-edit",
+ "hcl-primitives",
+ "indexmap",
+ "itoa",
+ "serde",
+ "vecmap-rs",
 ]
 
 [[package]]
@@ -1463,6 +1510,16 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1992,6 +2049,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "pratt"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e0a4425d076f0718b820673a38fbf3747080c61017eeb0dd79bc7e472b8bb8"
 
 [[package]]
 name = "predicates"
@@ -2727,6 +2790,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vecmap-rs"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9758649b51083aa8008666f41c23f05abca1766aad4cc447b195dd83ef1297b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "version_check"

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -25,7 +25,8 @@ msgpack = ["dkit-core/msgpack"]
 excel = ["dkit-core/excel"]
 sqlite = ["dkit-core/sqlite"]
 parquet = ["dkit-core/parquet", "dep:arrow", "dep:parquet-impl", "dep:bytes"]
-all = ["xml", "msgpack", "excel", "sqlite", "parquet"]
+hcl = ["dkit-core/hcl"]
+all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl"]
 
 [dependencies]
 dkit-core = { version = "1.2.0", path = "../dkit-core" }

--- a/dkit-cli/src/commands/convert.rs
+++ b/dkit-cli/src/commands/convert.rs
@@ -11,6 +11,7 @@ use super::{
 };
 use dkit_core::format::csv::{CsvReader, CsvWriter};
 use dkit_core::format::env::{EnvReader, EnvWriter};
+use dkit_core::format::hcl::{HclReader, HclWriter};
 use dkit_core::format::html::HtmlWriter;
 use dkit_core::format::ini::{IniReader, IniWriter};
 use dkit_core::format::json::{JsonReader, JsonWriter};
@@ -31,6 +32,7 @@ use dkit_core::value::Value;
 const SUPPORTED_EXTENSIONS: &[&str] = &[
     "json", "jsonl", "ndjson", "csv", "tsv", "yaml", "yml", "toml", "env", "ini", "cfg", "xml",
     "msgpack", "xlsx", "xls", "xlsm", "xlsb", "ods", "db", "sqlite", "sqlite3", "parquet", "pq",
+    "hcl", "tf", "tfvars",
 ];
 
 pub struct ConvertArgs<'a> {
@@ -561,6 +563,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -629,6 +632,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Env => EnvWriter.write(value),
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
+        Format::Hcl => HclWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/diff.rs
+++ b/dkit-cli/src/commands/diff.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use dkit_core::format::csv::CsvReader;
 use dkit_core::format::env::EnvReader;
+use dkit_core::format::hcl::HclReader;
 use dkit_core::format::ini::IniReader;
 use dkit_core::format::json::JsonReader;
 use dkit_core::format::jsonl::JsonlReader;
@@ -218,6 +219,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")

--- a/dkit-cli/src/commands/flatten.rs
+++ b/dkit-cli/src/commands/flatten.rs
@@ -11,6 +11,7 @@ use super::{
 };
 use dkit_core::format::csv::{CsvReader, CsvWriter};
 use dkit_core::format::env::{EnvReader, EnvWriter};
+use dkit_core::format::hcl::{HclReader, HclWriter};
 use dkit_core::format::html::HtmlWriter;
 use dkit_core::format::ini::{IniReader, IniWriter};
 use dkit_core::format::json::{JsonReader, JsonWriter};
@@ -482,6 +483,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -552,6 +554,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Env => EnvWriter.write(value),
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
+        Format::Hcl => HclWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/merge.rs
+++ b/dkit-cli/src/commands/merge.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use dkit_core::format::csv::{CsvReader, CsvWriter};
 use dkit_core::format::env::{EnvReader, EnvWriter};
+use dkit_core::format::hcl::{HclReader, HclWriter};
 use dkit_core::format::html::HtmlWriter;
 use dkit_core::format::ini::{IniReader, IniWriter};
 use dkit_core::format::json::{JsonReader, JsonWriter};
@@ -199,6 +200,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -227,6 +229,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Env => EnvWriter.write(value),
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
+        Format::Hcl => HclWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/query.rs
+++ b/dkit-cli/src/commands/query.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use dkit_core::format::csv::CsvReader;
 use dkit_core::format::env::{EnvReader, EnvWriter};
+use dkit_core::format::hcl::{HclReader, HclWriter};
 use dkit_core::format::html::HtmlWriter;
 use dkit_core::format::ini::{IniReader, IniWriter};
 use dkit_core::format::json::{JsonReader, JsonWriter};
@@ -184,6 +185,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -221,6 +223,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Env => EnvWriter.write(value),
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
+        Format::Hcl => HclWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/sample.rs
+++ b/dkit-cli/src/commands/sample.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use dkit_core::format::csv::{CsvReader, CsvWriter};
 use dkit_core::format::env::{EnvReader, EnvWriter};
+use dkit_core::format::hcl::{HclReader, HclWriter};
 use dkit_core::format::html::HtmlWriter;
 use dkit_core::format::ini::{IniReader, IniWriter};
 use dkit_core::format::json::{JsonReader, JsonWriter};
@@ -323,6 +324,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -393,6 +395,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Env => EnvWriter.write(value),
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
+        Format::Hcl => HclWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/schema.rs
+++ b/dkit-cli/src/commands/schema.rs
@@ -8,6 +8,7 @@ use super::{
 use anyhow::{bail, Result};
 use dkit_core::format::csv::CsvReader;
 use dkit_core::format::env::EnvReader;
+use dkit_core::format::hcl::HclReader;
 use dkit_core::format::ini::IniReader;
 use dkit_core::format::json::JsonReader;
 use dkit_core::format::jsonl::JsonlReader;
@@ -322,6 +323,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")

--- a/dkit-cli/src/commands/stats.rs
+++ b/dkit-cli/src/commands/stats.rs
@@ -9,6 +9,7 @@ use super::{
 use anyhow::{bail, Context, Result};
 use dkit_core::format::csv::CsvReader;
 use dkit_core::format::env::EnvReader;
+use dkit_core::format::hcl::HclReader;
 use dkit_core::format::ini::IniReader;
 use dkit_core::format::json::JsonReader;
 use dkit_core::format::jsonl::JsonlReader;
@@ -880,6 +881,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")

--- a/dkit-cli/src/commands/validate.rs
+++ b/dkit-cli/src/commands/validate.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use dkit_core::format::csv::CsvReader;
 use dkit_core::format::env::EnvReader;
+use dkit_core::format::hcl::HclReader;
 use dkit_core::format::ini::IniReader;
 use dkit_core::format::json::JsonReader;
 use dkit_core::format::jsonl::JsonlReader;
@@ -197,6 +198,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")

--- a/dkit-cli/src/commands/view.rs
+++ b/dkit-cli/src/commands/view.rs
@@ -12,6 +12,7 @@ use crate::output::table::{render_table, TableOptions};
 use dkit_core::format::csv::CsvReader;
 use dkit_core::format::csv::CsvWriter;
 use dkit_core::format::env::{EnvReader, EnvWriter};
+use dkit_core::format::hcl::{HclReader, HclWriter};
 use dkit_core::format::html::HtmlWriter;
 use dkit_core::format::ini::{IniReader, IniWriter};
 use dkit_core::format::json::{JsonReader, JsonWriter};
@@ -249,6 +250,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Env => EnvReader.read(content),
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
+        Format::Hcl => HclReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -277,6 +279,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Env => EnvWriter.write(value),
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
+        Format::Hcl => HclWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -17,7 +17,8 @@ msgpack = ["dep:rmp-serde"]
 excel = ["dep:calamine"]
 sqlite = ["dep:rusqlite"]
 parquet = ["dep:arrow", "dep:parquet-impl", "dep:bytes"]
-all = ["xml", "msgpack", "excel", "sqlite", "parquet"]
+hcl = ["dep:hcl-rs"]
+all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -35,6 +36,7 @@ rusqlite = { version = "0.31", features = ["bundled"], optional = true }
 arrow = { version = "53", default-features = false, features = ["prettyprint"], optional = true }
 parquet-impl = { package = "parquet", version = "53", default-features = false, features = ["arrow", "snap", "zstd"], optional = true }
 bytes = { version = "1", optional = true }
+hcl-rs = { version = "0.19", optional = true }
 jsonschema = { version = "0.17", default-features = false }
 rand = "0.8"
 regex = "1"

--- a/dkit-core/src/error.rs
+++ b/dkit-core/src/error.rs
@@ -1,7 +1,7 @@
 /// 지원하는 포맷 목록 (에러 메시지용)
 pub const SUPPORTED_FORMATS: &[&str] = &[
     "json", "jsonl", "csv", "tsv", "yaml", "yml", "toml", "env", "xml", "msgpack", "xlsx",
-    "sqlite", "parquet", "md", "html", "table",
+    "sqlite", "parquet", "hcl", "tf", "md", "html", "table",
 ];
 
 /// Compute Levenshtein edit distance between two strings.

--- a/dkit-core/src/format/hcl.rs
+++ b/dkit-core/src/format/hcl.rs
@@ -1,0 +1,478 @@
+use std::io::{Read, Write};
+
+use indexmap::IndexMap;
+
+use crate::format::{FormatReader, FormatWriter};
+use crate::value::Value;
+
+/// hcl::Value → 내부 Value 변환
+fn from_hcl_value(v: hcl::Value) -> Value {
+    match v {
+        hcl::Value::Null => Value::Null,
+        hcl::Value::Bool(b) => Value::Bool(b),
+        hcl::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::Integer(i)
+            } else if let Some(f) = n.as_f64() {
+                Value::Float(f)
+            } else {
+                Value::String(n.to_string())
+            }
+        }
+        hcl::Value::String(s) => Value::String(s),
+        hcl::Value::Array(arr) => Value::Array(arr.into_iter().map(from_hcl_value).collect()),
+        hcl::Value::Object(map) => {
+            let obj: IndexMap<String, Value> = map
+                .into_iter()
+                .map(|(k, v)| (k, from_hcl_value(v)))
+                .collect();
+            Value::Object(obj)
+        }
+    }
+}
+
+/// 내부 Value → hcl::Value 변환
+fn to_hcl_value(v: &Value) -> hcl::Value {
+    match v {
+        Value::Null => hcl::Value::Null,
+        Value::Bool(b) => hcl::Value::Bool(*b),
+        Value::Integer(n) => hcl::Value::Number((*n).into()),
+        Value::Float(f) => {
+            if let Some(n) = hcl::Number::from_f64(*f) {
+                hcl::Value::Number(n)
+            } else {
+                // NaN/Infinity → string
+                hcl::Value::String(f.to_string())
+            }
+        }
+        Value::String(s) => hcl::Value::String(s.clone()),
+        Value::Array(arr) => hcl::Value::Array(arr.iter().map(to_hcl_value).collect()),
+        Value::Object(map) => {
+            let hcl_map: hcl::Map<String, hcl::Value> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), to_hcl_value(v)))
+                .collect();
+            hcl::Value::Object(hcl_map)
+        }
+    }
+}
+
+/// HCL 포맷 Reader
+///
+/// HCL v2 문법을 파싱하여 내부 Value로 변환한다.
+/// 블록 구조는 중첩된 Object로 매핑된다.
+pub struct HclReader;
+
+impl FormatReader for HclReader {
+    fn read(&self, input: &str) -> anyhow::Result<Value> {
+        let hcl_val: hcl::Value =
+            hcl::from_str(input).map_err(|e| crate::error::DkitError::ParseError {
+                format: "HCL".to_string(),
+                source: Box::new(e),
+            })?;
+        Ok(from_hcl_value(hcl_val))
+    }
+
+    fn read_from_reader(&self, mut reader: impl Read) -> anyhow::Result<Value> {
+        let mut input = String::new();
+        reader
+            .read_to_string(&mut input)
+            .map_err(|e| crate::error::DkitError::ParseError {
+                format: "HCL".to_string(),
+                source: Box::new(e),
+            })?;
+        self.read(&input)
+    }
+}
+
+/// HCL 포맷 Writer
+///
+/// 내부 Value를 HCL 형식으로 직렬화한다.
+/// 최상위는 반드시 Object여야 한다. 다른 타입은 "data" 키로 감싼다.
+pub struct HclWriter;
+
+impl FormatWriter for HclWriter {
+    fn write(&self, value: &Value) -> anyhow::Result<String> {
+        let hcl_val = match value {
+            Value::Object(_) => to_hcl_value(value),
+            _ => {
+                let mut map = hcl::Map::new();
+                map.insert("data".to_string(), to_hcl_value(value));
+                hcl::Value::Object(map)
+            }
+        };
+        hcl::to_string(&hcl_val).map_err(|e| {
+            crate::error::DkitError::WriteError {
+                format: "HCL".to_string(),
+                source: Box::new(e),
+            }
+            .into()
+        })
+    }
+
+    fn write_to_writer(&self, value: &Value, mut writer: impl Write) -> anyhow::Result<()> {
+        let output = self.write(value)?;
+        writer
+            .write_all(output.as_bytes())
+            .map_err(|e| crate::error::DkitError::WriteError {
+                format: "HCL".to_string(),
+                source: Box::new(e),
+            })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- from_hcl_value 변환 테스트 ---
+
+    #[test]
+    fn test_convert_null() {
+        assert_eq!(from_hcl_value(hcl::Value::Null), Value::Null);
+    }
+
+    #[test]
+    fn test_convert_bool() {
+        assert_eq!(from_hcl_value(hcl::Value::Bool(true)), Value::Bool(true));
+        assert_eq!(from_hcl_value(hcl::Value::Bool(false)), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_convert_integer() {
+        assert_eq!(
+            from_hcl_value(hcl::Value::Number(42.into())),
+            Value::Integer(42)
+        );
+    }
+
+    #[test]
+    fn test_convert_float() {
+        let n = hcl::Number::from_f64(3.14).unwrap();
+        assert_eq!(from_hcl_value(hcl::Value::Number(n)), Value::Float(3.14));
+    }
+
+    #[test]
+    fn test_convert_string() {
+        assert_eq!(
+            from_hcl_value(hcl::Value::String("hello".to_string())),
+            Value::String("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn test_convert_array() {
+        let arr = hcl::Value::Array(vec![
+            hcl::Value::Number(1.into()),
+            hcl::Value::String("two".to_string()),
+            hcl::Value::Bool(true),
+        ]);
+        let v = from_hcl_value(arr);
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0], Value::Integer(1));
+        assert_eq!(arr[1], Value::String("two".to_string()));
+        assert_eq!(arr[2], Value::Bool(true));
+    }
+
+    #[test]
+    fn test_convert_object() {
+        let mut map = hcl::Map::new();
+        map.insert("name".to_string(), hcl::Value::String("dkit".to_string()));
+        map.insert("version".to_string(), hcl::Value::Number(1.into()));
+        let v = from_hcl_value(hcl::Value::Object(map));
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.get("name"), Some(&Value::String("dkit".to_string())));
+        assert_eq!(obj.get("version"), Some(&Value::Integer(1)));
+    }
+
+    // --- to_hcl_value 왕복 변환 테스트 ---
+
+    #[test]
+    fn test_roundtrip_primitives() {
+        let values = vec![
+            Value::Null,
+            Value::Bool(false),
+            Value::Integer(100),
+            Value::Float(2.718),
+            Value::String("test".to_string()),
+        ];
+        for v in values {
+            let hcl_v = to_hcl_value(&v);
+            let back = from_hcl_value(hcl_v);
+            assert_eq!(back, v);
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_complex() {
+        let mut map = IndexMap::new();
+        map.insert(
+            "key".to_string(),
+            Value::Array(vec![Value::Integer(1), Value::Integer(2)]),
+        );
+        let original = Value::Object(map);
+        let hcl_v = to_hcl_value(&original);
+        let back = from_hcl_value(hcl_v);
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn test_nan_converts_to_string() {
+        let hcl_v = to_hcl_value(&Value::Float(f64::NAN));
+        assert_eq!(hcl_v, hcl::Value::String("NaN".to_string()));
+    }
+
+    #[test]
+    fn test_infinity_converts_to_string() {
+        let hcl_v = to_hcl_value(&Value::Float(f64::INFINITY));
+        assert_eq!(hcl_v, hcl::Value::String("inf".to_string()));
+    }
+
+    // --- HclReader 테스트 ---
+
+    #[test]
+    fn test_reader_simple_attributes() {
+        let reader = HclReader;
+        let input = r#"
+name = "dkit"
+count = 42
+enabled = true
+"#;
+        let v = reader.read(input).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.get("name"), Some(&Value::String("dkit".to_string())));
+        assert_eq!(obj.get("count"), Some(&Value::Integer(42)));
+        assert_eq!(obj.get("enabled"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn test_reader_block_structure() {
+        let reader = HclReader;
+        let input = r#"
+resource "aws_instance" "example" {
+  ami           = "ami-12345678"
+  instance_type = "t2.micro"
+}
+"#;
+        let v = reader.read(input).unwrap();
+        let resource = v.as_object().unwrap().get("resource").unwrap();
+        let aws_instance = resource.as_object().unwrap().get("aws_instance").unwrap();
+        let example = aws_instance.as_object().unwrap().get("example").unwrap();
+        assert_eq!(
+            example.as_object().unwrap().get("ami"),
+            Some(&Value::String("ami-12345678".to_string()))
+        );
+        assert_eq!(
+            example.as_object().unwrap().get("instance_type"),
+            Some(&Value::String("t2.micro".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_reader_nested_blocks() {
+        let reader = HclReader;
+        let input = r#"
+resource "aws_instance" "web" {
+  ami = "ami-abc123"
+
+  tags = {
+    Name = "web-server"
+    Env  = "production"
+  }
+}
+"#;
+        let v = reader.read(input).unwrap();
+        let resource = v.as_object().unwrap().get("resource").unwrap();
+        let instance = resource
+            .as_object()
+            .unwrap()
+            .get("aws_instance")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .get("web")
+            .unwrap();
+        let tags = instance.as_object().unwrap().get("tags").unwrap();
+        assert_eq!(
+            tags.as_object().unwrap().get("Name"),
+            Some(&Value::String("web-server".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_reader_array_attribute() {
+        let reader = HclReader;
+        let input = r#"
+tags = ["a", "b", "c"]
+ports = [80, 443]
+"#;
+        let v = reader.read(input).unwrap();
+        let obj = v.as_object().unwrap();
+        let tags = obj.get("tags").unwrap().as_array().unwrap();
+        assert_eq!(tags.len(), 3);
+        assert_eq!(tags[0], Value::String("a".to_string()));
+        let ports = obj.get("ports").unwrap().as_array().unwrap();
+        assert_eq!(ports.len(), 2);
+        assert_eq!(ports[0], Value::Integer(80));
+    }
+
+    #[test]
+    fn test_reader_invalid_hcl() {
+        let reader = HclReader;
+        let result = reader.read("{ invalid hcl syntax !!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_reader_empty_input() {
+        let reader = HclReader;
+        let v = reader.read("").unwrap();
+        assert_eq!(v, Value::Object(IndexMap::new()));
+    }
+
+    #[test]
+    fn test_reader_from_reader() {
+        let reader = HclReader;
+        let input = b"name = \"test\"" as &[u8];
+        let v = reader.read_from_reader(input).unwrap();
+        assert_eq!(
+            v.as_object().unwrap().get("name"),
+            Some(&Value::String("test".to_string()))
+        );
+    }
+
+    // --- HclWriter 테스트 ---
+
+    #[test]
+    fn test_writer_simple_object() {
+        let writer = HclWriter;
+        let v = Value::Object({
+            let mut m = IndexMap::new();
+            m.insert("name".to_string(), Value::String("test".to_string()));
+            m.insert("count".to_string(), Value::Integer(42));
+            m
+        });
+        let output = writer.write(&v).unwrap();
+        assert!(output.contains("name"));
+        assert!(output.contains("\"test\""));
+        assert!(output.contains("42"));
+    }
+
+    #[test]
+    fn test_writer_wraps_non_object() {
+        let writer = HclWriter;
+        let output = writer.write(&Value::Integer(42)).unwrap();
+        assert!(output.contains("data = 42"));
+    }
+
+    #[test]
+    fn test_writer_wraps_array() {
+        let writer = HclWriter;
+        let v = Value::Array(vec![Value::Integer(1), Value::Integer(2)]);
+        let output = writer.write(&v).unwrap();
+        assert!(output.contains("data"));
+    }
+
+    #[test]
+    fn test_writer_nested_object() {
+        let writer = HclWriter;
+        let v = Value::Object({
+            let mut m = IndexMap::new();
+            m.insert(
+                "server".to_string(),
+                Value::Object({
+                    let mut inner = IndexMap::new();
+                    inner.insert("host".to_string(), Value::String("localhost".to_string()));
+                    inner.insert("port".to_string(), Value::Integer(8080));
+                    inner
+                }),
+            );
+            m
+        });
+        let output = writer.write(&v).unwrap();
+        assert!(output.contains("server"));
+        assert!(output.contains("localhost"));
+        assert!(output.contains("8080"));
+    }
+
+    #[test]
+    fn test_writer_to_writer() {
+        let writer = HclWriter;
+        let v = Value::Object({
+            let mut m = IndexMap::new();
+            m.insert("x".to_string(), Value::Integer(42));
+            m
+        });
+        let mut buf = Vec::new();
+        writer.write_to_writer(&v, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("x"));
+        assert!(output.contains("42"));
+    }
+
+    // --- 왕복 변환 테스트 (Reader → Writer → Reader) ---
+
+    #[test]
+    fn test_full_roundtrip() {
+        let hcl_input = r#"
+name = "dkit"
+version = 1
+enabled = true
+tags = ["cli", "data"]
+"#;
+        let reader = HclReader;
+        let writer = HclWriter;
+
+        let value = reader.read(hcl_input).unwrap();
+        let hcl_output = writer.write(&value).unwrap();
+        let value2 = reader.read(&hcl_output).unwrap();
+
+        assert_eq!(value, value2);
+    }
+
+    // --- 특수 케이스 ---
+
+    #[test]
+    fn test_unicode_string() {
+        let reader = HclReader;
+        let v = reader.read("emoji = \"🎉\"\nkorean = \"한글\"").unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.get("emoji"), Some(&Value::String("🎉".to_string())));
+        assert_eq!(obj.get("korean"), Some(&Value::String("한글".to_string())));
+    }
+
+    #[test]
+    fn test_negative_numbers() {
+        let reader = HclReader;
+        let v = reader.read("neg_int = -42\nneg_float = -3.14").unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.get("neg_int"), Some(&Value::Integer(-42)));
+        assert_eq!(obj.get("neg_float"), Some(&Value::Float(-3.14)));
+    }
+
+    #[test]
+    fn test_terraform_style_config() {
+        let reader = HclReader;
+        let input = r#"
+terraform {
+  required_version = ">= 1.0"
+}
+
+variable "region" {
+  type    = "string"
+  default = "us-west-2"
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+"#;
+        let v = reader.read(input).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key("terraform"));
+        assert!(obj.contains_key("variable"));
+        assert!(obj.contains_key("provider"));
+    }
+}

--- a/dkit-core/src/format/mod.rs
+++ b/dkit-core/src/format/mod.rs
@@ -207,6 +207,38 @@ pub mod xlsx {
     }
 }
 
+/// HCL (HashiCorp Configuration Language) reader and writer.
+#[cfg(feature = "hcl")]
+pub mod hcl;
+#[cfg(not(feature = "hcl"))]
+pub mod hcl {
+    //! Stub module — HCL feature not enabled.
+    use super::{FormatReader, FormatWriter};
+    use crate::value::Value;
+    use std::io::{Read, Write};
+
+    const MSG: &str = "HCL support requires the 'hcl' feature.\n  Install with: cargo install dkit --features hcl";
+
+    pub struct HclReader;
+    impl FormatReader for HclReader {
+        fn read(&self, _: &str) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+        fn read_from_reader(&self, _: impl Read) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+    }
+    pub struct HclWriter;
+    impl FormatWriter for HclWriter {
+        fn write(&self, _: &Value) -> anyhow::Result<String> {
+            anyhow::bail!(MSG)
+        }
+        fn write_to_writer(&self, _: &Value, _: impl Write) -> anyhow::Result<()> {
+            anyhow::bail!(MSG)
+        }
+    }
+}
+
 /// XML reader and writer.
 #[cfg(feature = "xml")]
 pub mod xml;
@@ -300,6 +332,8 @@ pub enum Format {
     Ini,
     /// Java `.properties` file format (`*.properties`)
     Properties,
+    /// HCL (HashiCorp Configuration Language) (`*.hcl`, `*.tf`, `*.tfvars`)
+    Hcl,
 }
 
 impl Format {
@@ -322,6 +356,7 @@ impl Format {
             "env" | "dotenv" => Ok(Format::Env),
             "ini" | "cfg" | "conf" | "config" => Ok(Format::Ini),
             "properties" => Ok(Format::Properties),
+            "hcl" | "tf" | "tfvars" => Ok(Format::Hcl),
             _ => Err(DkitError::UnknownFormat(s.to_string())),
         }
     }
@@ -369,6 +404,15 @@ impl Format {
             ));
         }
 
+        if cfg!(feature = "hcl") {
+            formats.push(("hcl", "HCL (HashiCorp Configuration Language)"));
+        } else {
+            formats.push((
+                "hcl",
+                "HCL (HashiCorp Configuration Language) (requires --features hcl)",
+            ));
+        }
+
         formats.push(("env", "Environment variables (.env) format"));
         formats.push(("ini", "INI/CFG configuration file format"));
         formats.push(("properties", "Java .properties file format"));
@@ -399,6 +443,7 @@ impl std::fmt::Display for Format {
             Format::Env => write!(f, "ENV"),
             Format::Ini => write!(f, "INI"),
             Format::Properties => write!(f, "Properties"),
+            Format::Hcl => write!(f, "HCL"),
         }
     }
 }
@@ -428,6 +473,7 @@ pub fn detect_format(path: &Path) -> Result<Format, DkitError> {
         Some("env") => Ok(Format::Env),
         Some("ini" | "cfg") => Ok(Format::Ini),
         Some("properties") => Ok(Format::Properties),
+        Some("hcl" | "tf" | "tfvars") => Ok(Format::Hcl),
         Some(ext) => Err(DkitError::UnknownFormat(ext.to_string())),
         None => Err(DkitError::UnknownFormat("(no extension)".to_string())),
     }


### PR DESCRIPTION
## Summary
- HCL v2 (HashiCorp Configuration Language) 포맷의 Reader/Writer 구현 (`hcl-rs` 크레이트 활용)
- `.hcl`, `.tf`, `.tfvars` 파일 확장자 지원, 블록 구조를 중첩 Object로 매핑
- `--features hcl` feature flag로 선택적 의존성 관리 (stub 모듈 포함)
- 모든 CLI 서브커맨드(convert, query, view, stats, diff, merge, flatten, sample, schema, validate)에 HCL 포맷 통합

## Test plan
- [x] `cargo test --features hcl` — 672 tests passed (HCL 단위 테스트 27개 포함)
- [x] `cargo test` — 645 tests passed (feature 비활성 시 stub 정상 동작)
- [x] `cargo clippy --features hcl -- -D warnings` — 경고 없음
- [x] `cargo fmt -- --check` — 포맷 검사 통과

Closes #195

https://claude.ai/code/session_01FoKe5CEjEKffjjVicMjhkS