### PR TITLE
feat: add --template flag for custom text output formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +512,28 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-targets",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -654,6 +685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +793,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,10 +855,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -916,6 +982,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "tera",
  "thiserror 1.0.69",
  "toml",
 ]
@@ -1075,6 +1142,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1200,30 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.11.0",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "half"
@@ -1220,6 +1321,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1351,6 +1461,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1978,6 +2104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2123,87 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2450,6 +2666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2687,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "smallvec"
@@ -2545,6 +2788,28 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tera"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "globwalk",
+ "humansize",
+ "lazy_static",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "rand",
+ "regex",
+ "serde",
+ "serde_json",
+ "slug",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2734,6 +2999,18 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -27,7 +27,8 @@ sqlite = ["dkit-core/sqlite"]
 parquet = ["dkit-core/parquet", "dep:arrow", "dep:parquet-impl", "dep:bytes"]
 hcl = ["dkit-core/hcl"]
 plist = ["dkit-core/plist"]
-all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist"]
+template = ["dkit-core/template"]
+all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist", "template"]
 
 [dependencies]
 dkit-core = { version = "1.4.0", path = "../dkit-core" }

--- a/dkit-cli/src/cli.rs
+++ b/dkit-cli/src/cli.rs
@@ -259,6 +259,17 @@ pub enum Commands {
         /// Only applies when converting multiple files.
         #[arg(long, value_name = "N")]
         parallel: Option<String>,
+
+        /// Inline Tera template string for template output format.
+        /// Each record is rendered through this template.
+        /// Use with -f template. Example: '{{ name }} <{{ email }}>'
+        #[arg(long, value_name = "STRING")]
+        template: Option<String>,
+
+        /// Path to a Tera template file for template output format.
+        /// Use with -f template.
+        #[arg(long, value_name = "PATH", conflicts_with = "template")]
+        template_file: Option<String>,
     },
 
     /// Query data using path expressions

--- a/dkit-cli/src/commands/convert.rs
+++ b/dkit-cli/src/commands/convert.rs
@@ -24,6 +24,7 @@ use dkit_core::format::markdown::MarkdownWriter;
 use dkit_core::format::msgpack::{MsgpackReader, MsgpackWriter};
 use dkit_core::format::plist::{PlistReader, PlistWriter};
 use dkit_core::format::properties::{PropertiesReader, PropertiesWriter};
+use dkit_core::format::template::TemplateWriter;
 use dkit_core::format::toml::{TomlReader, TomlWriter};
 use dkit_core::format::xml::{XmlReader, XmlWriter};
 use dkit_core::format::yaml::{YamlReader, YamlWriter};
@@ -69,6 +70,8 @@ pub struct ConvertArgs<'a> {
     pub log_format: Option<&'a str>,
     pub log_error: LogParseErrorMode,
     pub parallel: Option<usize>,
+    pub template: Option<String>,
+    pub template_file: Option<String>,
 }
 
 /// convert 서브커맨드 실행
@@ -106,6 +109,8 @@ pub fn run(args: &ConvertArgs) -> Result<()> {
         full_html: args.full_html,
         indent: args.indent.clone(),
         sort_keys: args.sort_keys,
+        template: args.template.clone(),
+        template_file: args.template_file.clone(),
     };
 
     // stdin mode: no input files or explicit "-"
@@ -664,6 +669,7 @@ fn read_value(content: &str, format: Format, options: &FormatOptions) -> Result<
         Format::Parquet => {
             bail!("Parquet files must be read from a file path, not from text input")
         }
+        Format::Template => bail!("Template is an output-only format and cannot be used as input"),
         Format::Markdown => bail!("Markdown is an output-only format and cannot be used as input"),
         Format::Html => bail!("HTML is an output-only format and cannot be used as input"),
         Format::Table => bail!("Table is an output-only format and cannot be used as input"),
@@ -730,6 +736,7 @@ fn write_value(value: &Value, format: Format, options: &FormatOptions) -> Result
         Format::Parquet => {
             bail!("Internal error: Parquet output should be handled via write_output")
         }
