### PR TITLE
test: add v1.3.0 integration tests and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ dkit completions powershell > dkit.ps1 && . ./dkit.ps1
 | INI/CFG     | `.ini`, `.cfg`         |  ✓   |   ✓   | Section-based config files     |
 | .properties | `.properties`          |  ✓   |   ✓   | Java properties files          |
 | .env        | `.env`                 |  ✓   |   ✓   | Environment variable files     |
+| HCL         | `.hcl`, `.tf`, `.tfvars` |  ✓   |   ✓   | Terraform / HashiCorp configs  |
+| plist       | `.plist`               |  ✓   |   ✓   | macOS Property List (XML)      |
 | Markdown    | `.md`                  |  —   |   ✓   | GFM table, output-only         |
 | HTML        | `.html`                |  —   |   ✓   | Styled tables, output-only     |
 
@@ -171,6 +173,23 @@ dkit convert .env --to json                         # .env → JSON
 dkit convert config.json --to env -o .env            # JSON → .env
 dkit diff .env.dev .env.prod                         # Compare environments
 
+# HCL / Terraform format
+dkit convert main.tf --to json                      # Terraform → JSON
+dkit convert variables.json --to hcl -o vars.tf     # JSON → HCL
+dkit query main.tf '.resource.aws_instance'         # Query Terraform config
+
+# plist (macOS Property List) format
+dkit convert Info.plist --to json                   # plist → JSON
+dkit convert config.json --to plist -o Info.plist   # JSON → plist
+dkit query Info.plist '.CFBundleVersion'             # Query plist value
+
+# Explode (unnest arrays into rows)
+dkit convert data.json --to csv --explode tags      # Unnest array field
+
+# Pivot / Unpivot (reshape data)
+dkit convert wide.csv --to json --unpivot 'jan,feb,mar' --key month --value sales
+dkit convert long.csv --to json --pivot --index name --columns month --values sales
+
 # Watch mode (re-convert on file change)
 dkit convert data.json --to csv --watch
 ```
@@ -195,6 +214,14 @@ dkit query data.json '.[*].name'                     # All names (wildcard)
 # IN / NOT IN, matches operators
 dkit query data.json '.[] | where status in ("active", "pending")'
 dkit query data.json '.[] | where name matches "^[A-C]"'
+
+# Recursive descent (..) — find keys at any depth
+dkit query nested.json '..email'                     # All 'email' fields
+dkit query terraform.json '..instance_type'          # Deep key search
+
+# Conditional expressions
+dkit query data.json '.[] | select name, if(age < 18, "minor", "adult") as category'
+dkit query data.json '.[] | select name, case when score >= 90 then "A" when score >= 70 then "B" else "C" end as grade'
 
 # Aggregate functions
 dkit query data.csv '.[] | count'
@@ -223,6 +250,7 @@ dkit query data.json '.users[]' --to csv -o users.csv
 | `.[]` | Iterate all elements |
 | `.[*]` | Wildcard (same as `[]`) |
 | `.[0:3]`, `.[-2:]`, `.[::2]` | Array slicing (start:end:step) |
+| `..key` | Recursive descent (find key at any depth) |
 | `where .field == value` | Filter (`==`, `!=`, `>`, `<`, `>=`, `<=`) |
 | `where .field contains "str"` | String filter (`contains`, `starts_with`, `ends_with`) |
 | `where .field in ("a", "b")` | Membership filter (`in`, `not in`) |
@@ -241,8 +269,9 @@ dkit query data.json '.users[]' --to csv -o users.csv
 | Date     | `now`, `date`, `year`, `month`, `day` |
 | Type     | `to_int`, `to_float`, `to_string`, `to_bool` |
 | Util     | `coalesce`, `if_null` |
+| Conditional | `if(cond, then, else)`, `case when ... then ... end` |
 
-**Aggregate functions:** `count`, `sum`, `avg`, `min`, `max`, `distinct`
+**Aggregate functions:** `count`, `sum`, `avg`, `min`, `max`, `distinct`, `median`, `percentile`, `stddev`, `variance`, `mode`, `group_concat`
 
 See [Query Syntax Reference](docs/query-syntax.md) for the full grammar and more examples.
 
@@ -364,6 +393,8 @@ dkit y2j config.yaml                # YAML → JSON
 | SQLite input | ✓ | — | — | — |
 | INI / .properties | ✓ | — | — | — |
 | .env files | ✓ | — | — | — |
+| HCL / Terraform | ✓ | — | — | — |
+| plist (macOS) | ✓ | — | — | — |
 | Cross-format convert | ✓ | — | Partial | Partial |
 | Query (where/select/sort) | ✓ | ✓ | ✓ | ✓ |
 | Aggregate / GROUP BY | ✓ | Partial | ✓ | — |

--- a/dkit-cli/tests/v130_integration_test.rs
+++ b/dkit-cli/tests/v130_integration_test.rs
@@ -1,0 +1,1153 @@
+/// v1.3.0 Integration Tests
+///
+/// Comprehensive integration tests for v1.3.0 features:
+/// - `--explode` flag (unnest/flatten arrays into rows)
+/// - `--pivot` / `--unpivot` flags (data reshaping)
+/// - HCL (HashiCorp Configuration Language) format Reader/Writer
+/// - `.plist` (macOS Property List) format Reader/Writer
+/// - Recursive descent (`..`) operator for deep key search
+/// - Conditional expressions (`if/then/else`, `case/when`) in query
+/// - Statistical aggregate functions (median, percentile, stddev, variance, mode, group_concat)
+/// - Combined feature tests
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn dkit() -> Command {
+    Command::cargo_bin("dkit").unwrap()
+}
+
+// ============================================================
+// --explode tests
+// ============================================================
+
+#[test]
+fn explode_array_field_into_rows() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "tags": ["rust", "python"]},
+          {"name": "Bob", "tags": ["java", "go", "rust"]}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--explode",
+            "tags",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Alice should appear twice (rust, python)
+    assert_eq!(stdout.matches("Alice").count(), 2);
+    // Bob should appear three times (java, go, rust)
+    assert_eq!(stdout.matches("Bob").count(), 3);
+    assert!(stdout.contains("rust"));
+    assert!(stdout.contains("python"));
+    assert!(stdout.contains("java"));
+    assert!(stdout.contains("go"));
+}
+
+#[test]
+fn explode_empty_array_excludes_record() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "tags": ["x"]},
+          {"name": "Bob", "tags": []},
+          {"name": "Charlie", "tags": ["y", "z"]}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--explode",
+            "tags",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Alice"));
+    // Bob has empty array, should be excluded
+    assert!(!stdout.contains("Bob"));
+    assert!(stdout.contains("Charlie"));
+}
+
+#[test]
+fn explode_with_csv_output() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "tags": ["a", "b"]},
+          {"name": "Bob", "tags": ["c"]}
+        ]"#,
+    )
+    .unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "csv",
+            "--explode",
+            "tags",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+#[test]
+fn explode_multiple_fields() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "tags": ["x"], "scores": [10, 20]}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--explode",
+            "tags",
+            "--explode",
+            "scores",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should produce 1 (tags) * 2 (scores) = 2 rows
+    assert_eq!(stdout.matches("Alice").count(), 2);
+}
+
+// ============================================================
+// --pivot / --unpivot tests
+// ============================================================
+
+#[test]
+fn unpivot_wide_to_long() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("wide.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "jan": 100, "feb": 200, "mar": 300},
+          {"name": "Bob", "jan": 150, "feb": 250, "mar": 350}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--unpivot",
+            "jan,feb,mar",
+            "--key",
+            "month",
+            "--value",
+            "sales",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Each person should appear 3 times (jan, feb, mar)
+    assert_eq!(stdout.matches("Alice").count(), 3);
+    assert_eq!(stdout.matches("Bob").count(), 3);
+    assert!(stdout.contains("month"));
+    assert!(stdout.contains("sales"));
+    assert!(stdout.contains("jan"));
+    assert!(stdout.contains("feb"));
+    assert!(stdout.contains("mar"));
+}
+
+#[test]
+fn unpivot_default_key_value_names() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("wide.json");
+    fs::write(&input, r#"[{"name": "A", "x": 1, "y": 2}]"#).unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--unpivot",
+            "x,y",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Default key name is "variable", default value name is "value"
+    assert!(stdout.contains("variable"));
+    assert!(stdout.contains("value"));
+}
+
+#[test]
+fn pivot_long_to_wide() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("long.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "month": "jan", "sales": 100},
+          {"name": "Alice", "month": "feb", "sales": 200},
+          {"name": "Bob", "month": "jan", "sales": 150},
+          {"name": "Bob", "month": "feb", "sales": 250}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--pivot",
+            "--index",
+            "name",
+            "--columns",
+            "month",
+            "--values",
+            "sales",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Each person should appear once
+    assert_eq!(stdout.matches("Alice").count(), 1);
+    assert_eq!(stdout.matches("Bob").count(), 1);
+    // Month columns should be present
+    assert!(stdout.contains("jan"));
+    assert!(stdout.contains("feb"));
+}
+
+#[test]
+fn unpivot_to_csv_output() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("wide.json");
+    fs::write(&input, r#"[{"name": "Alice", "q1": 10, "q2": 20}]"#).unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "csv",
+            "--unpivot",
+            "q1,q2",
+            "--key",
+            "quarter",
+            "--value",
+            "amount",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("quarter"))
+        .stdout(predicate::str::contains("amount"));
+}
+
+// ============================================================
+// HCL format tests
+// ============================================================
+
+#[cfg(feature = "hcl")]
+mod hcl_tests {
+    use super::*;
+
+    #[test]
+    fn hcl_to_json_conversion() {
+        let tmp = TempDir::new().unwrap();
+        let input = tmp.path().join("main.tf");
+        fs::write(
+            &input,
+            r#"
+variable "region" {
+  default = "us-east-1"
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-12345678"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        let output = dkit()
+            .args(&["convert", input.to_str().unwrap(), "-f", "json"])
+            .output()
+            .unwrap();
+
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.contains("variable"));
+        assert!(stdout.contains("resource"));
+        assert!(stdout.contains("us-east-1"));
+        assert!(stdout.contains("t2.micro"));
+    }
+
+    #[test]
+    fn json_to_hcl_conversion() {
+        let tmp = TempDir::new().unwrap();
+        let input = tmp.path().join("config.json");
+        fs::write(&input, r#"{"server": {"host": "localhost", "port": 8080}}"#).unwrap();
+
+        dkit()
+            .args(&["convert", input.to_str().unwrap(), "-f", "hcl"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("server"))
+            .stdout(predicate::str::contains("localhost"));
+    }
+
+    #[test]
+    fn hcl_query() {
+        let tmp = TempDir::new().unwrap();
+        let input = tmp.path().join("main.tf");
+        fs::write(
+            &input,
+            r#"
+variable "region" {
+  default = "us-west-2"
+}
+"#,
+        )
+        .unwrap();
+
+        dkit()
+            .args(&["query", input.to_str().unwrap(), ".variable.region.default"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("us-west-2"));
+    }
+
+    #[test]
+    fn hcl_to_yaml_conversion() {
+        let tmp = TempDir::new().unwrap();
+        let input = tmp.path().join("config.tf");
+        fs::write(
+            &input,
+            r#"
+database {
+  host = "db.example.com"
+  port = 5432
+}
+"#,
+        )
+        .unwrap();
+
+        dkit()
+            .args(&["convert", input.to_str().unwrap(), "-f", "yaml"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("db.example.com"))
+            .stdout(predicate::str::contains("5432"));
+    }
+}
+
+// ============================================================
+// .plist format tests
+// ============================================================
+
+#[cfg(feature = "plist")]
+mod plist_tests {
+    use super::*;
+
+    #[test]
+    fn plist_to_json_conversion() {
+        let tmp = TempDir::new().unwrap();
+        let input = tmp.path().join("Info.plist");
+        fs::write(
+            &input,
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>MyApp</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+    <key>CFBundleExecutable</key>
+    <string>myapp</string>
+</dict>
+</plist>"#,
+        )
+        .unwrap();
+
+        let output = dkit()
+            .args(&["convert", input.to_str().unwrap(), "-f", "json"])
+            .output()
+            .unwrap();
+
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.contains("CFBundleName"));
+        assert!(stdout.contains("MyApp"));
+        assert!(stdout.contains("1.0.0"));
+    }
+
+    #[test]
+    fn json_to_plist_conversion() {
+        let tmp = TempDir::new().unwrap();
+        let input = tmp.path().join("config.json");
+        fs::write(
+            &input,
+            r#"{"name": "TestApp", "version": "2.0", "debug": true}"#,
+        )
+        .unwrap();
+
+        dkit()
+            .args(&["convert", input.to_str().unwrap(), "-f", "plist"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("TestApp"))
+            .stdout(predicate::str::contains("2.0"));
+    }
+
+    #[test]
+    fn plist_query_field() {
+        let tmp = TempDir::new().unwrap();
+        let input = tmp.path().join("Info.plist");
+        fs::write(
+            &input,
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleVersion</key>
+    <string>3.2.1</string>
+    <key>CFBundleName</key>
+    <string>TestApp</string>
+</dict>
+</plist>"#,
+        )
+        .unwrap();
+
+        dkit()
+            .args(&["query", input.to_str().unwrap(), ".CFBundleVersion"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("3.2.1"));
+    }
+
+    #[test]
+    fn plist_with_array_and_nested_dict() {
+        let tmp = TempDir::new().unwrap();
+        let input = tmp.path().join("complex.plist");
+        fs::write(
+            &input,
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>items</key>
+    <array>
+        <dict>
+            <key>name</key>
+            <string>First</string>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Second</string>
+        </dict>
+    </array>
+    <key>count</key>
+    <integer>42</integer>
+</dict>
+</plist>"#,
+        )
+        .unwrap();
+
+        let output = dkit()
+            .args(&["convert", input.to_str().unwrap(), "-f", "json"])
+            .output()
+            .unwrap();
+
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.contains("First"));
+        assert!(stdout.contains("Second"));
+        assert!(stdout.contains("42"));
+    }
+}
+
+// ============================================================
+// Recursive descent (..) operator tests
+// ============================================================
+
+#[test]
+fn recursive_descent_find_all_keys() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("nested.json");
+    fs::write(
+        &input,
+        r#"{
+          "users": [
+            {"name": "Alice", "address": {"city": "Seoul"}},
+            {"name": "Bob", "address": {"city": "Busan"}}
+          ],
+          "admin": {"name": "Charlie"}
+        }"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), "..name"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Alice"));
+    assert!(stdout.contains("Bob"));
+    assert!(stdout.contains("Charlie"));
+}
+
+#[test]
+fn recursive_descent_deeply_nested() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("deep.json");
+    fs::write(
+        &input,
+        r#"{
+          "a": {
+            "b": {
+              "c": {
+                "id": 1
+              },
+              "id": 2
+            },
+            "id": 3
+          },
+          "id": 4
+        }"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), "..id"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should find all 4 'id' fields
+    assert!(stdout.contains('1'));
+    assert!(stdout.contains('2'));
+    assert!(stdout.contains('3'));
+    assert!(stdout.contains('4'));
+}
+
+#[test]
+fn recursive_descent_with_path_prefix() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"{
+          "config": {
+            "db": {"host": "localhost"},
+            "cache": {"host": "redis.local"}
+          },
+          "host": "top-level"
+        }"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), ".config..host"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("localhost"));
+    assert!(stdout.contains("redis.local"));
+    // top-level 'host' should NOT be included (scoped under .config)
+    assert!(!stdout.contains("top-level"));
+}
+
+#[test]
+fn recursive_descent_with_pipeline() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"{
+          "teams": [
+            {"name": "Alpha", "members": [{"email": "a@test.com"}, {"email": "b@test.com"}]},
+            {"name": "Beta", "members": [{"email": "c@test.com"}]}
+          ]
+        }"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), "..email"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("a@test.com"));
+    assert!(stdout.contains("b@test.com"));
+    assert!(stdout.contains("c@test.com"));
+}
+
+// ============================================================
+// Conditional expressions (if/then/else, case/when) tests
+// ============================================================
+
+#[test]
+fn if_function_in_select() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "age": 15},
+          {"name": "Bob", "age": 30},
+          {"name": "Charlie", "age": 70}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | select name, if(age < 18, \"minor\", \"adult\") as category",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("minor"));
+    assert!(stdout.contains("adult"));
+}
+
+#[test]
+fn nested_if_function() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "age": 15},
+          {"name": "Bob", "age": 30},
+          {"name": "Charlie", "age": 70}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | select name, if(age < 18, \"minor\", if(age < 65, \"adult\", \"senior\")) as category",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("minor"));
+    assert!(stdout.contains("adult"));
+    assert!(stdout.contains("senior"));
+}
+
+#[test]
+fn case_when_expression() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "score": 95},
+          {"name": "Bob", "score": 72},
+          {"name": "Charlie", "score": 45}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | select name, case when score >= 90 then \"A\" when score >= 70 then \"B\" else \"C\" end as grade",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Alice: A, Bob: B, Charlie: C
+    assert!(stdout.contains('A'));
+    assert!(stdout.contains('B'));
+    assert!(stdout.contains('C'));
+}
+
+#[test]
+fn if_with_string_comparison() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "role": "engineer"},
+          {"name": "Bob", "role": "manager"}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | select name, if(role == \"engineer\", \"tech\", \"non-tech\") as dept",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("tech"));
+    assert!(stdout.contains("non-tech"));
+}
+
+// ============================================================
+// Statistical aggregate functions tests
+// ============================================================
+
+#[test]
+fn median_aggregate() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"value": 10},
+          {"value": 20},
+          {"value": 30},
+          {"value": 40},
+          {"value": 50}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), ".[] | median value"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("30"));
+}
+
+#[test]
+fn median_even_count() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"value": 10},
+          {"value": 20},
+          {"value": 30},
+          {"value": 40}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), ".[] | median value"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // median of [10,20,30,40] = 25
+    assert!(stdout.contains("25"));
+}
+
+#[test]
+fn percentile_aggregate() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    // 100 values from 1 to 100
+    let data: Vec<String> = (1..=100).map(|i| format!("{{\"value\": {}}}", i)).collect();
+    fs::write(&input, format!("[{}]", data.join(","))).unwrap();
+
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | percentile value 0.5",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // p50 of 1..100 should be around 50
+    assert!(stdout.contains("50"));
+}
+
+#[test]
+fn stddev_aggregate() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"value": 2},
+          {"value": 4},
+          {"value": 4},
+          {"value": 4},
+          {"value": 5},
+          {"value": 5},
+          {"value": 7},
+          {"value": 9}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), ".[] | stddev value"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // stddev of [2,4,4,4,5,5,7,9] = 2.0 (population stddev)
+    assert!(stdout.contains('2'));
+}
+
+#[test]
+fn variance_aggregate() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"value": 2},
+          {"value": 4},
+          {"value": 4},
+          {"value": 4},
+          {"value": 5},
+          {"value": 5},
+          {"value": 7},
+          {"value": 9}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), ".[] | variance value"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // variance of [2,4,4,4,5,5,7,9] = 4.0 (population variance)
+    assert!(stdout.contains('4'));
+}
+
+#[test]
+fn mode_aggregate() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"color": "red"},
+          {"color": "blue"},
+          {"color": "red"},
+          {"color": "green"},
+          {"color": "red"},
+          {"color": "blue"}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), ".[] | mode color"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("red"));
+}
+
+#[test]
+fn group_concat_aggregate() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"category": "fruit", "name": "apple"},
+          {"category": "fruit", "name": "banana"},
+          {"category": "veg", "name": "carrot"},
+          {"category": "fruit", "name": "cherry"}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | group_by category group_concat(name, \", \")",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("fruit"));
+    assert!(stdout.contains("carrot"));
+}
+
+#[test]
+fn statistical_functions_in_group_by() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"dept": "eng", "salary": 80000},
+          {"dept": "eng", "salary": 90000},
+          {"dept": "eng", "salary": 100000},
+          {"dept": "sales", "salary": 60000},
+          {"dept": "sales", "salary": 70000}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | group_by dept median(salary), stddev(salary)",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("eng"));
+    assert!(stdout.contains("sales"));
+    // eng median should be 90000
+    assert!(stdout.contains("90000"));
+}
+
+// ============================================================
+// Combined feature tests
+// ============================================================
+
+#[test]
+fn explode_with_filter_and_sort() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "tags": ["rust", "python", "java"]},
+          {"name": "Bob", "tags": ["go", "rust"]}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--explode",
+            "tags",
+            "--sort-by",
+            "tags",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("rust"));
+    assert!(stdout.contains("python"));
+}
+
+#[test]
+fn recursive_descent_with_different_formats() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.yaml");
+    fs::write(
+        &input,
+        r#"
+config:
+  database:
+    host: db.example.com
+  cache:
+    host: cache.example.com
+host: top-level
+"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&["query", input.to_str().unwrap(), "..host"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("db.example.com"));
+    assert!(stdout.contains("cache.example.com"));
+    assert!(stdout.contains("top-level"));
+}
+
+#[test]
+fn conditional_with_aggregate() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "age": 15, "score": 85},
+          {"name": "Bob", "age": 30, "score": 92},
+          {"name": "Charlie", "age": 70, "score": 78}
+        ]"#,
+    )
+    .unwrap();
+
+    // Use if() in select, then get results
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | select name, if(age < 18, \"minor\", \"adult\") as category, score",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("minor"));
+    assert!(stdout.contains("adult"));
+}
+
+#[test]
+fn unpivot_with_csv_and_query() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("wide.csv");
+    fs::write(
+        &input,
+        "name,q1,q2,q3\nAlice,100,200,300\nBob,150,250,350\n",
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "convert",
+            input.to_str().unwrap(),
+            "-f",
+            "json",
+            "--unpivot",
+            "q1,q2,q3",
+            "--key",
+            "quarter",
+            "--value",
+            "amount",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("quarter"));
+    assert!(stdout.contains("amount"));
+    // Each person has 3 rows
+    assert_eq!(stdout.matches("Alice").count(), 3);
+    assert_eq!(stdout.matches("Bob").count(), 3);
+}
+
+#[test]
+fn explode_with_view_command() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"name": "Alice", "skills": ["rust", "python"]},
+          {"name": "Bob", "skills": ["java"]}
+        ]"#,
+    )
+    .unwrap();
+
+    dkit()
+        .args(&["view", input.to_str().unwrap(), "--explode", "skills"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"))
+        .stdout(predicate::str::contains("rust"))
+        .stdout(predicate::str::contains("python"))
+        .stdout(predicate::str::contains("java"));
+}
+
+#[test]
+fn statistical_functions_with_filter() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("data.json");
+    fs::write(
+        &input,
+        r#"[
+          {"dept": "eng", "salary": 80000},
+          {"dept": "eng", "salary": 90000},
+          {"dept": "eng", "salary": 100000},
+          {"dept": "sales", "salary": 60000},
+          {"dept": "sales", "salary": 70000}
+        ]"#,
+    )
+    .unwrap();
+
+    let output = dkit()
+        .args(&[
+            "query",
+            input.to_str().unwrap(),
+            ".[] | where dept == \"eng\" | median salary",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // eng salaries: 80000, 90000, 100000 → median = 90000
+    assert!(stdout.contains("90000"));
+}

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -66,6 +66,14 @@ dkit convert --from <FORMAT> --to <FORMAT>  # stdin 사용 시
 | `--map <EXPR>` | | 기존 필드 값 변환 (여러 번 사용 가능, e.g. `name = upper(name)`) | |
 | `--indent <INDENT>` | | JSON 들여쓰기 (숫자: 스페이스 수, `tab`: 탭 문자) | 2 |
 | `--sort-keys` | | JSON 객체 키를 알파벳순으로 정렬 | false |
+| `--explode <FIELD>` | | 배열 필드를 개별 행으로 펼침 (여러 번 사용 가능) | |
+| `--unpivot <COLUMNS>` | | Wide → Long 변환: 언피벗할 컬럼 목록 (쉼표 구분) | |
+| `--pivot` | | Long → Wide 변환 모드 활성화 | false |
+| `--key <NAME>` | | 언피벗 시 key 컬럼명 | `variable` |
+| `--value <NAME>` | | 언피벗/피벗 시 value 컬럼명 | `value` |
+| `--index <FIELDS>` | | 피벗 시 유지할 인덱스 컬럼 (쉼표 구분) | |
+| `--columns <FIELD>` | | 피벗 시 새 컬럼명이 될 필드 | |
+| `--values <FIELD>` | | 피벗 시 새 컬럼 값이 될 필드 | |
 | `--dry-run` | | 미리보기 모드 (파일 생성 없이 stdout으로 출력) | false |
 | `--dry-run-limit <N>` | | 미리보기 시 출력 레코드 수 | 10 |
 
@@ -184,6 +192,26 @@ dkit convert config.json --to properties -o app.properties  # JSON → propertie
 dkit convert .env --to json                              # .env → JSON
 dkit convert config.json --to env -o .env                # JSON → .env
 dkit convert .env --to yaml                              # .env → YAML
+
+# HCL (Terraform) 포맷 변환
+dkit convert main.tf --to json                           # HCL → JSON
+dkit convert variables.json --to hcl -o vars.tf          # JSON → HCL
+dkit convert main.tf --to yaml                           # HCL → YAML
+
+# plist (macOS Property List) 포맷 변환
+dkit convert Info.plist --to json                        # plist → JSON
+dkit convert config.json --to plist -o Info.plist        # JSON → plist
+
+# Explode (배열 필드를 개별 행으로 펼침)
+dkit convert data.json --to csv --explode tags           # 배열 → 개별 행
+dkit convert data.json --to json --explode tags --explode categories  # 복수 필드
+
+# Unpivot (Wide → Long)
+dkit convert wide.csv --to json --unpivot 'jan,feb,mar' --key month --value sales
+dkit convert data.json --to csv --unpivot 'q1,q2,q3'    # 기본 키명: variable, value
+
+# Pivot (Long → Wide)
+dkit convert long.csv --to json --pivot --index name --columns month --values sales
 ```
 
 ## query

