### PR TITLE
feat: add recursive descent (`..`) operator for deep key search

### DIFF
--- a/dkit-core/src/query/evaluator.rs
+++ b/dkit-core/src/query/evaluator.rs
@@ -61,6 +61,9 @@ pub fn evaluate_path(value: &Value, path: &Path) -> Result<Value, DkitError> {
                         ));
                     }
                 },
+                Segment::RecursiveDescent(name) => {
+                    recursive_collect(val, name, &mut next_results);
+                }
             }
         }
 
@@ -71,7 +74,10 @@ pub fn evaluate_path(value: &Value, path: &Path) -> Result<Value, DkitError> {
     let has_iterate = path.segments.iter().any(|s| {
         matches!(
             s,
-            Segment::Iterate | Segment::Wildcard | Segment::Slice { .. }
+            Segment::Iterate
+                | Segment::Wildcard
+                | Segment::Slice { .. }
+                | Segment::RecursiveDescent(_)
         )
     });
     if has_iterate {
@@ -159,6 +165,26 @@ fn apply_slice(
     }
 
     Ok(result)
+}
+
+/// 재귀적으로 Value 트리를 DFS 순회하며 지정된 키를 가진 값을 수집
+fn recursive_collect(value: &Value, key: &str, results: &mut Vec<Value>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(v) = map.get(key) {
+                results.push(v.clone());
+            }
+            for (_, v) in map {
+                recursive_collect(v, key, results);
+            }
+        }
+        Value::Array(arr) => {
+            for item in arr {
+                recursive_collect(item, key, results);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// 음수 인덱스를 양수로 변환
@@ -708,5 +734,95 @@ mod tests {
         ]);
         let result = eval(&data, ".[:]").unwrap();
         assert_eq!(result, data);
+    }
+
+    // --- 재귀 하강 (recursive descent `..`) ---
+
+    #[test]
+    fn test_recursive_descent_simple() {
+        let data = sample_data();
+        // .name is "dkit", .users[*].name are "Alice", "Bob", "Charlie"
+        let result = eval(&data, "..name").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![
+                Value::String("dkit".to_string()),
+                Value::String("Alice".to_string()),
+                Value::String("Bob".to_string()),
+                Value::String("Charlie".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_recursive_descent_nested() {
+        let data = sample_data();
+        // .config.database.host = "localhost"
+        let result = eval(&data, "..host").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![Value::String("localhost".to_string())])
+        );
+    }
+
+    #[test]
+    fn test_recursive_descent_no_match() {
+        let data = sample_data();
+        let result = eval(&data, "..nonexistent").unwrap();
+        assert_eq!(result, Value::Array(vec![]));
+    }
+
+    #[test]
+    fn test_recursive_descent_with_prefix_path() {
+        let data = sample_data();
+        // .config..host should find "localhost" within config subtree
+        let result = eval(&data, ".config..host").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![Value::String("localhost".to_string())])
+        );
+    }
+
+    #[test]
+    fn test_recursive_descent_deeply_nested() {
+        // Build a deeply nested structure
+        let mut inner = IndexMap::new();
+        inner.insert("id".to_string(), Value::Integer(42));
+
+        let mut mid = IndexMap::new();
+        mid.insert("nested".to_string(), Value::Object(inner));
+        mid.insert("id".to_string(), Value::Integer(1));
+
+        let mut outer = IndexMap::new();
+        outer.insert("data".to_string(), Value::Object(mid));
+
+        let data = Value::Object(outer);
+        let result = eval(&data, "..id").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![Value::Integer(1), Value::Integer(42)])
+        );
+    }
+
+    #[test]
+    fn test_recursive_descent_in_array() {
+        // Array of objects at root
+        let arr = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("x".to_string(), Value::Integer(1));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("x".to_string(), Value::Integer(2));
+                Value::Object(m)
+            },
+        ]);
+        let result = eval(&arr, "..x").unwrap();
+        assert_eq!(
+            result,
+            Value::Array(vec![Value::Integer(1), Value::Integer(2)])
+        );
     }
 }

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -33,6 +33,8 @@ pub enum Segment {
     },
     /// 배열 와일드카드 (`[*]`) — Iterate와 동일 의미
     Wildcard,
