### PR TITLE
chore: prepare v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-03-27
+
+### Added
+
+- **Log format parsing (`--log-format`)**: Parse log files into structured data with pre-defined formats (Apache Combined/Common, nginx, syslog) and custom user-defined patterns — `dkit convert access.log -f json --log-format apache`. (#197)
+- **`--parallel` flag for batch conversion**: Multi-threaded parallel processing for multi-file conversions via `rayon` — `dkit convert logs/*.json -f csv --parallel 4` or `--parallel auto` for automatic core detection. (#215)
+- **`--time` execution profiling**: Measure and display execution time breakdown (parse, transform, write, total) on stderr for any subcommand — `dkit convert huge.json -f csv --time`. (#216)
+- **`--explain` query plan**: Display the query execution plan without running the query — `dkit query data.json 'select ...' --explain`. Shows scan, filter, group by, aggregate, sort, and project steps. (#216)
+
+### Testing & Docs
+
+- **Comprehensive v1.4.0 integration tests**: End-to-end tests for `--log-format`, `--parallel`, `--time`, and `--explain`. README and docs updated. (#204)
+
 ## [1.3.0] - 2026-03-27
 
 ### Added
@@ -192,7 +205,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI pipeline**: GitHub Actions workflow with test (Linux/macOS/Windows), clippy, and rustfmt checks.
 - **Test suite**: Integration tests covering all conversion paths, query operations, table view, fixture data, edge cases (unicode, empty input, quoted CSV fields).
 
-[Unreleased]: https://github.com/syangkkim/dkit/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/syangkkim/dkit/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/syangkkim/dkit/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/syangkkim/dkit/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/syangkkim/dkit/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/syangkkim/dkit/compare/v1.0.0...v1.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "dkit"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "dkit-core"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkit"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "A unified CLI to convert, query, and explore data across formats"
@@ -30,7 +30,7 @@ plist = ["dkit-core/plist"]
 all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist"]
 
 [dependencies]
-dkit-core = { version = "1.3.0", path = "../dkit-core" }
+dkit-core = { version = "1.4.0", path = "../dkit-core" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 serde = { version = "1", features = ["derive"] }

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkit-core"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "Core library for dkit — data format conversion and querying engine"


### PR DESCRIPTION
## Summary
- Bump version 1.3.0 → 1.4.0 in `dkit-core/Cargo.toml` and `dkit-cli/Cargo.toml`
- Update CHANGELOG.md with v1.4.0 entries (log format parsing, --parallel, --time, --explain)
- All checks verified: `cargo fmt`, `cargo clippy`, `cargo test` (all pass)

Closes #205

https://claude.ai/code/session_01E3pbAJDCj7ZobDxnbprAy1