--- a/docs/query-syntax.md
+++ b/docs/query-syntax.md
@@ -32,6 +32,26 @@ dkit query data.json '.[::2]'            # 짝수 인덱스 요소 (step=2)
 dkit query data.json '.[1:5:2]'          # 인덱스 1~4 중 step=2
 ```
 
+## Recursive Descent (`..`)
+
+깊이에 관계없이 특정 키를 재귀적으로 찾는다. jq의 `..` 연산자에 해당.
+
+```bash
+# 모든 depth의 "email" 필드 찾기
+dkit query nested.json '..email'
+
+# 특정 경로 아래에서만 재귀 탐색
+dkit query data.json '.config..host'
+
+# 모든 "id" 필드 수집
+dkit query complex.json '..id'
+
+# 재귀 탐색 후 파이프라인 연결
+dkit query data.json '..name | where name != "admin"'
+```
+
+결과는 배열로 반환된다. depth limit이 적용되어 순환 참조를 방지한다.
+
 ## Pipeline
 
 `|` 로 여러 연산을 체이닝한다. 앞 연산의 결과가 다음 연산의 입력이 된다.
@@ -330,6 +350,62 @@ dkit query data.csv '.[] | select upper(name) as NAME, round(price, 2) as price_
 | `coalesce(a, b, ...)` | 첫 번째 non-null 값 반환 | `coalesce(name, "unknown")` |
 | `if_null(v, default)` | null이면 기본값 반환 | `if_null(email, "N/A")` |
 
+### 조건부 표현식
+
+#### if(condition, then, else)
+
+간단한 조건부 값 할당. 중첩 가능.
+
+```bash
+# 단순 조건
+dkit query data.json '.[] | select name, if(age < 18, "minor", "adult") as category'
+
+# 중첩 if
+dkit query data.json '.[] | select name, if(age < 18, "minor", if(age < 65, "adult", "senior")) as category'
+
+# 문자열 비교
+dkit query data.json '.[] | select name, if(role == "engineer", "tech", "non-tech") as dept'
+```
+
+#### case when ... then ... else ... end
+
+SQL 스타일의 다중 조건 분기. 복잡한 조건에 적합.
+
+```bash
+# 점수 등급 분류
+dkit query data.json '.[] | select name, case when score >= 90 then "A" when score >= 70 then "B" else "C" end as grade'
+
+# 다중 조건
+dkit query data.json '.[] | select name, case when age < 18 then "minor" when age < 65 then "adult" else "senior" end as category'
+```
+
+### Statistical Aggregate Functions
+
+기존 집계 함수(count, sum, avg, min, max, distinct) 외에 통계 분석용 함수를 지원한다.
+
+| 함수 | 설명 | 예시 |
+|------|------|------|
+| `median(field)` | 중앙값 | `.[] \| median salary` |
+| `percentile(field, p)` | p번째 백분위수 (p: 0.0~1.0) | `.[] \| percentile latency 0.95` |
+| `stddev(field)` | 표준편차 (모집단) | `.[] \| stddev score` |
+| `variance(field)` | 분산 | `.[] \| variance score` |
+| `mode(field)` | 최빈값 | `.[] \| mode color` |
+| `group_concat(field, sep)` | 그룹 내 문자열 연결 | `group_by category group_concat(name, ", ")` |
+
+```bash
+# 급여 중앙값
+dkit query employees.json '.[] | median salary'
+
+# 응답 시간 p95, p99
+dkit query metrics.json '.[] | percentile latency 0.95'
+
+# 부서별 통계
+dkit query employees.json '.[] | group_by department median(salary), stddev(salary)'
+
+# 카테고리별 이름 합치기
+dkit query products.json '.[] | group_by category group_concat(name, ", ")'
+```
+
 ### 함수 조합 예시
 
 ```bash