+        Format::Template => TemplateWriter::new(options.clone()).write(value),
         Format::Markdown => MarkdownWriter.write(value),
         Format::Html => HtmlWriter::new(options.styled, options.full_html).write(value),
         Format::Table => {

--- a/dkit-cli/src/commands/merge.rs
+++ b/dkit-cli/src/commands/merge.rs
@@ -105,6 +105,8 @@ pub fn run(args: &MergeArgs) -> Result<()> {
         full_html: false,
         indent: None,
         sort_keys: false,
+        template: None,
+        template_file: None,
     };
 
     if target_format == Format::Msgpack {

--- a/dkit-cli/src/main.rs
+++ b/dkit-cli/src/main.rs
@@ -354,6 +354,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
             log_format,
             log_error,
             parallel,
+            template,
+            template_file,
         } => {
             let parallel_threads = parse_parallel_option(&parallel)?;
             let run = || {
@@ -422,6 +424,8 @@ fn run_command(cli: Cli) -> anyhow::Result<()> {
                     log_format: log_format.as_deref(),
                     log_error: parse_log_error_mode(&log_error),
                     parallel: parallel_threads,
+                    template: template.clone(),
+                    template_file: template_file.clone(),
                 })
             };
 

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -19,7 +19,8 @@ sqlite = ["dep:rusqlite"]
 parquet = ["dep:arrow", "dep:parquet-impl", "dep:bytes"]
 hcl = ["dep:hcl-rs"]
 plist = ["dep:plist", "dep:base64"]
-all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist"]
+template = ["dep:tera"]
+all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist", "template"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -40,6 +41,7 @@ bytes = { version = "1", optional = true }
 hcl-rs = { version = "0.19", optional = true }
 plist = { version = "1", optional = true }
 base64 = { version = "0.22", optional = true }
+tera = { version = "1", optional = true }
 jsonschema = { version = "0.17", default-features = false }
 rand = "0.8"
 regex = "1"

--- a/dkit-core/src/format/mod.rs
+++ b/dkit-core/src/format/mod.rs
@@ -273,6 +273,36 @@ pub mod plist {
     }
 }
 
+/// Template-based custom text output writer.
+#[cfg(feature = "template")]
+pub mod template;
+#[cfg(not(feature = "template"))]
+pub mod template {
+    //! Stub module — Template feature not enabled.
+    use super::FormatWriter;
+    use crate::value::Value;
+    use std::io::Write;
+
+    const MSG: &str = "Template support requires the 'template' feature.\n  Install with: cargo install dkit --features template";
+
+    pub struct TemplateWriter {
+        _private: (),
+    }
+    impl TemplateWriter {
+        pub fn new(_options: super::FormatOptions) -> Self {
+            Self { _private: () }
+        }
+    }
+    impl FormatWriter for TemplateWriter {
+        fn write(&self, _: &Value) -> anyhow::Result<String> {
+            anyhow::bail!(MSG)
+        }
+        fn write_to_writer(&self, _: &Value, _: impl Write) -> anyhow::Result<()> {
+            anyhow::bail!(MSG)
+        }
+    }
+}
+
 /// XML reader and writer.
 #[cfg(feature = "xml")]
 pub mod xml;
@@ -370,6 +400,8 @@ pub enum Format {
     Hcl,
     /// macOS Property List (`*.plist`)
     Plist,
+    /// Template-based custom text output (write-only)
+    Template,
 }
 
 impl Format {
@@ -394,6 +426,7 @@ impl Format {
             "properties" => Ok(Format::Properties),
             "hcl" | "tf" | "tfvars" => Ok(Format::Hcl),
             "plist" => Ok(Format::Plist),
+            "template" | "tpl" => Ok(Format::Template),
             _ => Err(DkitError::UnknownFormat(s.to_string())),
         }
     }
@@ -459,6 +492,15 @@ impl Format {
             ));
         }
 
+        if cfg!(feature = "template") {
+            formats.push(("template", "Custom text output via Tera templates"));
+        } else {
+            formats.push((
+                "template",
+                "Custom text output via Tera templates (requires --features template)",
+            ));
+        }
+
         formats.push(("env", "Environment variables (.env) format"));
         formats.push(("ini", "INI/CFG configuration file format"));
         formats.push(("properties", "Java .properties file format"));
@@ -491,6 +533,7 @@ impl std::fmt::Display for Format {
             Format::Properties => write!(f, "Properties"),
             Format::Hcl => write!(f, "HCL"),
             Format::Plist => write!(f, "Plist"),
+            Format::Template => write!(f, "Template"),
         }
     }
 }
