### PR TITLE
feat: add conditional expressions (if/then/else, case/when) to query

### DIFF
--- a/dkit-core/src/query/filter.rs
+++ b/dkit-core/src/query/filter.rs
@@ -933,7 +933,7 @@ fn select_exprs(value: &Value, exprs: &[SelectExpr]) -> Result<Value, DkitError>
 }
 
 /// 조건식 평가
-fn evaluate_condition(value: &Value, condition: &Condition) -> Result<bool, DkitError> {
+pub(crate) fn evaluate_condition(value: &Value, condition: &Condition) -> Result<bool, DkitError> {
     match condition {
         Condition::Comparison(cmp) => evaluate_comparison(value, cmp),
         Condition::And(left, right) => {
@@ -3079,5 +3079,119 @@ mod tests {
         assert_eq!(row["name"], Value::String("Alice".to_string()));
         assert_eq!(row["jan"], Value::Integer(100));
         assert_eq!(row["feb"], Value::Integer(200));
+    }
+
+    // --- if() / case expression integration tests ---
+
+    #[test]
+    fn test_select_with_if_expr() {
+        let data = sample_users();
+        let q = parse_query(".[] | select name, if(age < 30, \"young\", \"senior\") as category")
+            .unwrap();
+        let result = apply_operations(data, &q.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // Alice: age 30, not < 30 → "senior"
+        assert_eq!(
+            arr[0].as_object().unwrap()["category"],
+            Value::String("senior".to_string())
+        );
+        // Bob: age 25, < 30 → "young"
+        assert_eq!(
+            arr[1].as_object().unwrap()["category"],
+            Value::String("young".to_string())
+        );
+        // Charlie: age 35, not < 30 → "senior"
+        assert_eq!(
+            arr[2].as_object().unwrap()["category"],
+            Value::String("senior".to_string())
+        );
+    }
+
+    #[test]
+    fn test_select_with_nested_if() {
+        let data = sample_users();
+        let q = parse_query(
+            ".[] | select name, if(age < 28, \"young\", if(age < 33, \"mid\", \"senior\")) as cat",
+        )
+        .unwrap();
+        let result = apply_operations(data, &q.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // Alice: 30 → mid
+        assert_eq!(
+            arr[0].as_object().unwrap()["cat"],
+            Value::String("mid".to_string())
+        );
+        // Bob: 25 → young
+        assert_eq!(
+            arr[1].as_object().unwrap()["cat"],
+            Value::String("young".to_string())
+        );
+        // Charlie: 35 → senior
+        assert_eq!(
+            arr[2].as_object().unwrap()["cat"],
+            Value::String("senior".to_string())
+        );
+    }
+
+    #[test]
+    fn test_select_with_case() {
+        let data = sample_users();
+        let q = parse_query(
+            ".[] | select name, case when city == \"Seoul\" then \"capital\" when city == \"Busan\" then \"port\" else \"other\" end as city_type",
+        )
+        .unwrap();
+        let result = apply_operations(data, &q.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0].as_object().unwrap()["city_type"],
+            Value::String("capital".to_string())
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap()["city_type"],
+            Value::String("port".to_string())
+        );
+        assert_eq!(
+            arr[2].as_object().unwrap()["city_type"],
+            Value::String("capital".to_string())
+        );
+    }
+
+    #[test]
+    fn test_select_case_no_else_returns_null() {
+        let data = sample_users();
+        let q = parse_query(
+            ".[] | select name, case when city == \"Tokyo\" then \"japan\" end as country",
+        )
+        .unwrap();
+        let result = apply_operations(data, &q.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // None match → null
+        for item in arr {
+            assert_eq!(item.as_object().unwrap()["country"], Value::Null);
+        }
+    }
+
+    #[test]
+    fn test_add_field_with_if() {
+        let data = sample_users();
+        let (name, expr) =
+            crate::query::parser::parse_add_field_expr("group = if(age >= 30, \"A\", \"B\")")
+                .unwrap();
+        let op = Operation::AddField { name, expr };
+        let result = apply_operation(data, &op).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0].as_object().unwrap()["group"],
+            Value::String("A".to_string())
+        );
+        assert_eq!(
+            arr[1].as_object().unwrap()["group"],
+            Value::String("B".to_string())
+        );
+        assert_eq!(
+            arr[2].as_object().unwrap()["group"],
+            Value::String("A".to_string())
+        );
     }
 }

--- a/dkit-core/src/query/functions.rs
+++ b/dkit-core/src/query/functions.rs
@@ -1,4 +1,5 @@
 use crate::error::DkitError;
+use crate::query::filter::evaluate_condition;
 use crate::query::parser::{ArithmeticOp, Expr, LiteralValue};
 use crate::value::Value;
 
@@ -22,6 +23,28 @@ pub fn evaluate_expr(row: &Value, expr: &Expr) -> Result<Value, DkitError> {
             let lv = evaluate_expr(row, left)?;
             let rv = evaluate_expr(row, right)?;
             evaluate_binary_op(op, &lv, &rv)
+        }
+        Expr::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            if evaluate_condition(row, condition)? {
+                evaluate_expr(row, then_expr)
+            } else {
+                evaluate_expr(row, else_expr)
+            }
+        }
+        Expr::Case { branches, default } => {
+            for (condition, expr) in branches {
+                if evaluate_condition(row, condition)? {
+                    return evaluate_expr(row, expr);
+                }
+            }
+            match default {
+                Some(expr) => evaluate_expr(row, expr),
+                None => Ok(Value::Null),
+            }
         }
     }
 }