@@ -366,8 +442,9 @@ dkit query sales.csv '.rows[] | where region == "KR"' --to json -o korea.json
 
 ```
 query       = path ( "|" operation )*
-path        = "." segment*
+path        = "." segment* | ".." IDENTIFIER    (* recursive descent *)
 segment     = field_access | index_access | iterate | wildcard | slice
+            | ".." IDENTIFIER                    (* recursive descent mid-path *)
 field_access = IDENTIFIER ( "." IDENTIFIER )*
 index_access = "[" INTEGER "]"
 iterate     = "[" "]"
@@ -376,12 +453,15 @@ slice       = "[" [ INTEGER ] ":" [ INTEGER ] [ ":" INTEGER ] "]"
 
 operation   = where_op | select_op | sort_op | limit_op
             | count_op | sum_op | avg_op | min_op | max_op | distinct_op
-            | group_by_op
+            | median_op | percentile_op | stddev_op | variance_op | mode_op
+            | group_concat_op | group_by_op
 where_op    = "where" condition
 select_op   = "select" select_expr ( "," select_expr )*
 select_expr = expr [ "as" IDENTIFIER ]
-expr        = IDENTIFIER | literal | func_call
+expr        = IDENTIFIER | literal | func_call | if_expr | case_expr
 func_call   = IDENTIFIER "(" [ expr ( "," expr )* ] ")"
+if_expr     = "if" "(" condition "," expr "," expr ")"
+case_expr   = "case" ( "when" condition "then" expr )+ [ "else" expr ] "end"
 sort_op     = "sort" IDENTIFIER [ "desc" ]
 limit_op    = "limit" INTEGER
 count_op    = "count" [ IDENTIFIER ]
@@ -390,9 +470,16 @@ avg_op      = "avg" IDENTIFIER
 min_op      = "min" IDENTIFIER
 max_op      = "max" IDENTIFIER
 distinct_op = "distinct" IDENTIFIER
+median_op   = "median" IDENTIFIER
+percentile_op = "percentile" IDENTIFIER NUMBER
+stddev_op   = "stddev" IDENTIFIER
+variance_op = "variance" IDENTIFIER
+mode_op     = "mode" IDENTIFIER
+group_concat_op = "group_concat" IDENTIFIER STRING
 group_by_op = "group_by" IDENTIFIER ( "," IDENTIFIER )* aggregate* [ "having" condition ]
-aggregate   = agg_func "(" [ IDENTIFIER ] ")"
+aggregate   = agg_func "(" [ IDENTIFIER [ "," expr ] ] ")"
 agg_func    = "count" | "sum" | "avg" | "min" | "max"
+            | "median" | "percentile" | "stddev" | "variance" | "mode" | "group_concat"
 
 condition   = comparison ( logic_op comparison )*
 comparison  = IDENTIFIER compare_op value

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -258,6 +258,35 @@ pub struct FormatOptions {
 - `--full-html`: 완전한 HTML 문서 (DOCTYPE, charset, 선택적 style 블록)
 - HTML 엔티티 이스케이프 (`&`, `<`, `>`, `"`, `'`)
 
