### PR TITLE
feat: add statistical aggregate functions (median, percentile, stddev, variance, mode, group_concat)

### DIFF
--- a/dkit-core/src/query/filter.rs
+++ b/dkit-core/src/query/filter.rs
@@ -29,6 +29,12 @@ fn apply_operation(value: Value, operation: &Operation) -> Result<Value, DkitErr
         Operation::Min { field } => apply_min(value, field),
         Operation::Max { field } => apply_max(value, field),
         Operation::Distinct { field } => apply_distinct(value, field),
+        Operation::Median { field } => apply_median(value, field),
+        Operation::Percentile { field, p } => apply_percentile(value, field, *p),
+        Operation::Stddev { field } => apply_stddev(value, field),
+        Operation::Variance { field } => apply_variance(value, field),
+        Operation::Mode { field } => apply_mode(value, field),
+        Operation::GroupConcat { field, separator } => apply_group_concat(value, field, separator),
         Operation::GroupBy {
             fields,
             having,
@@ -404,6 +410,213 @@ fn apply_distinct(value: Value, field: &str) -> Result<Value, DkitError> {
         }
         _ => Err(DkitError::QueryError(
             "distinct requires an array input".to_string(),
+        )),
+    }
+}
+
+/// 배열에서 숫자 필드 값을 추출하는 헬퍼
+fn collect_numeric_values(arr: &[Value], field: &str) -> Result<Vec<f64>, DkitError> {
+    let mut values = Vec::new();
+    for item in arr {
+        match item {
+            Value::Object(map) => match map.get(field) {
+                Some(Value::Integer(n)) => values.push(*n as f64),
+                Some(Value::Float(f)) => values.push(*f),
+                Some(Value::Null) | None => {}
+                Some(v) => {
+                    return Err(DkitError::QueryError(format!(
+                        "field '{}' is not numeric (got {})",
+                        field, v
+                    )));
+                }
+            },
+            _ => {
+                return Err(DkitError::QueryError(
+                    "requires an array of objects".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(values)
+}
+
+/// 아이템 슬라이스에서 숫자 필드 값을 추출하는 헬퍼 (group aggregate용)
+fn collect_numeric_values_from_items(items: &[Value], field: &str) -> Vec<f64> {
+    let mut values = Vec::new();
+    for item in items {
+        if let Value::Object(map) = item {
+            match map.get(field) {
+                Some(Value::Integer(n)) => values.push(*n as f64),
+                Some(Value::Float(f)) => values.push(*f),
+                _ => {}
+            }
+        }
+    }
+    values
+}
+
+/// percentile 계산 헬퍼 (linear interpolation)
+fn compute_percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let index = p * (sorted.len() - 1) as f64;
+    let lower = index.floor() as usize;
+    let upper = index.ceil() as usize;
+    if lower == upper {
+        sorted[lower]
+    } else {
+        let frac = index - lower as f64;
+        sorted[lower] * (1.0 - frac) + sorted[upper] * frac
+    }
+}
+
+/// median: 배열에서 지정된 숫자 필드의 중앙값을 반환
+fn apply_median(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut values = collect_numeric_values(&arr, field)?;
+            if values.is_empty() {
+                return Ok(Value::Null);
+            }
+            values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let mid = values.len() / 2;
+            if values.len() % 2 == 0 {
+                Ok(Value::Float((values[mid - 1] + values[mid]) / 2.0))
+            } else {
+                Ok(Value::Float(values[mid]))
+            }
+        }
+        _ => Err(DkitError::QueryError(
+            "median requires an array input".to_string(),
+        )),
+    }
+}
+
+/// percentile: 배열에서 지정된 숫자 필드의 p번째 백분위수를 반환
+fn apply_percentile(value: Value, field: &str, p: f64) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut values = collect_numeric_values(&arr, field)?;
+            if values.is_empty() {
+                return Ok(Value::Null);
+            }
+            values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            Ok(Value::Float(compute_percentile(&values, p)))
+        }
+        _ => Err(DkitError::QueryError(
+            "percentile requires an array input".to_string(),
+        )),
+    }
+}
+
+/// stddev: 배열에서 지정된 숫자 필드의 표준편차(모집단)를 반환
+fn apply_stddev(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let values = collect_numeric_values(&arr, field)?;
+            if values.is_empty() {
+                return Ok(Value::Null);
+            }
+            let mean = values.iter().sum::<f64>() / values.len() as f64;
+            let variance =
+                values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / values.len() as f64;
+            Ok(Value::Float(variance.sqrt()))
+        }
+        _ => Err(DkitError::QueryError(
+            "stddev requires an array input".to_string(),
+        )),
+    }
+}
+
+/// variance: 배열에서 지정된 숫자 필드의 분산을 반환
+fn apply_variance(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let values = collect_numeric_values(&arr, field)?;
+            if values.is_empty() {
+                return Ok(Value::Null);
+            }
+            let mean = values.iter().sum::<f64>() / values.len() as f64;
+            let variance =
+                values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / values.len() as f64;
+            Ok(Value::Float(variance))
+        }
+        _ => Err(DkitError::QueryError(
+            "variance requires an array input".to_string(),
+        )),
+    }
+}
+
+/// mode: 배열에서 지정된 필드의 최빈값을 반환
+fn apply_mode(value: Value, field: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut freq: Vec<(Value, usize)> = Vec::new();
+            for item in &arr {
+                match item {
+                    Value::Object(map) => {
+                        if let Some(v) = map.get(field) {
+                            if matches!(v, Value::Null) {
+                                continue;
+                            }
+                            if let Some(entry) = freq.iter_mut().find(|(val, _)| val == v) {
+                                entry.1 += 1;
+                            } else {
+                                freq.push((v.clone(), 1));
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(DkitError::QueryError(
+                            "mode requires an array of objects".to_string(),
+                        ));
+                    }
+                }
+            }
+            if freq.is_empty() {
+                return Ok(Value::Null);
+            }
+            let max_count = freq.iter().map(|(_, c)| *c).max().unwrap_or(0);
+            let mode_val = freq.into_iter().find(|(_, c)| *c == max_count).unwrap().0;
+            Ok(mode_val)
+        }
+        _ => Err(DkitError::QueryError(
+            "mode requires an array input".to_string(),
+        )),
+    }
+}
+
+/// group_concat: 배열에서 지정된 필드의 값을 문자열로 연결
+fn apply_group_concat(value: Value, field: &str, separator: &str) -> Result<Value, DkitError> {
+    match value {
+        Value::Array(arr) => {
+            let mut parts: Vec<String> = Vec::new();
+            for item in &arr {
+                match item {
+                    Value::Object(map) => {
+                        if let Some(v) = map.get(field) {
+                            match v {
+                                Value::Null => {}
+                                Value::String(s) => parts.push(s.clone()),
+                                Value::Integer(n) => parts.push(n.to_string()),
+                                Value::Float(f) => parts.push(f.to_string()),
+                                Value::Bool(b) => parts.push(b.to_string()),
+                                _ => parts.push(format!("{}", v)),
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(DkitError::QueryError(
+                            "group_concat requires an array of objects".to_string(),
+                        ));
+                    }
+                }
+            }
+            Ok(Value::String(parts.join(separator)))
+        }
+        _ => Err(DkitError::QueryError(
+            "group_concat requires an array input".to_string(),
         )),
     }
 }
@@ -901,6 +1114,106 @@ fn compute_group_aggregate(
                 }
             }
             Ok(max_val.unwrap_or(Value::Null))
+        }
+        AggregateFunc::Median => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("median() requires a field argument".to_string())
+            })?;
+            let mut values = collect_numeric_values_from_items(items, f);
+            if values.is_empty() {
+                return Ok(Value::Null);
+            }
+            values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let mid = values.len() / 2;
+            if values.len() % 2 == 0 {
+                Ok(Value::Float((values[mid - 1] + values[mid]) / 2.0))
+            } else {
+                Ok(Value::Float(values[mid]))
+            }
+        }
+        AggregateFunc::Percentile(p) => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("percentile() requires a field argument".to_string())
+            })?;
+            let mut values = collect_numeric_values_from_items(items, f);
+            if values.is_empty() {
+                return Ok(Value::Null);
+            }
+            values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            Ok(Value::Float(compute_percentile(&values, *p)))
+        }
+        AggregateFunc::Stddev => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("stddev() requires a field argument".to_string())
+            })?;
+            let values = collect_numeric_values_from_items(items, f);
+            if values.is_empty() {
+                return Ok(Value::Null);
+            }
+            let mean = values.iter().sum::<f64>() / values.len() as f64;
+            let variance =
+                values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / values.len() as f64;
+            Ok(Value::Float(variance.sqrt()))
+        }
+        AggregateFunc::Variance => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("variance() requires a field argument".to_string())
+            })?;
+            let values = collect_numeric_values_from_items(items, f);
+            if values.is_empty() {
+                return Ok(Value::Null);
+            }
+            let mean = values.iter().sum::<f64>() / values.len() as f64;
+            let variance =
+                values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / values.len() as f64;
+            Ok(Value::Float(variance))
+        }
+        AggregateFunc::Mode => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("mode() requires a field argument".to_string())
+            })?;
+            let mut freq: Vec<(Value, usize)> = Vec::new();
+            for item in items {
+                if let Value::Object(map) = item {
+                    if let Some(v) = map.get(f) {
+                        if matches!(v, Value::Null) {
+                            continue;
+                        }
+                        if let Some(entry) = freq.iter_mut().find(|(val, _)| val == v) {
+                            entry.1 += 1;
+                        } else {
+                            freq.push((v.clone(), 1));
+                        }
+                    }
+                }
+            }
+            if freq.is_empty() {
+                return Ok(Value::Null);
+            }
+            let max_count = freq.iter().map(|(_, c)| *c).max().unwrap_or(0);
+            let mode_val = freq.into_iter().find(|(_, c)| *c == max_count).unwrap().0;
+            Ok(mode_val)
+        }
+        AggregateFunc::GroupConcat(separator) => {
+            let f = field.ok_or_else(|| {
+                DkitError::QueryError("group_concat() requires a field argument".to_string())
+            })?;
+            let mut parts: Vec<String> = Vec::new();
+            for item in items {
+                if let Value::Object(map) = item {
+                    if let Some(v) = map.get(f) {
+                        match v {
+                            Value::Null => {}
+                            Value::String(s) => parts.push(s.clone()),
+                            Value::Integer(n) => parts.push(n.to_string()),
+                            Value::Float(fv) => parts.push(fv.to_string()),
+                            Value::Bool(b) => parts.push(b.to_string()),
+                            _ => parts.push(format!("{}", v)),
+                        }
+                    }
+                }
+            }
+            Ok(Value::String(parts.join(separator)))
         }
     }
 }
