### PR TITLE
feat: add .plist (macOS Property List) format Reader/Writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "base64 0.22.1",
  "bytes",
  "calamine",
  "criterion",
@@ -904,6 +905,7 @@ dependencies = [
  "indexmap",
  "jsonschema",
  "parquet",
+ "plist",
  "quick-xml 0.37.5",
  "rand",
  "regex",
@@ -1999,6 +2001,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap",
+ "quick-xml 0.38.4",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2135,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -2606,6 +2630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -26,7 +26,8 @@ excel = ["dkit-core/excel"]
 sqlite = ["dkit-core/sqlite"]
 parquet = ["dkit-core/parquet", "dep:arrow", "dep:parquet-impl", "dep:bytes"]
 hcl = ["dkit-core/hcl"]
-all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl"]
+plist = ["dkit-core/plist"]
+all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist"]
 
 [dependencies]
 dkit-core = { version = "1.2.0", path = "../dkit-core" }

--- a/dkit-cli/src/commands/convert.rs
+++ b/dkit-cli/src/commands/convert.rs
@@ -18,6 +18,7 @@ use dkit_core::format::json::{JsonReader, JsonWriter};
 use dkit_core::format::jsonl::{JsonlReader, JsonlWriter};
 use dkit_core::format::markdown::MarkdownWriter;
 use dkit_core::format::msgpack::{MsgpackReader, MsgpackWriter};
+use dkit_core::format::plist::{PlistReader, PlistWriter};
 use dkit_core::format::properties::{PropertiesReader, PropertiesWriter};
 use dkit_core::format::toml::{TomlReader, TomlWriter};
 use dkit_core::format::xml::{XmlReader, XmlWriter};
@@ -564,6 +565,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -633,6 +635,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
         Format::Hcl => HclWriter.write(value),
+        Format::Plist => PlistWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/diff.rs
+++ b/dkit-cli/src/commands/diff.rs
@@ -14,6 +14,7 @@ use dkit_core::format::ini::IniReader;
 use dkit_core::format::json::JsonReader;
 use dkit_core::format::jsonl::JsonlReader;
 use dkit_core::format::msgpack::MsgpackReader;
+use dkit_core::format::plist::PlistReader;
 use dkit_core::format::properties::PropertiesReader;
 use dkit_core::format::toml::TomlReader;
 use dkit_core::format::xml::XmlReader;
@@ -220,6 +221,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")

--- a/dkit-cli/src/commands/flatten.rs
+++ b/dkit-cli/src/commands/flatten.rs
@@ -18,6 +18,7 @@ use dkit_core::format::json::{JsonReader, JsonWriter};
 use dkit_core::format::jsonl::{JsonlReader, JsonlWriter};
 use dkit_core::format::markdown::MarkdownWriter;
 use dkit_core::format::msgpack::{MsgpackReader, MsgpackWriter};
+use dkit_core::format::plist::{PlistReader, PlistWriter};
 use dkit_core::format::properties::{PropertiesReader, PropertiesWriter};
 use dkit_core::format::toml::{TomlReader, TomlWriter};
 use dkit_core::format::xml::{XmlReader, XmlWriter};
@@ -484,6 +485,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -555,6 +557,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
         Format::Hcl => HclWriter.write(value),
+        Format::Plist => PlistWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/merge.rs
+++ b/dkit-cli/src/commands/merge.rs
@@ -16,6 +16,7 @@ use dkit_core::format::json::{JsonReader, JsonWriter};
 use dkit_core::format::jsonl::{JsonlReader, JsonlWriter};
 use dkit_core::format::markdown::MarkdownWriter;
 use dkit_core::format::msgpack::{MsgpackReader, MsgpackWriter};
+use dkit_core::format::plist::{PlistReader, PlistWriter};
 use dkit_core::format::properties::{PropertiesReader, PropertiesWriter};
 use dkit_core::format::toml::{TomlReader, TomlWriter};
 use dkit_core::format::xml::{XmlReader, XmlWriter};
@@ -201,6 +202,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -230,6 +232,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
         Format::Hcl => HclWriter.write(value),
+        Format::Plist => PlistWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/query.rs
+++ b/dkit-cli/src/commands/query.rs
@@ -17,6 +17,7 @@ use dkit_core::format::json::{JsonReader, JsonWriter};
 use dkit_core::format::jsonl::{JsonlReader, JsonlWriter};
 use dkit_core::format::markdown::MarkdownWriter;
 use dkit_core::format::msgpack::{MsgpackReader, MsgpackWriter};
+use dkit_core::format::plist::{PlistReader, PlistWriter};
 use dkit_core::format::properties::{PropertiesReader, PropertiesWriter};
 use dkit_core::format::toml::{TomlReader, TomlWriter};
 use dkit_core::format::xml::{XmlReader, XmlWriter};
@@ -186,6 +187,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -224,6 +226,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
         Format::Hcl => HclWriter.write(value),
+        Format::Plist => PlistWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/sample.rs
+++ b/dkit-cli/src/commands/sample.rs
@@ -21,6 +21,7 @@ use dkit_core::format::json::{JsonReader, JsonWriter};
 use dkit_core::format::jsonl::{JsonlReader, JsonlWriter};
 use dkit_core::format::markdown::MarkdownWriter;
 use dkit_core::format::msgpack::{MsgpackReader, MsgpackWriter};
+use dkit_core::format::plist::{PlistReader, PlistWriter};
 use dkit_core::format::properties::{PropertiesReader, PropertiesWriter};
 use dkit_core::format::toml::{TomlReader, TomlWriter};
 use dkit_core::format::xml::{XmlReader, XmlWriter};
@@ -325,6 +326,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -396,6 +398,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
         Format::Hcl => HclWriter.write(value),
+        Format::Plist => PlistWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-cli/src/commands/schema.rs
+++ b/dkit-cli/src/commands/schema.rs
@@ -13,6 +13,7 @@ use dkit_core::format::ini::IniReader;
 use dkit_core::format::json::JsonReader;
 use dkit_core::format::jsonl::JsonlReader;
 use dkit_core::format::msgpack::MsgpackReader;
+use dkit_core::format::plist::PlistReader;
 use dkit_core::format::properties::PropertiesReader;
 use dkit_core::format::toml::TomlReader;
 use dkit_core::format::xml::XmlReader;
@@ -324,6 +325,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")

--- a/dkit-cli/src/commands/stats.rs
+++ b/dkit-cli/src/commands/stats.rs
@@ -14,6 +14,7 @@ use dkit_core::format::ini::IniReader;
 use dkit_core::format::json::JsonReader;
 use dkit_core::format::jsonl::JsonlReader;
 use dkit_core::format::msgpack::MsgpackReader;
+use dkit_core::format::plist::PlistReader;
 use dkit_core::format::properties::PropertiesReader;
 use dkit_core::format::toml::TomlReader;
 use dkit_core::format::xml::XmlReader;
@@ -882,6 +883,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")

--- a/dkit-cli/src/commands/validate.rs
+++ b/dkit-cli/src/commands/validate.rs
@@ -15,6 +15,7 @@ use dkit_core::format::ini::IniReader;
 use dkit_core::format::json::JsonReader;
 use dkit_core::format::jsonl::JsonlReader;
 use dkit_core::format::msgpack::MsgpackReader;
+use dkit_core::format::plist::PlistReader;
 use dkit_core::format::properties::PropertiesReader;
 use dkit_core::format::toml::TomlReader;
 use dkit_core::format::xml::XmlReader;
@@ -199,6 +200,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")

--- a/dkit-cli/src/commands/view.rs
+++ b/dkit-cli/src/commands/view.rs
@@ -19,6 +19,7 @@ use dkit_core::format::json::{JsonReader, JsonWriter};
 use dkit_core::format::jsonl::{JsonlReader, JsonlWriter};
 use dkit_core::format::markdown::MarkdownWriter;
 use dkit_core::format::msgpack::{MsgpackReader, MsgpackWriter};
+use dkit_core::format::plist::{PlistReader, PlistWriter};
 use dkit_core::format::properties::{PropertiesReader, PropertiesWriter};
 use dkit_core::format::toml::{TomlReader, TomlWriter};
 use dkit_core::format::xml::{XmlReader, XmlWriter};
@@ -251,6 +252,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Ini => IniReader.read(content),
         Format::Properties => PropertiesReader.read(content),
         Format::Hcl => HclReader.read(content),
+        Format::Plist => PlistReader.read(content),
         Format::Msgpack => MsgpackReader.read(content),
         Format::Xlsx => {
             bail!("Excel files must be read as binary; use file path input instead of stdin")
@@ -280,6 +282,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Ini => IniWriter.write(value),
         Format::Properties => PropertiesWriter.write(value),
         Format::Hcl => HclWriter.write(value),
+        Format::Plist => PlistWriter.write(value),
         Format::Msgpack => MsgpackWriter.write(value),
         Format::Xlsx => bail!("Excel is an input-only format and cannot be used as output"),
         Format::Sqlite => bail!("SQLite is an input-only format and cannot be used as output"),

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -18,7 +18,8 @@ excel = ["dep:calamine"]
 sqlite = ["dep:rusqlite"]
 parquet = ["dep:arrow", "dep:parquet-impl", "dep:bytes"]
 hcl = ["dep:hcl-rs"]
-all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl"]
+plist = ["dep:plist", "dep:base64"]
+all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -37,6 +38,8 @@ arrow = { version = "53", default-features = false, features = ["prettyprint"], 
 parquet-impl = { package = "parquet", version = "53", default-features = false, features = ["arrow", "snap", "zstd"], optional = true }
 bytes = { version = "1", optional = true }
 hcl-rs = { version = "0.19", optional = true }
+plist = { version = "1", optional = true }
+base64 = { version = "0.22", optional = true }
 jsonschema = { version = "0.17", default-features = false }
 rand = "0.8"
 regex = "1"

--- a/dkit-core/src/format/mod.rs
+++ b/dkit-core/src/format/mod.rs
@@ -239,6 +239,38 @@ pub mod hcl {
     }
 }
 
+/// macOS Property List (plist) reader and writer.
+#[cfg(feature = "plist")]
+pub mod plist;
+#[cfg(not(feature = "plist"))]
+pub mod plist {
+    //! Stub module — plist feature not enabled.
+    use super::{FormatReader, FormatWriter};
+    use crate::value::Value;
+    use std::io::{Read, Write};
+
+    const MSG: &str = "Plist support requires the 'plist' feature.\n  Install with: cargo install dkit --features plist";
+
+    pub struct PlistReader;
+    impl FormatReader for PlistReader {
+        fn read(&self, _: &str) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+        fn read_from_reader(&self, _: impl Read) -> anyhow::Result<Value> {
+            anyhow::bail!(MSG)
+        }
+    }
+    pub struct PlistWriter;
+    impl FormatWriter for PlistWriter {
+        fn write(&self, _: &Value) -> anyhow::Result<String> {
+            anyhow::bail!(MSG)
+        }
+        fn write_to_writer(&self, _: &Value, _: impl Write) -> anyhow::Result<()> {
+            anyhow::bail!(MSG)
+        }
+    }
+}
+
 /// XML reader and writer.
 #[cfg(feature = "xml")]
 pub mod xml;
@@ -334,6 +366,8 @@ pub enum Format {
     Properties,
     /// HCL (HashiCorp Configuration Language) (`*.hcl`, `*.tf`, `*.tfvars`)
     Hcl,
+    /// macOS Property List (`*.plist`)
+    Plist,
 }
 
 impl Format {
@@ -357,6 +391,7 @@ impl Format {
             "ini" | "cfg" | "conf" | "config" => Ok(Format::Ini),
             "properties" => Ok(Format::Properties),
             "hcl" | "tf" | "tfvars" => Ok(Format::Hcl),
+            "plist" => Ok(Format::Plist),
             _ => Err(DkitError::UnknownFormat(s.to_string())),
         }
     }
@@ -413,6 +448,15 @@ impl Format {
             ));
         }
 