+### HCL (HashiCorp Configuration Language) ↔ Value
+
+- `hcl-rs` 크레이트 사용
+- HCL v2 문법 지원 (Terraform 0.12+)
+- 블록 구조 → 중첩 Object로 매핑
+- 읽기: HCL 파싱 후 `Value::Object` 트리로 변환
+- 쓰기: `Value::Object` → HCL 블록/속성 형식 출력
+- 포맷 자동 감지: `.hcl`, `.tf`, `.tfvars` 확장자
+- feature flag: `hcl` (선택적 의존성)
+- **참고**: HCL은 블록 기반 언어로, 단순 key=value가 아닌 복잡한 구조 지원
+
+### plist (macOS Property List) ↔ Value
+
+- `plist` 크레이트 사용
+- XML plist 형식 지원
+- 데이터 타입 매핑:
+  - `dict` → `Value::Object`
+  - `array` → `Value::Array`
+  - `string` → `Value::String`
+  - `integer` → `Value::Integer`
+  - `real` → `Value::Float`
+  - `true`/`false` → `Value::Bool`
+  - `date` → `Value::String` (ISO 8601)
+  - `data` → `Value::String` (Base64 인코딩)
+- 읽기: XML plist 파싱 후 `Value` 트리로 변환
+- 쓰기: `Value` → XML plist 형식 출력
+- 포맷 자동 감지: `.plist` 확장자
+- feature flag: `plist` (선택적 의존성)
+
 ## Encoding Support
 
 ### 인코딩 감지 우선순위