@@ -3193,5 +3506,453 @@ mod tests {
             arr[2].as_object().unwrap()["group"],
             Value::String("A".to_string())
         );
+    }
+
+    // --- 통계 집계 함수 테스트 ---
+
+    fn sample_scores() -> Value {
+        Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Alice".to_string()));
+                m.insert("score".to_string(), Value::Integer(90));
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Bob".to_string()));
+                m.insert("score".to_string(), Value::Integer(80));
+                m.insert("dept".to_string(), Value::String("B".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Charlie".to_string()));
+                m.insert("score".to_string(), Value::Integer(70));
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Diana".to_string()));
+                m.insert("score".to_string(), Value::Integer(85));
+                m.insert("dept".to_string(), Value::String("B".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Eve".to_string()));
+                m.insert("score".to_string(), Value::Integer(95));
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                Value::Object(m)
+            },
+        ])
+    }
+
+    #[test]
+    fn test_median_odd_count() {
+        let data = sample_scores();
+        let query = parse_query(".[] | median score").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        // sorted: 70, 80, 85, 90, 95 → median = 85.0
+        assert_eq!(result, Value::Float(85.0));
+    }
+
+    #[test]
+    fn test_median_even_count() {
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("val".to_string(), Value::Integer(10));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("val".to_string(), Value::Integer(20));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("val".to_string(), Value::Integer(30));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("val".to_string(), Value::Integer(40));
+                Value::Object(m)
+            },
+        ]);
+        let query = parse_query(".[] | median val").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        // sorted: 10, 20, 30, 40 → median = (20+30)/2 = 25.0
+        assert_eq!(result, Value::Float(25.0));
+    }
+
+    #[test]
+    fn test_median_empty() {
+        let data = Value::Array(vec![]);
+        let result = apply_median(data, "val").unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_percentile_basic() {
+        let data = sample_scores();
+        let query = parse_query(".[] | percentile score 0.5").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        // sorted: 70, 80, 85, 90, 95 → p50 = 85.0
+        assert_eq!(result, Value::Float(85.0));
+    }
+
+    #[test]
+    fn test_percentile_p0_and_p1() {
+        let data = sample_scores();
+        // p=0.0 → minimum
+        let result = apply_percentile(data.clone(), "score", 0.0).unwrap();
+        assert_eq!(result, Value::Float(70.0));
+
+        // p=1.0 → maximum
+        let result = apply_percentile(data, "score", 1.0).unwrap();
+        assert_eq!(result, Value::Float(95.0));
+    }
+
+    #[test]
+    fn test_percentile_interpolation() {
+        // Values: 10, 20, 30, 40 → p=0.25 → index=0.75 → lerp(10,20,0.75) = 17.5
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("v".to_string(), Value::Integer(10));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("v".to_string(), Value::Integer(20));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("v".to_string(), Value::Integer(30));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("v".to_string(), Value::Integer(40));
+                Value::Object(m)
+            },
+        ]);
+        let result = apply_percentile(data, "v", 0.25).unwrap();
+        assert_eq!(result, Value::Float(17.5));
+    }
+
+    #[test]
+    fn test_percentile_empty() {
+        let data = Value::Array(vec![]);
+        let result = apply_percentile(data, "val", 0.5).unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_stddev_basic() {
+        // values: 70, 80, 85, 90, 95 → mean=84, variance=((14^2+4^2+1+6^2+11^2)/5)=74, stddev=sqrt(74)
+        let data = sample_scores();
+        let query = parse_query(".[] | stddev score").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        match result {
+            Value::Float(f) => {
+                let expected = (74.0_f64).sqrt(); // ~8.602
+                assert!(
+                    (f - expected).abs() < 0.001,
+                    "stddev was {}, expected {}",
+                    f,
+                    expected
+                );
+            }
+            _ => panic!("expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_stddev_empty() {
+        let data = Value::Array(vec![]);
+        let result = apply_stddev(data, "score").unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_variance_basic() {
+        let data = sample_scores();
+        let query = parse_query(".[] | variance score").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        match result {
+            Value::Float(f) => {
+                // mean=84, var = (196+16+1+36+121)/5 = 370/5 = 74
+                assert!(
+                    (f - 74.0).abs() < 0.001,
+                    "variance was {}, expected 74.0",
+                    f
+                );
+            }
+            _ => panic!("expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_variance_empty() {
+        let data = Value::Array(vec![]);
+        let result = apply_variance(data, "score").unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_mode_basic() {
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("color".to_string(), Value::String("red".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("color".to_string(), Value::String("blue".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("color".to_string(), Value::String("red".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("color".to_string(), Value::String("green".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("color".to_string(), Value::String("red".to_string()));
+                Value::Object(m)
+            },
+        ]);
+        let query = parse_query(".[] | mode color").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(result, Value::String("red".to_string()));
+    }
+
+    #[test]
+    fn test_mode_numeric() {
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("v".to_string(), Value::Integer(1));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("v".to_string(), Value::Integer(2));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("v".to_string(), Value::Integer(2));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("v".to_string(), Value::Integer(3));
+                Value::Object(m)
+            },
+        ]);
+        let result = apply_mode(data, "v").unwrap();
+        assert_eq!(result, Value::Integer(2));
+    }
+
+    #[test]
+    fn test_mode_empty() {
+        let data = Value::Array(vec![]);
+        let result = apply_mode(data, "v").unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_group_concat_basic() {
+        let data = sample_scores();
+        let query = parse_query(".[] | group_concat name \", \"").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(
+            result,
+            Value::String("Alice, Bob, Charlie, Diana, Eve".to_string())
+        );
+    }
+
+    #[test]
+    fn test_group_concat_default_separator() {
+        let data = sample_scores();
+        let query = parse_query(".[] | group_concat name").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        assert_eq!(
+            result,
+            Value::String("Alice, Bob, Charlie, Diana, Eve".to_string())
+        );
+    }
+
+    #[test]
+    fn test_group_concat_with_integers() {
+        let data = sample_scores();
+        let result = apply_group_concat(data, "score", "-").unwrap();
+        assert_eq!(result, Value::String("90-80-70-85-95".to_string()));
+    }
+
+    #[test]
+    fn test_group_concat_empty() {
+        let data = Value::Array(vec![]);
+        let result = apply_group_concat(data, "name", ", ").unwrap();
+        assert_eq!(result, Value::String("".to_string()));
+    }
+
+    // --- group_by with new aggregate functions ---
+
+    #[test]
+    fn test_group_by_median() {
+        let data = sample_scores();
+        let query = parse_query(".[] | group_by dept median(score)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // dept A: scores 90, 70, 95 → sorted: 70, 90, 95 → median = 90.0
+        let dept_a = arr
+            .iter()
+            .find(|o| o.as_object().unwrap().get("dept") == Some(&Value::String("A".to_string())))
+            .unwrap();
+        assert_eq!(
+            dept_a.as_object().unwrap().get("median_score"),
+            Some(&Value::Float(90.0))
+        );
+        // dept B: scores 80, 85 → median = 82.5
+        let dept_b = arr
+            .iter()
+            .find(|o| o.as_object().unwrap().get("dept") == Some(&Value::String("B".to_string())))
+            .unwrap();
+        assert_eq!(
+            dept_b.as_object().unwrap().get("median_score"),
+            Some(&Value::Float(82.5))
+        );
+    }
+
+    #[test]
+    fn test_group_by_percentile() {
+        let data = sample_scores();
+        let query = parse_query(".[] | group_by dept percentile(score, 0.5)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_group_by_stddev() {
+        let data = sample_scores();
+        let query = parse_query(".[] | group_by dept stddev(score)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // Just verify it returns Float values
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert!(matches!(obj.get("stddev_score"), Some(Value::Float(_))));
+        }
+    }
+
+    #[test]
+    fn test_group_by_variance() {
+        let data = sample_scores();
+        let query = parse_query(".[] | group_by dept variance(score)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert!(matches!(obj.get("variance_score"), Some(Value::Float(_))));
+        }
+    }
+
+    #[test]
+    fn test_group_by_mode() {
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                m.insert("grade".to_string(), Value::String("A".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                m.insert("grade".to_string(), Value::String("B".to_string()));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                m.insert("grade".to_string(), Value::String("A".to_string()));
+                Value::Object(m)
+            },
+        ]);
+        let query = parse_query(".[] | group_by dept mode(grade)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(
+            arr[0].as_object().unwrap().get("mode_grade"),
+            Some(&Value::String("A".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_group_by_group_concat() {
+        let data = sample_scores();
+        let query = parse_query(".[] | group_by dept group_concat(name, \", \")").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // dept A: Alice, Charlie, Eve
+        let dept_a = arr
+            .iter()
+            .find(|o| o.as_object().unwrap().get("dept") == Some(&Value::String("A".to_string())))
+            .unwrap();
+        assert_eq!(
+            dept_a.as_object().unwrap().get("group_concat_name"),
+            Some(&Value::String("Alice, Charlie, Eve".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_group_by_multiple_new_aggregates() {
+        let data = sample_scores();
+        let query =
+            parse_query(".[] | group_by dept median(score), stddev(score), mode(score)").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert!(obj.contains_key("median_score"));
+            assert!(obj.contains_key("stddev_score"));
+            assert!(obj.contains_key("mode_score"));
+        }
     }
 }

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -61,6 +61,18 @@ pub enum Operation {
     Max { field: String },
     /// `distinct field` 고유값 목록
     Distinct { field: String },
+    /// `median field` 중앙값
+    Median { field: String },
+    /// `percentile field p` p번째 백분위수 (p: 0.0~1.0)
+    Percentile { field: String, p: f64 },
+    /// `stddev field` 표준편차 (모집단)
+    Stddev { field: String },
+    /// `variance field` 분산
+    Variance { field: String },
+    /// `mode field` 최빈값
+    Mode { field: String },
+    /// `group_concat field separator` 그룹 내 문자열 연결
+    GroupConcat { field: String, separator: String },
     /// `group_by field1, field2` 그룹별 집계
     /// 집계 연산: `group_by category | select category, count, sum_price`
     GroupBy {
@@ -117,6 +129,12 @@ pub enum AggregateFunc {
     Avg,
     Min,
     Max,
+    Median,
+    Percentile(f64),
+    Stddev,
+    Variance,
+    Mode,
+    GroupConcat(String),
 }
 
 /// Boolean condition used in `where` clauses.
@@ -541,6 +559,52 @@ impl Parser {
                 let field = self.parse_identifier()?;
                 Ok(Operation::Distinct { field })
             }
+            "median" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Median { field })
+            }
+            "percentile" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                self.skip_whitespace();
+                let p = self.parse_float_value()?;
+                if !(0.0..=1.0).contains(&p) {
+                    return Err(DkitError::QueryError(
+                        "percentile: p must be between 0.0 and 1.0".to_string(),
+                    ));
+                }
+                Ok(Operation::Percentile { field, p })
+            }
+            "stddev" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Stddev { field })
+            }
+            "variance" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Variance { field })
+            }
+            "mode" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                Ok(Operation::Mode { field })
+            }
+            "group_concat" => {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                self.skip_whitespace();
+                let separator = if self.peek() == Some('"') {
+                    match self.parse_string_literal()? {
+                        LiteralValue::String(s) => s,
+                        _ => ", ".to_string(),
+                    }
+                } else {
+                    ", ".to_string()
+                };
+                Ok(Operation::GroupConcat { field, separator })
+            }
             "group_by" => {
                 self.skip_whitespace();
                 let fields = self.parse_identifier_list()?;
@@ -607,18 +671,25 @@ impl Parser {
             }
         };
 
-        let func = match func_name.as_str() {
-            "count" => AggregateFunc::Count,
-            "sum" => AggregateFunc::Sum,
-            "avg" => AggregateFunc::Avg,
-            "min" => AggregateFunc::Min,
-            "max" => AggregateFunc::Max,
-            _ => {
-                // Not an aggregate function, restore position
-                self.pos = saved_pos;
-                return Ok(None);
-            }
-        };
+        // Check if it's a known aggregate function name
+        let is_known = matches!(
+            func_name.as_str(),
+            "count"
+                | "sum"
+                | "avg"
+                | "min"
+                | "max"
+                | "median"
+                | "percentile"
+                | "stddev"
+                | "variance"
+                | "mode"
+                | "group_concat"
+        );
+        if !is_known {
+            self.pos = saved_pos;
+            return Ok(None);
+        }
 
         self.skip_whitespace();
 
@@ -635,6 +706,50 @@ impl Parser {
             None
         } else {
             Some(self.parse_identifier()?)
+        };
+
+        self.skip_whitespace();
+
+        // Parse extra arguments for percentile and group_concat
+        let func = match func_name.as_str() {
+            "count" => AggregateFunc::Count,
+            "sum" => AggregateFunc::Sum,
+            "avg" => AggregateFunc::Avg,
+            "min" => AggregateFunc::Min,
+            "max" => AggregateFunc::Max,
+            "median" => AggregateFunc::Median,
+            "percentile" => {
+                if !self.consume_char(',') {
+                    return Err(DkitError::QueryError(format!(
+                        "percentile() requires a second argument (p value) at position {}",
+                        self.pos
+                    )));
+                }
+                self.skip_whitespace();
+                let p = self.parse_float_value()?;
+                if !(0.0..=1.0).contains(&p) {
+                    return Err(DkitError::QueryError(
+                        "percentile: p must be between 0.0 and 1.0".to_string(),
+                    ));
+                }
+                AggregateFunc::Percentile(p)
+            }
+            "stddev" => AggregateFunc::Stddev,
+            "variance" => AggregateFunc::Variance,
+            "mode" => AggregateFunc::Mode,
+            "group_concat" => {
+                let separator = if self.consume_char(',') {
+                    self.skip_whitespace();
+                    match self.parse_string_literal()? {
+                        LiteralValue::String(s) => s,
+                        _ => ", ".to_string(),
+                    }
+                } else {
+                    ", ".to_string()
+                };
+                AggregateFunc::GroupConcat(separator)
+            }
+            _ => unreachable!(),
         };
 
         self.skip_whitespace();
@@ -1357,6 +1472,36 @@ impl Parser {
     }
 
     /// 양의 정수 파싱 (limit 절용)
+    /// 부동소수점 값 파싱 (0.95 등)
+    fn parse_float_value(&mut self) -> Result<f64, DkitError> {
+        let start = self.pos;
+        if self.peek() == Some('-') {
+            self.advance();
+        }
+        while !self.is_at_end() && self.input[self.pos].is_ascii_digit() {
+            self.pos += 1;
+        }
+        if self.peek() == Some('.') {
+            self.advance();
+            while !self.is_at_end() && self.input[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+        if self.pos == start {
+            return Err(DkitError::QueryError(format!(
+                "expected number at position {}",
+                self.pos
+            )));
+        }
+        let num_str: String = self.input[start..self.pos].iter().collect();
+        num_str.parse().map_err(|_| {
+            DkitError::QueryError(format!(
+                "invalid number '{}' at position {}",
+                num_str, start
+            ))
+        })
+    }
+
     fn parse_positive_integer(&mut self) -> Result<usize, DkitError> {
         let start = self.pos;
         while !self.is_at_end() && self.input[self.pos].is_ascii_digit() {
@@ -2733,6 +2878,131 @@ mod tests {
             assert!(default.is_some());
         } else {
             panic!("expected Case expression");
+        }
+    }
+
+    // --- 통계 집계 함수 파싱 테스트 ---
+
+    #[test]
+    fn test_parse_median() {
+        let q = parse_query(".[] | median score").unwrap();
+        assert!(matches!(&q.operations[0], Operation::Median { field } if field == "score"));
+    }
+
+    #[test]
+    fn test_parse_percentile() {
+        let q = parse_query(".[] | percentile score 0.95").unwrap();
+        if let Operation::Percentile { field, p } = &q.operations[0] {
+            assert_eq!(field, "score");
+            assert!((p - 0.95).abs() < f64::EPSILON);
+        } else {
+            panic!("expected Percentile operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_percentile_invalid_p() {
+        let result = parse_query(".[] | percentile score 1.5");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_stddev() {
+        let q = parse_query(".[] | stddev salary").unwrap();
+        assert!(matches!(&q.operations[0], Operation::Stddev { field } if field == "salary"));
+    }
+
+    #[test]
+    fn test_parse_variance() {
+        let q = parse_query(".[] | variance salary").unwrap();
+        assert!(matches!(&q.operations[0], Operation::Variance { field } if field == "salary"));
+    }
+
+    #[test]
+    fn test_parse_mode() {
+        let q = parse_query(".[] | mode category").unwrap();
+        assert!(matches!(&q.operations[0], Operation::Mode { field } if field == "category"));
+    }
+
+    #[test]
+    fn test_parse_group_concat() {
+        let q = parse_query(".[] | group_concat name \", \"").unwrap();
+        if let Operation::GroupConcat { field, separator } = &q.operations[0] {
+            assert_eq!(field, "name");
+            assert_eq!(separator, ", ");
+        } else {
+            panic!("expected GroupConcat operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_group_concat_default_separator() {
+        let q = parse_query(".[] | group_concat name").unwrap();
+        if let Operation::GroupConcat { field, separator } = &q.operations[0] {
+            assert_eq!(field, "name");
+            assert_eq!(separator, ", ");
+        } else {
+            panic!("expected GroupConcat operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_group_by_with_median() {
+        let q = parse_query(".[] | group_by dept median(score)").unwrap();
+        if let Operation::GroupBy {
+            fields, aggregates, ..
+        } = &q.operations[0]
+        {
+            assert_eq!(fields, &["dept"]);
+            assert_eq!(aggregates.len(), 1);
+            assert!(matches!(aggregates[0].func, AggregateFunc::Median));
+            assert_eq!(aggregates[0].field, Some("score".to_string()));
+            assert_eq!(aggregates[0].alias, "median_score");
+        } else {
+            panic!("expected GroupBy operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_group_by_with_percentile() {
+        let q = parse_query(".[] | group_by dept percentile(score, 0.95)").unwrap();
+        if let Operation::GroupBy { aggregates, .. } = &q.operations[0] {
+            assert_eq!(aggregates.len(), 1);
+            if let AggregateFunc::Percentile(p) = aggregates[0].func {
+                assert!((p - 0.95).abs() < f64::EPSILON);
+            } else {
+                panic!("expected Percentile aggregate");
+            }
+        } else {
+            panic!("expected GroupBy operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_group_by_with_group_concat() {
+        let q = parse_query(".[] | group_by dept group_concat(name, \", \")").unwrap();
+        if let Operation::GroupBy { aggregates, .. } = &q.operations[0] {
+            assert_eq!(aggregates.len(), 1);
+            if let AggregateFunc::GroupConcat(sep) = &aggregates[0].func {
+                assert_eq!(sep, ", ");
+            } else {
+                panic!("expected GroupConcat aggregate");
+            }
+        } else {
+            panic!("expected GroupBy operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_group_by_mixed_aggregates() {
+        let q = parse_query(".[] | group_by dept count(), median(score), stddev(score)").unwrap();
+        if let Operation::GroupBy { aggregates, .. } = &q.operations[0] {
+            assert_eq!(aggregates.len(), 3);
+            assert!(matches!(aggregates[0].func, AggregateFunc::Count));
+            assert!(matches!(aggregates[1].func, AggregateFunc::Median));
+            assert!(matches!(aggregates[2].func, AggregateFunc::Stddev));
+        } else {
+            panic!("expected GroupBy operation");
         }
     }
 }


### PR DESCRIPTION
## Summary
- 쿼리 엔진에 6개의 통계 집계 함수 추가: `median`, `percentile`, `stddev`, `variance`, `mode`, `group_concat`
- 파이프라인 연산(`| median score`)과 `group_by` 내 집계(`group_by dept median(score)`) 모두 지원
- 파서, 평가기, 단위 테스트 포함 (713 tests all passing)

## 추가된 함수
| 함수 | 설명 | 사용 예시 |
|------|------|----------|
| `median(field)` | 중앙값 | `.[] \| median salary` |
| `percentile(field, p)` | p번째 백분위수 (0.0~1.0) | `.[] \| percentile latency 0.95` |
| `stddev(field)` | 표준편차 (모집단) | `.[] \| stddev score` |
| `variance(field)` | 분산 | `.[] \| variance score` |
| `mode(field)` | 최빈값 | `.[] \| mode category` |
| `group_concat(field, sep)` | 문자열 연결 | `.[] \| group_concat name ", "` |

## Test plan
- [x] `cargo test` — 713 tests 전체 통과
- [x] `cargo clippy -- -D warnings` — 경고 없음
- [x] `cargo fmt -- --check` — 포맷 통과
- [x] 파이프라인 연산 단위 테스트 (median, percentile, stddev, variance, mode, group_concat)
- [x] group_by 집계 단위 테스트 (모든 새 함수)
- [x] 파서 단위 테스트 (새 키워드, 인자 파싱, 에러 케이스)

Closes #214

https://claude.ai/code/session_01Ey1sEitYQfa2bVivDAdBRC