@@ -125,6 +148,14 @@ pub fn expr_default_key(expr: &Expr) -> String {
             }
         }
         Expr::BinaryOp { left, .. } => expr_default_key(left),
+        Expr::If { then_expr, .. } => expr_default_key(then_expr),
+        Expr::Case { branches, .. } => {
+            if let Some((_, expr)) = branches.first() {
+                expr_default_key(expr)
+            } else {
+                "case".to_string()
+            }
+        }
     }
 }
 
@@ -1414,5 +1445,212 @@ mod tests {
             evaluate_expr(&row, &expr).unwrap(),
             Value::String("Item42".to_string())
         );
+    }
+
+    // --- if() expression evaluation tests ---
+
+    #[test]
+    fn test_eval_if_true_branch() {
+        use crate::query::parser::{CompareOp, Comparison, Condition};
+        let row = Value::Object(
+            vec![
+                ("age".to_string(), Value::Integer(15)),
+                ("name".to_string(), Value::String("Alice".to_string())),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let expr = Expr::If {
+            condition: Condition::Comparison(Comparison {
+                field: "age".to_string(),
+                op: CompareOp::Lt,
+                value: LiteralValue::Integer(18),
+            }),
+            then_expr: Box::new(Expr::Literal(LiteralValue::String("minor".to_string()))),
+            else_expr: Box::new(Expr::Literal(LiteralValue::String("adult".to_string()))),
+        };
+        assert_eq!(
+            evaluate_expr(&row, &expr).unwrap(),
+            Value::String("minor".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eval_if_false_branch() {
+        use crate::query::parser::{CompareOp, Comparison, Condition};
+        let row = Value::Object(
+            vec![("age".to_string(), Value::Integer(30))]
+                .into_iter()
+                .collect(),
+        );
+        let expr = Expr::If {
+            condition: Condition::Comparison(Comparison {
+                field: "age".to_string(),
+                op: CompareOp::Lt,
+                value: LiteralValue::Integer(18),
+            }),
+            then_expr: Box::new(Expr::Literal(LiteralValue::String("minor".to_string()))),
+            else_expr: Box::new(Expr::Literal(LiteralValue::String("adult".to_string()))),
+        };
+        assert_eq!(
+            evaluate_expr(&row, &expr).unwrap(),
+            Value::String("adult".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eval_if_nested() {
+        use crate::query::parser::{CompareOp, Comparison, Condition};
+        let row = Value::Object(
+            vec![("age".to_string(), Value::Integer(70))]
+                .into_iter()
+                .collect(),
+        );
+        let expr = Expr::If {
+            condition: Condition::Comparison(Comparison {
+                field: "age".to_string(),
+                op: CompareOp::Lt,
+                value: LiteralValue::Integer(18),
+            }),
+            then_expr: Box::new(Expr::Literal(LiteralValue::String("minor".to_string()))),
+            else_expr: Box::new(Expr::If {
+                condition: Condition::Comparison(Comparison {
+                    field: "age".to_string(),
+                    op: CompareOp::Lt,
+                    value: LiteralValue::Integer(65),
+                }),
+                then_expr: Box::new(Expr::Literal(LiteralValue::String("adult".to_string()))),
+                else_expr: Box::new(Expr::Literal(LiteralValue::String("senior".to_string()))),
+            }),
+        };
+        assert_eq!(
+            evaluate_expr(&row, &expr).unwrap(),
+            Value::String("senior".to_string())
+        );
+    }
+
+    // --- case/when expression evaluation tests ---
+
+    #[test]
+    fn test_eval_case_first_branch() {
+        use crate::query::parser::{CompareOp, Comparison, Condition};
+        let row = Value::Object(
+            vec![("status".to_string(), Value::String("active".to_string()))]
+                .into_iter()
+                .collect(),
+        );
+        let expr = Expr::Case {
+            branches: vec![
+                (
+                    Condition::Comparison(Comparison {
+                        field: "status".to_string(),
+                        op: CompareOp::Eq,
+                        value: LiteralValue::String("active".to_string()),
+                    }),
+                    Expr::Literal(LiteralValue::String("A".to_string())),
+                ),
+                (
+                    Condition::Comparison(Comparison {
+                        field: "status".to_string(),
+                        op: CompareOp::Eq,
+                        value: LiteralValue::String("inactive".to_string()),
+                    }),
+                    Expr::Literal(LiteralValue::String("I".to_string())),
+                ),
+            ],
+            default: Some(Box::new(Expr::Literal(LiteralValue::String(
+                "U".to_string(),
+            )))),
+        };
+        assert_eq!(
+            evaluate_expr(&row, &expr).unwrap(),
+            Value::String("A".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eval_case_second_branch() {
+        use crate::query::parser::{CompareOp, Comparison, Condition};
+        let row = Value::Object(
+            vec![("status".to_string(), Value::String("inactive".to_string()))]
+                .into_iter()
+                .collect(),
+        );
+        let expr = Expr::Case {
+            branches: vec![
+                (
+                    Condition::Comparison(Comparison {
+                        field: "status".to_string(),
+                        op: CompareOp::Eq,
+                        value: LiteralValue::String("active".to_string()),
+                    }),
+                    Expr::Literal(LiteralValue::String("A".to_string())),
+                ),
+                (
+                    Condition::Comparison(Comparison {
+                        field: "status".to_string(),
+                        op: CompareOp::Eq,
+                        value: LiteralValue::String("inactive".to_string()),
+                    }),
+                    Expr::Literal(LiteralValue::String("I".to_string())),
+                ),
+            ],
+            default: Some(Box::new(Expr::Literal(LiteralValue::String(
+                "U".to_string(),
+            )))),
+        };
+        assert_eq!(
+            evaluate_expr(&row, &expr).unwrap(),
+            Value::String("I".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eval_case_default() {
+        use crate::query::parser::{CompareOp, Comparison, Condition};
+        let row = Value::Object(
+            vec![("status".to_string(), Value::String("pending".to_string()))]
+                .into_iter()
+                .collect(),
+        );
+        let expr = Expr::Case {
+            branches: vec![(
+                Condition::Comparison(Comparison {
+                    field: "status".to_string(),
+                    op: CompareOp::Eq,
+                    value: LiteralValue::String("active".to_string()),
+                }),
+                Expr::Literal(LiteralValue::String("A".to_string())),
+            )],
+            default: Some(Box::new(Expr::Literal(LiteralValue::String(
+                "other".to_string(),
+            )))),
+        };
+        assert_eq!(
+            evaluate_expr(&row, &expr).unwrap(),
+            Value::String("other".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eval_case_no_default_returns_null() {
+        use crate::query::parser::{CompareOp, Comparison, Condition};
+        let row = Value::Object(
+            vec![("status".to_string(), Value::String("pending".to_string()))]
+                .into_iter()
+                .collect(),
+        );
+        let expr = Expr::Case {
+            branches: vec![(
+                Condition::Comparison(Comparison {
+                    field: "status".to_string(),
+                    op: CompareOp::Eq,
+                    value: LiteralValue::String("active".to_string()),
+                }),
+                Expr::Literal(LiteralValue::String("A".to_string())),
+            )],
+            default: None,
+        };
+        assert_eq!(evaluate_expr(&row, &expr).unwrap(), Value::Null);
     }
 }

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -195,6 +195,17 @@ pub enum Expr {
         left: Box<Expr>,
         right: Box<Expr>,
     },
+    /// 조건 표현식: `if(condition, then_expr, else_expr)`
+    If {
+        condition: Condition,
+        then_expr: Box<Expr>,
+        else_expr: Box<Expr>,
+    },
+    /// CASE 표현식: `case when cond1 then expr1 [when cond2 then expr2]* [else expr] end`
+    Case {
+        branches: Vec<(Condition, Expr)>,
+        default: Option<Box<Expr>>,
+    },
 }
 
 /// SELECT 절의 컬럼 표현식
@@ -788,6 +799,10 @@ impl Parser {
                     "true" => return Ok(Expr::Literal(LiteralValue::Bool(true))),
                     "false" => return Ok(Expr::Literal(LiteralValue::Bool(false))),
                     "null" => return Ok(Expr::Literal(LiteralValue::Null)),
+                    // if(condition, then_expr, else_expr)
+                    "if" => return self.parse_if_expr(),
+                    // case when ... then ... [when ... then ...] [else ...] end
+                    "case" => return self.parse_case_expr(),
                     _ => {}
                 }
                 // Check for function call: name(...)
@@ -828,6 +843,100 @@ impl Parser {
                 self.pos
             ))),
         }
+    }
+
+    /// `if(condition, then_expr, else_expr)` 파싱
+    fn parse_if_expr(&mut self) -> Result<Expr, DkitError> {
+        self.skip_whitespace();
+        if !self.consume_char('(') {
+            return Err(DkitError::QueryError(format!(
+                "expected '(' after 'if' at position {}",
+                self.pos
+            )));
+        }
+        self.skip_whitespace();
+        let condition = self.parse_condition()?;
+        self.skip_whitespace();
+        if !self.consume_char(',') {
+            return Err(DkitError::QueryError(format!(
+                "expected ',' after condition in if() at position {}",
+                self.pos
+            )));
+        }
+        self.skip_whitespace();
+        let then_expr = self.parse_expr()?;
+        self.skip_whitespace();
+        if !self.consume_char(',') {
+            return Err(DkitError::QueryError(format!(
+                "expected ',' after then-expression in if() at position {}",
+                self.pos
+            )));
+        }
+        self.skip_whitespace();
+        let else_expr = self.parse_expr()?;
+        self.skip_whitespace();
+        if !self.consume_char(')') {
+            return Err(DkitError::QueryError(format!(
+                "expected ')' at position {}",
+                self.pos
+            )));
+        }
+        Ok(Expr::If {
+            condition,
+            then_expr: Box::new(then_expr),
+            else_expr: Box::new(else_expr),
+        })
+    }
+
+    /// `case when cond then expr [when cond then expr]* [else expr] end` 파싱
+    fn parse_case_expr(&mut self) -> Result<Expr, DkitError> {
+        let mut branches = Vec::new();
+        let mut default = None;
+
+        loop {
+            self.skip_whitespace();
+            let saved_pos = self.pos;
+            let keyword = self.parse_keyword().unwrap_or_default();
+            match keyword.as_str() {
+                "when" => {
+                    self.skip_whitespace();
+                    let condition = self.parse_condition()?;
+                    self.skip_whitespace();
+                    let then_kw = self.parse_keyword()?;
+                    if then_kw != "then" {
+                        return Err(DkitError::QueryError(format!(
+                            "expected 'then' after condition in case expression, found '{}'",
+                            then_kw
+                        )));
+                    }
+                    self.skip_whitespace();
+                    let expr = self.parse_expr()?;
+                    branches.push((condition, expr));
+                }
+                "else" => {
+                    self.skip_whitespace();
+                    default = Some(Box::new(self.parse_expr()?));
+                }
+                "end" => {
+                    break;
+                }
+                _ => {
+                    self.pos = saved_pos;
+                    return Err(DkitError::QueryError(format!(
+                        "expected 'when', 'else', or 'end' in case expression at position {}",
+                        self.pos
+                    )));
+                }
+            }
+        }
+
+        if branches.is_empty() {
+            return Err(DkitError::QueryError(
+                "case expression requires at least one 'when' branch".to_string(),
+            ));
+        }
+
+        Ok(Expr::Case { branches, default })
     }
 
     /// 쉼표로 구분된 식별자 목록 파싱: `IDENTIFIER ( "," IDENTIFIER )*`
@@ -2485,5 +2594,145 @@ mod tests {
             vec![Segment::RecursiveDescent("name".to_string())]
         );
         assert_eq!(q.operations.len(), 1);
+    }
+
+    // --- if() expression tests ---
+
+    #[test]
+    fn test_if_expr_simple() {
+        let q = parse_query(".items[] | select if(age < 18, \"minor\", \"adult\") as category")
+            .unwrap();
+        assert_eq!(q.operations.len(), 1);
+        if let Operation::Select(exprs) = &q.operations[0] {
+            assert_eq!(exprs.len(), 1);
+            assert_eq!(exprs[0].alias, Some("category".to_string()));
+            assert!(matches!(&exprs[0].expr, Expr::If { .. }));
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_if_expr_nested() {
+        let q = parse_query(
+            ".[] | select if(age < 18, \"minor\", if(age < 65, \"adult\", \"senior\")) as cat",
+        )
+        .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::If { else_expr, .. } = &exprs[0].expr {
+                assert!(matches!(else_expr.as_ref(), Expr::If { .. }));
+            } else {
+                panic!("expected If expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_if_expr_with_and_condition() {
+        let q = parse_query(".[] | select if(age > 18 and age < 65, \"adult\", \"other\") as cat")
+            .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::If { condition, .. } = &exprs[0].expr {
+                assert!(matches!(condition, Condition::And(_, _)));
+            } else {
+                panic!("expected If expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_if_expr_missing_paren() {
+        let result = parse_query(".[] | select if age < 18, \"minor\", \"adult\"");
+        assert!(result.is_err());
+    }
+
+    // --- case/when expression tests ---
+
+    #[test]
+    fn test_case_simple() {
+        let q = parse_query(
+            ".[] | select case when status == \"active\" then \"A\" else \"I\" end as code",
+        )
+        .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Case { branches, default } = &exprs[0].expr {
+                assert_eq!(branches.len(), 1);
+                assert!(default.is_some());
+            } else {
+                panic!("expected Case expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_case_multiple_when() {
+        let q = parse_query(
+            ".[] | select case when age < 18 then \"minor\" when age < 65 then \"adult\" else \"senior\" end as category",
+        )
+        .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Case { branches, default } = &exprs[0].expr {
+                assert_eq!(branches.len(), 2);
+                assert!(default.is_some());
+            } else {
+                panic!("expected Case expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_case_no_else() {
+        let q =
+            parse_query(".[] | select case when status == \"active\" then \"yes\" end as active")
+                .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Case { branches, default } = &exprs[0].expr {
+                assert_eq!(branches.len(), 1);
+                assert!(default.is_none());
+            } else {
+                panic!("expected Case expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_case_no_when_fails() {
+        let result = parse_query(".[] | select case else \"x\" end as y");
+        assert!(result.is_err());
+    }
+
+    // --- if/case in add-field ---
+
+    #[test]
+    fn test_add_field_with_if() {
+        let (name, expr) =
+            parse_add_field_expr("tier = if(revenue > 10000, \"gold\", \"silver\")").unwrap();
+        assert_eq!(name, "tier");
+        assert!(matches!(expr, Expr::If { .. }));
+    }
+
+    #[test]
+    fn test_add_field_with_case() {
+        let (name, expr) = parse_add_field_expr(
+            "tier = case when revenue > 10000 then \"gold\" when revenue > 5000 then \"silver\" else \"bronze\" end",
+        )
+        .unwrap();
+        assert_eq!(name, "tier");
+        if let Expr::Case { branches, default } = expr {
+            assert_eq!(branches.len(), 2);
+            assert!(default.is_some());
+        } else {
+            panic!("expected Case expression");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `if(condition, then_expr, else_expr)` function-style conditional expression supporting nesting for simple cases
- Add `case when cond then expr [when ...] [else expr] end` SQL-style conditional for multi-branch scenarios
- Both forms work in `select`, `--add-field`, and `--map` contexts
- 22 new tests covering parsing, evaluation, nested conditions, edge cases, and integration with pipeline operations

## Implementation
- New `Expr::If` and `Expr::Case` AST variants in `parser.rs`
- Parser methods `parse_if_expr()` and `parse_case_expr()` with full condition support (and/or, all comparison operators)
- Evaluation in `functions.rs` using existing `evaluate_condition` infrastructure (made `pub(crate)`)
- `case` without `else` returns `null` when no branch matches

## Usage Examples
```bash
# if/then/else (simple)
dkit query data.json '.[] | select name, if(age < 18, "minor", "adult") as category'

# Nested if
dkit query data.json '.[] | select if(age < 18, "minor", if(age < 65, "adult", "senior")) as cat'

# case/when (SQL-style)
dkit query data.json '.[] | select name, case when age < 18 then "minor" when age < 65 then "adult" else "senior" end as category'

# --add-field
dkit convert sales.csv -f csv --add-field 'tier = if(revenue > 10000, "gold", "silver")'
```

Closes #213

https://claude.ai/code/session_01BGCTMRZbE11MpxoVwjDEZq