+        if cfg!(feature = "plist") {
+            formats.push(("plist", "macOS Property List format"));
+        } else {
+            formats.push((
+                "plist",
+                "macOS Property List format (requires --features plist)",
+            ));
+        }
+
         formats.push(("env", "Environment variables (.env) format"));
         formats.push(("ini", "INI/CFG configuration file format"));
         formats.push(("properties", "Java .properties file format"));
@@ -444,6 +488,7 @@ impl std::fmt::Display for Format {
             Format::Ini => write!(f, "INI"),
             Format::Properties => write!(f, "Properties"),
             Format::Hcl => write!(f, "HCL"),
+            Format::Plist => write!(f, "Plist"),
         }
     }
 }
@@ -474,6 +519,7 @@ pub fn detect_format(path: &Path) -> Result<Format, DkitError> {
         Some("ini" | "cfg") => Ok(Format::Ini),
         Some("properties") => Ok(Format::Properties),
         Some("hcl" | "tf" | "tfvars") => Ok(Format::Hcl),
+        Some("plist") => Ok(Format::Plist),
         Some(ext) => Err(DkitError::UnknownFormat(ext.to_string())),
         None => Err(DkitError::UnknownFormat("(no extension)".to_string())),
     }
@@ -497,8 +543,11 @@ pub fn detect_format_from_content(content: &str) -> Result<(Format, Option<char>
         ));
     }
 