@@ -706,6 +749,10 @@ pub struct FormatOptions {
     pub indent: Option<String>,
     /// JSON 오브젝트 키를 알파벳순으로 정렬
     pub sort_keys: bool,
+    /// Inline template string for template output
+    pub template: Option<String>,
+    /// File path for template output
+    pub template_file: Option<String>,
 }
 
 impl Default for FormatOptions {
@@ -721,6 +768,8 @@ impl Default for FormatOptions {
             full_html: false,
             indent: None,
             sort_keys: false,
+            template: None,
+            template_file: None,
         }
     }
 }

--- a/dkit-core/src/format/template.rs
+++ b/dkit-core/src/format/template.rs
@@ -1,0 +1,226 @@
+use std::io::Write;
+
+use crate::format::{FormatOptions, FormatWriter};
+use crate::value::Value;
+
+/// Writer that renders each record through a Tera template.
+pub struct TemplateWriter {
+    options: FormatOptions,
+}
+
+impl TemplateWriter {
+    pub fn new(options: FormatOptions) -> Self {
+        Self { options }
+    }
+
+    fn resolve_template_string(&self) -> anyhow::Result<String> {
+        if let Some(ref tpl) = self.options.template {
+            Ok(tpl.clone())
+        } else if let Some(ref path) = self.options.template_file {
+            std::fs::read_to_string(path)
+                .map_err(|e| anyhow::anyhow!("Failed to read template file '{}': {}", path, e))
+        } else {
+            anyhow::bail!("Template format requires --template <STRING> or --template-file <PATH>")
+        }
+    }
+
+    fn render_value(&self, tera: &tera::Tera, value: &Value) -> anyhow::Result<String> {
+        let mut context = tera::Context::new();
+        match value {
+            Value::Object(map) => {
+                for (k, v) in map {
+                    context.insert(k, &value_to_tera(v));
+                }
+            }
+            _ => {
+                context.insert("value", &value_to_tera(value));
+            }
+        }
+        tera.render("template", &context)
+            .map_err(|e| anyhow::anyhow!("Template render error: {}", e))
+    }
+}
+
+impl FormatWriter for TemplateWriter {
+    fn write(&self, value: &Value) -> anyhow::Result<String> {
+        let tpl_str = self.resolve_template_string()?;
+        let mut tera = tera::Tera::default();
+        register_helpers(&mut tera);
+        tera.add_raw_template("template", &tpl_str)
+            .map_err(|e| anyhow::anyhow!("Template parse error: {}", e))?;
+
+        match value {
+            Value::Array(items) => {
+                let mut output = String::new();
+                for item in items {
+                    let rendered = self.render_value(&tera, item)?;
+                    output.push_str(&rendered);
+                    output.push('\n');
+                }
+                Ok(output)
+            }
+            _ => {
+                let mut output = self.render_value(&tera, value)?;
+                output.push('\n');
+                Ok(output)
+            }
+        }
+    }
+
+    fn write_to_writer(&self, value: &Value, mut writer: impl Write) -> anyhow::Result<()> {
+        let output = self.write(value)?;
+        writer.write_all(output.as_bytes())?;
+        Ok(())
+    }
+}
+
+/// Convert a dkit Value to a serde_json::Value for Tera context insertion.
+fn value_to_tera(value: &Value) -> serde_json::Value {
+    match value {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Integer(i) => serde_json::json!(*i),
+        Value::Float(f) => serde_json::json!(*f),
+        Value::String(s) => serde_json::Value::String(s.clone()),
+        Value::Array(arr) => serde_json::Value::Array(arr.iter().map(value_to_tera).collect()),
+        Value::Object(map) => {
+            let obj: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), value_to_tera(v)))
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+    }
+}
+
+/// Register built-in helper functions (upper, lower, default).
+fn register_helpers(tera: &mut tera::Tera) {
+    tera.register_filter(
+        "upper",
+        |value: &tera::Value, _args: &std::collections::HashMap<String, tera::Value>| match value
+            .as_str()
+        {
+            Some(s) => Ok(tera::Value::String(s.to_uppercase())),
+            None => Ok(value.clone()),
+        },
+    );
+    tera.register_filter(
+        "lower",
+        |value: &tera::Value, _args: &std::collections::HashMap<String, tera::Value>| match value
+            .as_str()
+        {
+            Some(s) => Ok(tera::Value::String(s.to_lowercase())),
+            None => Ok(value.clone()),
+        },
+    );
+    // "default" is already a built-in Tera filter, no need to register it.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn make_record(pairs: Vec<(&str, Value)>) -> Value {
+        let map: IndexMap<String, Value> =
+            pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+        Value::Object(map)
+    }
+
+    #[test]
+    fn test_single_record() {
+        let value = make_record(vec![
+            ("name", Value::String("Alice".into())),
+            ("email", Value::String("alice@example.com".into())),
+        ]);
+
+        let opts = FormatOptions {
+            template: Some("{{ name }} <{{ email }}>".into()),
+            ..Default::default()
+        };
+        let writer = TemplateWriter::new(opts);
+        let result = writer.write(&value).unwrap();
+        assert_eq!(result.trim(), "Alice <alice@example.com>");
+    }
+
+    #[test]
+    fn test_array_of_records() {
+        let value = Value::Array(vec![
+            make_record(vec![("name", Value::String("Alice".into()))]),
+            make_record(vec![("name", Value::String("Bob".into()))]),
+        ]);
+
+        let opts = FormatOptions {
+            template: Some("Hello, {{ name }}!".into()),
+            ..Default::default()
+        };
+        let writer = TemplateWriter::new(opts);
+        let result = writer.write(&value).unwrap();
+        assert_eq!(result.trim(), "Hello, Alice!\nHello, Bob!");
+    }
+
+    #[test]
+    fn test_upper_filter() {
+        let value = make_record(vec![("name", Value::String("alice".into()))]);
+
+        let opts = FormatOptions {
+            template: Some("{{ name | upper }}".into()),
+            ..Default::default()
+        };
+        let writer = TemplateWriter::new(opts);
+        let result = writer.write(&value).unwrap();
+        assert_eq!(result.trim(), "ALICE");
+    }
+
+    #[test]
+    fn test_lower_filter() {
+        let value = make_record(vec![("name", Value::String("ALICE".into()))]);
+
+        let opts = FormatOptions {
+            template: Some("{{ name | lower }}".into()),
+            ..Default::default()
+        };
+        let writer = TemplateWriter::new(opts);
+        let result = writer.write(&value).unwrap();
+        assert_eq!(result.trim(), "alice");
+    }
+
+    #[test]
+    fn test_default_filter() {
+        let value = make_record(vec![("name", Value::String("Alice".into()))]);
+
+        let opts = FormatOptions {
+            template: Some(r#"{{ missing | default(value="N/A") }}"#.into()),
+            ..Default::default()
+        };
+        let writer = TemplateWriter::new(opts);
+        let result = writer.write(&value).unwrap();
+        assert_eq!(result.trim(), "N/A");
+    }
+
+    #[test]
+    fn test_integer_and_float() {
+        let value = make_record(vec![
+            ("count", Value::Integer(42)),
+            ("price", Value::Float(9.99)),
+        ]);
+
+        let opts = FormatOptions {
+            template: Some("Count: {{ count }}, Price: {{ price }}".into()),
+            ..Default::default()
+        };
+        let writer = TemplateWriter::new(opts);
+        let result = writer.write(&value).unwrap();
+        assert_eq!(result.trim(), "Count: 42, Price: 9.99");
+    }
+
+    #[test]
+    fn test_no_template_error() {
+        let value = make_record(vec![("name", Value::String("Alice".into()))]);
+        let opts = FormatOptions::default();
+        let writer = TemplateWriter::new(opts);
+        let result = writer.write(&value);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("--template"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Tera-based template rendering as a new output format (`-f template`) for the `convert` command
- Support inline templates (`--template`) and file-based templates (`--template-file`)
- Built-in filters: `upper`, `lower`, `default` (plus all Tera built-in filters)
- Feature-gated via `--features template` with stub module when disabled

## Usage Examples
```bash
# Inline template
dkit convert users.json -f template --template '{{ name }} <{{ email }}>'

# With filters
dkit convert data.json -f template --template '{{ name | upper }} ({{ city | default(value="N/A") }})'

# File-based template
dkit convert data.json -f template --template-file report.tpl
```

## Test plan
- [x] Unit tests for single record, array of records, upper/lower/default filters, integer/float values, missing template error
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo test --features template` passes (736+ tests)
- [x] Manual smoke test with CLI

Closes #217

https://claude.ai/code/session_01JDGJDRXxDiX9EwGj4g2aPv