@@ -291,27 +320,42 @@ pub struct EncodingOptions {
 
 ```
 query       = path ("|" operation)*
-path        = "." segment*
+path        = "." segment* | ".." identifier      (* recursive descent *)
 segment     = field | index | iterate | wildcard | slice
+            | ".." identifier                      (* recursive descent mid-path *)
 field       = identifier
 index       = "[" integer "]"
 iterate     = "[]"
 wildcard    = "[" "*" "]"
 slice       = "[" [integer] ":" [integer] [":" integer] "]"
 operation   = where | select | sort | limit
+            | count | sum | avg | min | max | distinct
+            | median | percentile | stddev | variance | mode | group_concat
+            | group_by
 where       = "where" condition
 condition   = expr compare_op expr (logic_op expr compare_op expr)*
             | expr "in" "(" value_list ")"
             | expr "not" "in" "(" value_list ")"
             | expr "matches" string_literal
             | expr "not" "matches" string_literal
-select      = "select" field ("," field)*
+select      = "select" select_expr ("," select_expr)*
+select_expr = expr ["as" identifier]
 sort        = "sort" field ["desc"]
 limit       = "limit" integer
+median      = "median" identifier
+percentile  = "percentile" identifier number_literal
+stddev      = "stddev" identifier
+variance    = "variance" identifier
+mode        = "mode" identifier
+group_concat = "group_concat" identifier string_literal
 compare_op  = "==" | "!=" | ">" | "<" | ">=" | "<="
 logic_op    = "and" | "or"
 value_list  = value ("," value)*
 expr        = path | string_literal | number_literal
+            | func_call | if_expr | case_expr
+func_call   = identifier "(" [expr ("," expr)*] ")"
+if_expr     = "if" "(" condition "," expr "," expr ")"
+case_expr   = "case" ("when" condition "then" expr)+ ["else" expr] "end"
 ```
 
 ### Parser Implementation


### PR DESCRIPTION
## Summary
- Add 38 integration tests covering all v1.3.0 features: `--explode`, `--pivot`/`--unpivot`, HCL format, plist format, recursive descent (`..`), conditional expressions (`if`/`case when`), and statistical aggregate functions (`median`, `percentile`, `stddev`, `variance`, `mode`, `group_concat`)
- Update documentation (README.md, cli-spec.md, query-syntax.md, technical-spec.md) with new formats, features, EBNF grammar, and usage examples

## Test plan
- [x] All 38 new integration tests pass (`cargo test --features all --test v130_integration_test`)
- [x] All 852 existing unit tests pass (`cargo test --features all`)
- [x] `cargo clippy --features all -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

Closes #202

https://claude.ai/code/session_01AMBG45LJXddB3wNJCyj6WE