### PR TITLE
feat: add --parallel flag for multi-file batch conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,7 @@ dependencies = [
  "parquet",
  "predicates",
  "rand",
+ "rayon",
  "rusqlite",
  "serde",
  "serde_json",

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -49,6 +49,7 @@ arrow = { version = "53", default-features = false, features = ["prettyprint"], 
 parquet-impl = { package = "parquet", version = "53", default-features = false, features = ["arrow", "snap", "zstd"], optional = true }
 bytes = { version = "1", optional = true }
 glob = "0.3"
+rayon = "1"
 jsonschema = { version = "0.17", default-features = false }
 dirs = "6.0.0"
 notify = "7"

--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -33,7 +33,7 @@ pub struct Cli {
 pub enum Commands {
     /// Convert between data formats (JSON, CSV, YAML, TOML)
     #[command(
-        after_help = "Examples:\n  dkit convert data.json --format csv\n  dkit convert data.csv --format yaml --pretty\n  dkit convert a.json b.json --format csv --outdir ./output\n  dkit convert '*.json' --format csv --outdir ./output\n  dkit convert data_dir/ --format yaml --outdir ./output\n  dkit convert '*.json' -f csv --outdir out --rename '{name}.converted.{ext}'\n  dkit convert dir/ -f csv --outdir out --continue-on-error\n  cat data.json | dkit convert --from json --format toml\n  dkit convert - --from json --format csv < data.json\n  dkit convert data.json -f csv | dkit query - '.items[]' --from csv"
+        after_help = "Examples:\n  dkit convert data.json --format csv\n  dkit convert data.csv --format yaml --pretty\n  dkit convert a.json b.json --format csv --outdir ./output\n  dkit convert '*.json' --format csv --outdir ./output\n  dkit convert data_dir/ --format yaml --outdir ./output\n  dkit convert '*.json' -f csv --outdir out --rename '{name}.converted.{ext}'\n  dkit convert dir/ -f csv --outdir out --continue-on-error\n  dkit convert *.json -f csv --outdir out --parallel 4\n  dkit convert *.json -f csv --outdir out --parallel auto\n  cat data.json | dkit convert --from json --format toml\n  dkit convert - --from json --format csv < data.json\n  dkit convert data.json -f csv | dkit query - '.items[]' --from csv"
     )]
     Convert {
         /// Input file path(s). Use '-' or omit for stdin (auto-detects format or use --from)
@@ -249,6 +249,12 @@ pub enum Commands {
         /// How to handle log lines that fail to parse: 'skip' (default) or 'raw'
         #[arg(long, value_name = "MODE", default_value = "skip")]
         log_error: String,
+
+        /// Number of parallel threads for batch conversion.
+        /// Use a number (e.g. 4) or 'auto' to detect CPU cores.
+        /// Only applies when converting multiple files.
+        #[arg(long, value_name = "N")]
+        parallel: Option<String>,
     },
 
     /// Query data using path expressions

--- a/dkit-cli/src/commands/convert.rs
+++ b/dkit-cli/src/commands/convert.rs
@@ -1,8 +1,11 @@
 use std::fs;
 use std::io::{self, IsTerminal, Read, Write as _};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 use anyhow::{bail, Context, Result};
+use rayon::prelude::*;
 
 use super::{
     read_file_bytes, read_file_with_encoding, read_parquet_from_bytes, read_sqlite_from_path,
@@ -65,6 +68,7 @@ pub struct ConvertArgs<'a> {
     pub dry_run_limit: usize,
     pub log_format: Option<&'a str>,
     pub log_error: LogParseErrorMode,
+    pub parallel: Option<usize>,
 }
 
 /// convert 서브커맨드 실행
@@ -262,44 +266,99 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
             .with_context(|| format!("Failed to create directory {}", outdir.display()))?;
 
         let total = resolved_files.len();
-        let mut success_count = 0usize;
-        let mut error_count = 0usize;
-        let mut errors: Vec<(PathBuf, String)> = Vec::new();
 
-        for (idx, path) in resolved_files.iter().enumerate() {
-            eprint!("Converting ({}/{}) {} ... ", idx + 1, total, path.display());
+        if let Some(num_threads) = args.parallel {
+            // Parallel batch mode
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .build()
+                .context("Failed to create thread pool")?;
 
-            match convert_single_file(path, args, target_format, &write_options, outdir) {
-                Ok(()) => {
-                    success_count += 1;
-                    eprintln!("ok");
+            let success_count = AtomicUsize::new(0);
+            let error_count = AtomicUsize::new(0);
+            let errors: Mutex<Vec<(PathBuf, String)>> = Mutex::new(Vec::new());
+
+            pool.install(|| {
+                resolved_files.par_iter().for_each(|path| {
+                    let result =
+                        convert_single_file(path, args, target_format, &write_options, outdir);
+                    match result {
+                        Ok(()) => {
+                            let done = success_count.fetch_add(1, Ordering::Relaxed) + 1;
+                            let failed = error_count.load(Ordering::Relaxed);
+                            eprintln!(
+                                "Converting ({}/{}) {} ... ok",
+                                done + failed,
+                                total,
+                                path.display()
+                            );
+                        }
+                        Err(e) => {
+                            error_count.fetch_add(1, Ordering::Relaxed);
+                            let msg = format!("{e:#}");
+                            eprintln!("Converting {} ... FAILED: {msg}", path.display());
+                            errors.lock().unwrap().push((path.clone(), msg));
+                        }
+                    }
+                });
+            });
+
+            let success_count = success_count.load(Ordering::Relaxed);
+            let error_count = error_count.load(Ordering::Relaxed);
+            let errors = errors.into_inner().unwrap();
+
+            eprintln!();
+            eprintln!("Batch conversion complete: {success_count} succeeded, {error_count} failed out of {total} files");
+
+            if !errors.is_empty() {
+                eprintln!();
+                eprintln!("Failed files:");
+                for (path, msg) in &errors {
+                    eprintln!("  {}: {msg}", path.display());
                 }
-                Err(e) => {
-                    error_count += 1;
-                    let msg = format!("{e:#}");
-                    eprintln!("FAILED: {msg}");
-                    errors.push((path.clone(), msg));
-                    if !args.continue_on_error {
-                        bail!(
-                            "Conversion failed for {}\n  Use --continue-on-error to skip failed files",
-                            path.display()
-                        );
+                bail!("{error_count} file(s) failed to convert");
+            }
+        } else {
+            // Sequential batch mode
+            let mut success_count = 0usize;
+            let mut error_count = 0usize;
+            let mut errors: Vec<(PathBuf, String)> = Vec::new();
+
+            for (idx, path) in resolved_files.iter().enumerate() {
+                eprint!("Converting ({}/{}) {} ... ", idx + 1, total, path.display());
+
+                match convert_single_file(path, args, target_format, &write_options, outdir) {
+                    Ok(()) => {
+                        success_count += 1;
+                        eprintln!("ok");
+                    }
+                    Err(e) => {
+                        error_count += 1;
+                        let msg = format!("{e:#}");
+                        eprintln!("FAILED: {msg}");
+                        errors.push((path.clone(), msg));
+                        if !args.continue_on_error {
+                            bail!(
+                                "Conversion failed for {}\n  Use --continue-on-error to skip failed files",
+                                path.display()
+                            );
+                        }
                     }
                 }
             }
-        }
 
-        // Print summary
-        eprintln!();
-        eprintln!("Batch conversion complete: {success_count} succeeded, {error_count} failed out of {total} files");
-
-        if !errors.is_empty() {
+            // Print summary
             eprintln!();
-            eprintln!("Failed files:");
-            for (path, msg) in &errors {
-                eprintln!("  {}: {msg}", path.display());
+            eprintln!("Batch conversion complete: {success_count} succeeded, {error_count} failed out of {total} files");
+
+            if !errors.is_empty() {
+                eprintln!();
+                eprintln!("Failed files:");
+                for (path, msg) in &errors {
+                    eprintln!("  {}: {msg}", path.display());
+                }
+                bail!("{error_count} file(s) failed to convert");
             }
-            bail!("{error_count} file(s) failed to convert");
         }
 
         return Ok(());

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -342,7 +342,9 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             dry_run_limit,
             log_format,
             log_error,
+            parallel,
         } => {
+            let parallel_threads = parse_parallel_option(&parallel)?;
             let run = || {
                 commands::convert::run(&commands::convert::ConvertArgs {
                     input: &input,
@@ -408,6 +410,7 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                     dry_run_limit,
                     log_format: log_format.as_deref(),
                     log_error: parse_log_error_mode(&log_error),
+                    parallel: parallel_threads,
                 })
             };
 
@@ -845,5 +848,25 @@ fn parse_log_error_mode(s: &str) -> LogParseErrorMode {
     match s.to_lowercase().as_str() {
         "raw" => LogParseErrorMode::Raw,
         _ => LogParseErrorMode::Skip,
+    }
+}
+
+fn parse_parallel_option(opt: &Option<String>) -> anyhow::Result<Option<usize>> {
+    match opt {
+        None => Ok(None),
+        Some(s) => {
+            let s = s.trim().to_lowercase();
+            if s == "auto" {
+                Ok(Some(std::thread::available_parallelism()?.get()))
+            } else {
+                let n: usize = s.parse().map_err(|_| {
+                    anyhow::anyhow!("--parallel must be a positive number or 'auto', got '{s}'")
+                })?;
+                if n == 0 {
+                    anyhow::bail!("--parallel must be at least 1");
+                }
+                Ok(Some(n))
+            }
+        }
     }
 }

--- a/dkit-cli/tests/batch_convert_test.rs
+++ b/dkit-cli/tests/batch_convert_test.rs
@@ -257,3 +257,166 @@ fn batch_convert_shows_progress() {
         .stderr(predicate::str::contains("(2/2)"))
         .stderr(predicate::str::contains("ok"));
 }
+
+// --- Parallel batch conversion ---
+
+#[test]
+fn batch_convert_parallel_with_number() {
+    let input_dir = TempDir::new().unwrap();
+    let outdir = TempDir::new().unwrap();
+
+    fs::write(input_dir.path().join("a.json"), r#"[{"x": 1}]"#).unwrap();
+    fs::write(input_dir.path().join("b.json"), r#"[{"y": 2}]"#).unwrap();
+    fs::write(input_dir.path().join("c.json"), r#"[{"z": 3}]"#).unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input_dir.path().to_str().unwrap(),
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+            "--parallel",
+            "2",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "3 succeeded, 0 failed out of 3 files",
+        ));
+
+    assert!(outdir.path().join("a.csv").exists());
+    assert!(outdir.path().join("b.csv").exists());
+    assert!(outdir.path().join("c.csv").exists());
+}
+
+#[test]
+fn batch_convert_parallel_auto() {
+    let input_dir = TempDir::new().unwrap();
+    let outdir = TempDir::new().unwrap();
+
+    fs::write(input_dir.path().join("a.json"), r#"[{"x": 1}]"#).unwrap();
+    fs::write(input_dir.path().join("b.json"), r#"[{"y": 2}]"#).unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input_dir.path().to_str().unwrap(),
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+            "--parallel",
+            "auto",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "2 succeeded, 0 failed out of 2 files",
+        ));
+
+    assert!(outdir.path().join("a.csv").exists());
+    assert!(outdir.path().join("b.csv").exists());
+}
+
+#[test]
+fn batch_convert_parallel_with_errors() {
+    let input_dir = TempDir::new().unwrap();
+    let outdir = TempDir::new().unwrap();
+
+    fs::write(input_dir.path().join("good.json"), r#"[{"a": 1}]"#).unwrap();
+    fs::write(
+        input_dir.path().join("bad.json"),
+        "this is not valid json {{{",
+    )
+    .unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input_dir.path().to_str().unwrap(),
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+            "--parallel",
+            "2",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("1 succeeded"))
+        .stderr(predicate::str::contains("1 failed"))
+        .stderr(predicate::str::contains("Failed files:"));
+
+    assert!(outdir.path().join("good.csv").exists());
+    assert!(!outdir.path().join("bad.csv").exists());
+}
+
+#[test]
+fn batch_convert_parallel_invalid_value() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users.csv",
+            "--format",
+            "yaml",
+            "--outdir",
+            "/tmp/dkit_test_invalid",
+            "--parallel",
+            "abc",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--parallel must be a positive number or 'auto'",
+        ));
+}
+
+#[test]
+fn batch_convert_parallel_zero() {
+    dkit()
+        .args(&[
+            "convert",
+            "tests/fixtures/users.json",
+            "tests/fixtures/users.csv",
+            "--format",
+            "yaml",
+            "--outdir",
+            "/tmp/dkit_test_zero",
+            "--parallel",
+            "0",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--parallel must be at least 1"));
+}
+
+#[test]
+fn batch_convert_parallel_with_rename() {
+    let input_dir = TempDir::new().unwrap();
+    let outdir = TempDir::new().unwrap();
+
+    fs::write(input_dir.path().join("a.json"), r#"[{"x": 1}]"#).unwrap();
+    fs::write(input_dir.path().join("b.json"), r#"[{"y": 2}]"#).unwrap();
+
+    dkit()
+        .args(&[
+            "convert",
+            input_dir.path().to_str().unwrap(),
+            "--format",
+            "csv",
+            "--outdir",
+            outdir.path().to_str().unwrap(),
+            "--parallel",
+            "2",
+            "--rename",
+            "{name}.converted.{ext}",
+        ])
+        .assert()
+        .success();
+
+    assert!(outdir.path().join("a.converted.csv").exists());
+    assert!(outdir.path().join("b.converted.csv").exists());
+}


### PR DESCRIPTION
## Summary
- Add `--parallel <N|auto>` flag to `convert` subcommand for multi-threaded batch file conversion using rayon
- Supports explicit thread count (`--parallel 4`) or automatic CPU core detection (`--parallel auto`)
- Parallel mode processes all files concurrently with thread-safe progress reporting and error collection

## Changes
- **Cargo.toml**: Added `rayon = "1"` dependency
- **cli.rs**: Added `--parallel` CLI flag with help text and examples
- **convert.rs**: Implemented parallel batch processing using `rayon::ThreadPoolBuilder` with `AtomicUsize` counters and `Mutex`-protected error collection
- **main.rs**: Added `parse_parallel_option()` helper to parse `auto` or numeric values, wired up the flag
- **batch_convert_test.rs**: Added 6 new integration tests (parallel with number, auto, errors, invalid value, zero, rename)

## Test plan
- [x] `cargo test` — all 729 unit tests + all integration tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — formatted
- [x] New tests: `batch_convert_parallel_with_number`, `batch_convert_parallel_auto`, `batch_convert_parallel_with_errors`, `batch_convert_parallel_invalid_value`, `batch_convert_parallel_zero`, `batch_convert_parallel_with_rename`

Closes #215

https://claude.ai/code/session_01XtCkDHdyYX2vbfAePoS6nV