-    // XML: <?xml 또는 루트 태그로 시작
+    // Plist: <?xml followed by <!DOCTYPE plist or <plist
     if trimmed.starts_with("<?xml") || trimmed.starts_with("<!DOCTYPE") {
+        if trimmed.contains("<!DOCTYPE plist") || trimmed.contains("<plist") {
+            return Ok((Format::Plist, None));
+        }
         return Ok((Format::Xml, None));
     }
 

--- a/dkit-core/src/format/plist.rs
+++ b/dkit-core/src/format/plist.rs
@@ -1,0 +1,425 @@
+use std::io::{Read, Write};
+
+use indexmap::IndexMap;
+
+use crate::format::{FormatReader, FormatWriter};
+use crate::value::Value;
+
+/// plist::Value -> internal Value conversion
+fn from_plist_value(v: plist::Value) -> Value {
+    match v {
+        plist::Value::Boolean(b) => Value::Bool(b),
+        plist::Value::Integer(n) => {
+            if let Some(i) = n.as_signed() {
+                Value::Integer(i)
+            } else if let Some(u) = n.as_unsigned() {
+                // u64 that doesn't fit in i64
+                Value::Float(u as f64)
+            } else {
+                Value::Null
+            }
+        }
+        plist::Value::Real(f) => Value::Float(f),
+        plist::Value::String(s) => Value::String(s),
+        plist::Value::Array(arr) => Value::Array(arr.into_iter().map(from_plist_value).collect()),
+        plist::Value::Dictionary(dict) => {
+            let obj: IndexMap<String, Value> = dict
+                .into_iter()
+                .map(|(k, v)| (k, from_plist_value(v)))
+                .collect();
+            Value::Object(obj)
+        }
+        plist::Value::Data(bytes) => {
+            use base64::Engine;
+            Value::String(base64::engine::general_purpose::STANDARD.encode(bytes))
+        }
+        plist::Value::Date(date) => Value::String(date.to_xml_format()),
+        plist::Value::Uid(uid) => Value::Integer(uid.get() as i64),
+        _ => Value::Null,
+    }
+}
+
+/// internal Value -> plist::Value conversion
+fn to_plist_value(v: &Value) -> plist::Value {
+    match v {
+        Value::Null => plist::Value::String("".to_string()),
+        Value::Bool(b) => plist::Value::Boolean(*b),
+        Value::Integer(n) => plist::Value::Integer((*n).into()),
+        Value::Float(f) => plist::Value::Real(*f),
+        Value::String(s) => plist::Value::String(s.clone()),
+        Value::Array(arr) => plist::Value::Array(arr.iter().map(to_plist_value).collect()),
+        Value::Object(map) => {
+            let dict: plist::Dictionary = map
+                .iter()
+                .map(|(k, v)| (k.clone(), to_plist_value(v)))
+                .collect();
+            plist::Value::Dictionary(dict)
+        }
+    }
+}
+
+/// macOS Property List (plist) format reader.
+///
+/// Supports XML plist format. Parses plist data into the internal Value type.
+/// Data type mapping:
+/// - dict -> Object
+/// - array -> Array
+/// - string -> String
+/// - integer -> Integer
+/// - real -> Float
+/// - true/false -> Bool
+/// - date -> String (XML date format)
+/// - data -> String (Base64 encoded)
+pub struct PlistReader;
+
+impl FormatReader for PlistReader {
+    fn read(&self, input: &str) -> anyhow::Result<Value> {
+        let plist_val: plist::Value = plist::from_bytes(input.as_bytes()).map_err(|e| {
+            crate::error::DkitError::ParseError {
+                format: "plist".to_string(),
+                source: Box::new(e),
+            }
+        })?;
+        Ok(from_plist_value(plist_val))
+    }
+
+    fn read_from_reader(&self, mut reader: impl Read) -> anyhow::Result<Value> {
+        let mut buf = Vec::new();
+        reader
+            .read_to_end(&mut buf)
+            .map_err(|e| crate::error::DkitError::ParseError {
+                format: "plist".to_string(),
+                source: Box::new(e),
+            })?;
+        let plist_val: plist::Value =
+            plist::from_bytes(&buf).map_err(|e| crate::error::DkitError::ParseError {
+                format: "plist".to_string(),
+                source: Box::new(e),
+            })?;
+        Ok(from_plist_value(plist_val))
+    }
+}
+
+/// macOS Property List (plist) format writer.
+///
+/// Writes data as XML plist format.
+pub struct PlistWriter;
+
+impl FormatWriter for PlistWriter {
+    fn write(&self, value: &Value) -> anyhow::Result<String> {
+        let plist_val = to_plist_value(value);
+        let mut buf = Vec::new();
+        plist::to_writer_xml(&mut buf, &plist_val).map_err(|e| {
+            crate::error::DkitError::WriteError {
+                format: "plist".to_string(),
+                source: Box::new(e),
+            }
+        })?;
+        Ok(
+            String::from_utf8(buf).map_err(|e| crate::error::DkitError::WriteError {
+                format: "plist".to_string(),
+                source: Box::new(e),
+            })?,
+        )
+    }
+
+    fn write_to_writer(&self, value: &Value, writer: impl Write) -> anyhow::Result<()> {
+        let plist_val = to_plist_value(value);
+        plist::to_writer_xml(writer, &plist_val).map_err(|e| {
+            crate::error::DkitError::WriteError {
+                format: "plist".to_string(),
+                source: Box::new(e),
+            }
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_plist_value_bool() {
+        assert_eq!(
+            from_plist_value(plist::Value::Boolean(true)),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            from_plist_value(plist::Value::Boolean(false)),
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn test_from_plist_value_integer() {
+        assert_eq!(
+            from_plist_value(plist::Value::Integer(42.into())),
+            Value::Integer(42)
+        );
+        assert_eq!(
+            from_plist_value(plist::Value::Integer((-10).into())),
+            Value::Integer(-10)
+        );
+    }
+
+    #[test]
+    fn test_from_plist_value_real() {
+        assert_eq!(
+            from_plist_value(plist::Value::Real(3.14)),
+            Value::Float(3.14)
+        );
+    }
+
+    #[test]
+    fn test_from_plist_value_string() {
+        assert_eq!(
+            from_plist_value(plist::Value::String("hello".to_string())),
+            Value::String("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn test_from_plist_value_array() {
+        let arr = plist::Value::Array(vec![
+            plist::Value::Integer(1.into()),
+            plist::Value::String("two".to_string()),
+        ]);
+        let expected = Value::Array(vec![Value::Integer(1), Value::String("two".to_string())]);
+        assert_eq!(from_plist_value(arr), expected);
+    }
+
+    #[test]
+    fn test_from_plist_value_dict() {
+        let mut dict = plist::Dictionary::new();
+        dict.insert(
+            "name".to_string(),
+            plist::Value::String("Alice".to_string()),
+        );
+        dict.insert("age".to_string(), plist::Value::Integer(30.into()));
+        let result = from_plist_value(plist::Value::Dictionary(dict));
+        match result {
+            Value::Object(map) => {
+                assert_eq!(map.get("name"), Some(&Value::String("Alice".to_string())));
+                assert_eq!(map.get("age"), Some(&Value::Integer(30)));
+            }
+            _ => panic!("Expected Object"),
+        }
+    }
+
+    #[test]
+    fn test_from_plist_value_data() {
+        let data = plist::Value::Data(vec![0x48, 0x65, 0x6c, 0x6c, 0x6f]); // "Hello"
+        let result = from_plist_value(data);
+        // Base64 of "Hello" = "SGVsbG8="
+        assert_eq!(result, Value::String("SGVsbG8=".to_string()));
+    }
+
+    #[test]
+    fn test_to_plist_value_null() {
+        let result = to_plist_value(&Value::Null);
+        assert_eq!(result, plist::Value::String("".to_string()));
+    }
+
+    #[test]
+    fn test_to_plist_value_bool() {
+        assert_eq!(
+            to_plist_value(&Value::Bool(true)),
+            plist::Value::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn test_to_plist_value_integer() {
+        assert_eq!(
+            to_plist_value(&Value::Integer(42)),
+            plist::Value::Integer(42.into())
+        );
+    }
+
+    #[test]
+    fn test_to_plist_value_float() {
+        assert_eq!(to_plist_value(&Value::Float(2.5)), plist::Value::Real(2.5));
+    }
+
+    #[test]
+    fn test_to_plist_value_string() {
+        assert_eq!(
+            to_plist_value(&Value::String("test".to_string())),
+            plist::Value::String("test".to_string())
+        );
+    }
+
+    #[test]
+    fn test_to_plist_value_array() {
+        let val = Value::Array(vec![Value::Integer(1), Value::Bool(true)]);
+        let result = to_plist_value(&val);
+        let expected = plist::Value::Array(vec![
+            plist::Value::Integer(1.into()),
+            plist::Value::Boolean(true),
+        ]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_to_plist_value_object() {
+        let mut map = IndexMap::new();
+        map.insert("key".to_string(), Value::String("value".to_string()));
+        let val = Value::Object(map);
+        let result = to_plist_value(&val);
+        match result {
+            plist::Value::Dictionary(dict) => {
+                assert_eq!(
+                    dict.get("key"),
+                    Some(&plist::Value::String("value".to_string()))
+                );
+            }
+            _ => panic!("Expected Dictionary"),
+        }
+    }
+
+    #[test]
+    fn test_reader_xml_plist() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>MyApp</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+</dict>
+</plist>"#;
+        let reader = PlistReader;
+        let result = reader.read(xml).unwrap();
+        match &result {
+            Value::Object(map) => {
+                assert_eq!(
+                    map.get("CFBundleName"),
+                    Some(&Value::String("MyApp".to_string()))
+                );
+                assert_eq!(
+                    map.get("CFBundleVersion"),
+                    Some(&Value::String("1.0".to_string()))
+                );
+                assert_eq!(map.get("LSRequiresIPhoneOS"), Some(&Value::Bool(true)));
+            }
+            _ => panic!("Expected Object"),
+        }
+    }
+
+    #[test]
+    fn test_writer_xml_plist() {
+        let mut map = IndexMap::new();
+        map.insert("name".to_string(), Value::String("Test".to_string()));
+        map.insert("version".to_string(), Value::Integer(1));
+        let val = Value::Object(map);
+
+        let writer = PlistWriter;
+        let output = writer.write(&val).unwrap();
+        assert!(output.contains("<?xml version=\"1.0\""));
+        assert!(output.contains("<key>name</key>"));
+        assert!(output.contains("<string>Test</string>"));
+        assert!(output.contains("<key>version</key>"));
+        assert!(output.contains("<integer>1</integer>"));
+    }
+
+    #[test]
+    fn test_roundtrip_plist() {
+        let mut map = IndexMap::new();
+        map.insert("string_val".to_string(), Value::String("hello".to_string()));
+        map.insert("int_val".to_string(), Value::Integer(42));
+        map.insert("float_val".to_string(), Value::Float(3.14));
+        map.insert("bool_val".to_string(), Value::Bool(true));
+        map.insert(
+            "array_val".to_string(),
+            Value::Array(vec![Value::Integer(1), Value::Integer(2)]),
+        );
+        let original = Value::Object(map);
+
+        let writer = PlistWriter;
+        let xml = writer.write(&original).unwrap();
+
+        let reader = PlistReader;
+        let restored = reader.read(&xml).unwrap();
+        assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn test_reader_nested_plist() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>outer</key>
+    <dict>
+        <key>inner</key>
+        <array>
+            <integer>1</integer>
+            <integer>2</integer>
+            <integer>3</integer>
+        </array>
+    </dict>
+</dict>
+</plist>"#;
+        let reader = PlistReader;
+        let result = reader.read(xml).unwrap();
+        match &result {
+            Value::Object(outer) => match outer.get("outer") {
+                Some(Value::Object(inner_map)) => match inner_map.get("inner") {
+                    Some(Value::Array(arr)) => {
+                        assert_eq!(arr.len(), 3);
+                        assert_eq!(arr[0], Value::Integer(1));
+                    }
+                    _ => panic!("Expected Array for 'inner'"),
+                },
+                _ => panic!("Expected Object for 'outer'"),
+            },
+            _ => panic!("Expected Object"),
+        }
+    }
+
+    #[test]
+    fn test_reader_invalid_plist() {
+        let reader = PlistReader;
+        let result = reader.read("not a plist");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_from_reader() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>test</key>
+    <string>value</string>
+</dict>
+</plist>"#;
+        let reader = PlistReader;
+        let cursor = std::io::Cursor::new(xml.as_bytes());
+        let result = reader.read_from_reader(cursor).unwrap();
+        match &result {
+            Value::Object(map) => {
+                assert_eq!(map.get("test"), Some(&Value::String("value".to_string())));
+            }
+            _ => panic!("Expected Object"),
+        }
+    }
+
+    #[test]
+    fn test_write_to_writer() {
+        let val = Value::Object(IndexMap::from([(
+            "key".to_string(),
+            Value::String("val".to_string()),
+        )]));
+        let writer = PlistWriter;
+        let mut buf = Vec::new();
+        writer.write_to_writer(&val, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("<key>key</key>"));
+        assert!(output.contains("<string>val</string>"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `.plist` (macOS Property List) format Reader/Writer with feature-gated `plist` dependency
- Support XML plist format with data type mapping: dict→Object, array→Array, string→String, integer→Integer, real→Float, bool→Bool, date→String, data→Base64 String
- Register Plist format across all CLI commands (convert, query, view, flatten, merge, sample, diff, schema, stats, validate)

## Implementation Details
- Feature flag: `--features plist` (optional, with stub module when disabled)
- Dependencies: `plist ^1`, `base64 ^0.22` (both feature-gated)
- 21 unit tests covering value conversion, reading, writing, roundtrip, error handling
- File extension detection: `.plist`
- Content sniffing: detects `<!DOCTYPE plist` or `<plist>` in XML content

## Test plan
- [x] All 21 plist unit tests pass
- [x] Full test suite passes (666 tests)
- [x] `cargo clippy -- -D warnings` passes (with and without feature)
- [x] `cargo fmt -- --check` passes
- [x] Build succeeds without plist feature (stub module)

Closes #196

https://claude.ai/code/session_01J5roJHfbwYTxsrLnbTmNsg