+    /// 재귀 하강 (`..key`) — 모든 깊이에서 key 필드를 재귀적으로 수집
+    RecursiveDescent(String),
 }
 
 /// Pipeline operation applied after path navigation (e.g., `| where ...`, `| sort ...`).
@@ -259,7 +261,18 @@ impl Parser {
             return Ok(Path { segments });
         }
 
+        // `..key` — 재귀 하강 (루트 경로 바로 뒤)
+        if self.peek() == Some('.') {
+            self.advance(); // consume the second '.'
+            let field = self.parse_field()?;
+            if let Segment::Field(name) = field {
+                segments.push(Segment::RecursiveDescent(name));
+            }
+            return Ok(Path { segments });
+        }
+
         // 첫 번째 세그먼트: `[` 이면 인덱스/이터레이터, 아니면 필드
+        // Note: at this point, peek is NOT '.', so it must be '[' or identifier
         if self.peek() == Some('[') {
             segments.push(self.parse_bracket()?);
         } else if self.peek_is_identifier_start() {
@@ -270,11 +283,21 @@ impl Parser {
         while !self.is_at_end() {
             self.skip_whitespace();
             if self.peek() == Some('.') {
-                self.advance(); // consume '.'
-                if self.peek() == Some('[') {
-                    segments.push(self.parse_bracket()?);
+                // Check for `..` (recursive descent)
+                if self.pos + 1 < self.input.len() && self.input[self.pos + 1] == '.' {
+                    self.advance(); // consume first '.'
+                    self.advance(); // consume second '.'
+                    let field = self.parse_field()?;
+                    if let Segment::Field(name) = field {
+                        segments.push(Segment::RecursiveDescent(name));
+                    }
                 } else {
-                    segments.push(self.parse_field()?);
+                    self.advance(); // consume '.'
+                    if self.peek() == Some('[') {
+                        segments.push(self.parse_bracket()?);
+                    } else {
+                        segments.push(self.parse_field()?);
+                    }
                 }
             } else if self.peek() == Some('[') {
                 segments.push(self.parse_bracket()?);
@@ -2427,6 +2450,40 @@ mod tests {
     #[test]
     fn test_expr_subtraction() {
         let q = parse_query(".items[] | select price - discount as net").unwrap();
+        assert_eq!(q.operations.len(), 1);
+    }
+
+    // --- Recursive descent (`..`) tests ---
+
+    #[test]
+    fn test_recursive_descent_root() {
+        let q = parse_query("..name").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::RecursiveDescent("name".to_string())]
+        );
+        assert!(q.operations.is_empty());
+    }
+
+    #[test]
+    fn test_recursive_descent_after_field() {
+        let q = parse_query(".config..host").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![
+                Segment::Field("config".to_string()),
+                Segment::RecursiveDescent("host".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_recursive_descent_with_pipeline() {
+        let q = parse_query("..name | where name == \"Alice\"").unwrap();
+        assert_eq!(
+            q.path.segments,
+            vec![Segment::RecursiveDescent("name".to_string())]
+        );
         assert_eq!(q.operations.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- Add `..key` recursive descent operator to query path syntax, enabling deep key search across all nesting levels
- Implement DFS-based tree traversal in the evaluator that collects all matching values into an array
- Support `..key` both from root (`..name`) and after path prefix (`.config..host`)

Closes #212

## Test plan
- [x] Parser tests: `..name` from root, `.config..host` after field, with pipeline
- [x] Evaluator tests: simple, nested, no match, with prefix path, deeply nested, array of objects
- [x] End-to-end CLI test with piped JSON input
- [x] All 654 tests pass, clippy clean, fmt clean

https://claude.ai/code/session_0163NXEqzz2XXdYhnButH6Wo