### PR TITLE
feat: add window functions in query engine

### DIFF
--- a/dkit-core/src/query/filter.rs
+++ b/dkit-core/src/query/filter.rs
@@ -2,7 +2,7 @@ use crate::error::DkitError;
 use crate::query::functions::{evaluate_expr, expr_default_key};
 use crate::query::parser::{
     AggregateFunc, CompareOp, Comparison, Condition, Expr, GroupAggregate, LiteralValue, Operation,
-    SelectExpr,
+    SelectExpr, WindowFunc, WindowSpec,
 };
 use crate::value::Value;
 use indexmap::IndexMap;
@@ -76,13 +76,22 @@ fn apply_where(value: Value, condition: &Condition) -> Result<Value, DkitError> 
 
 /// select 절: 배열의 각 요소에 표현식을 적용하여 새 객체를 생성
 fn apply_select(value: Value, exprs: &[SelectExpr]) -> Result<Value, DkitError> {
+    // 윈도우 함수가 포함되어 있는지 확인
+    let has_window = exprs
+        .iter()
+        .any(|se| matches!(&se.expr, Expr::Window { .. }));
+
     match value {
         Value::Array(arr) => {
-            let projected: Result<Vec<Value>, DkitError> = arr
-                .into_iter()
-                .map(|item| select_exprs(&item, exprs))
-                .collect();
-            Ok(Value::Array(projected?))
+            if has_window {
+                apply_select_with_window(arr, exprs)
+            } else {
+                let projected: Result<Vec<Value>, DkitError> = arr
+                    .into_iter()
+                    .map(|item| select_exprs(&item, exprs))
+                    .collect();
+                Ok(Value::Array(projected?))
+            }
         }
         Value::Object(_) => select_exprs(&value, exprs),
         _ => Err(DkitError::QueryError(
@@ -1216,6 +1225,336 @@ fn compute_group_aggregate(
             Ok(Value::String(parts.join(separator)))
         }
     }
+}
+
+/// 윈도우 함수가 포함된 SELECT를 처리: 전체 배열을 한꺼번에 처리
+fn apply_select_with_window(arr: Vec<Value>, exprs: &[SelectExpr]) -> Result<Value, DkitError> {
+    let len = arr.len();
+
+    // 각 SelectExpr에 대해 윈도우 함수면 미리 전체 배열에 대한 결과를 계산
+    let mut window_results: Vec<Option<Vec<Value>>> = Vec::with_capacity(exprs.len());
+
+    for se in exprs {
+        if let Expr::Window { func, over } = &se.expr {
+            let results = evaluate_window_func(&arr, func, over)?;
+            window_results.push(Some(results));
+        } else {
+            window_results.push(None);
+        }
+    }
+
+    // 행별로 결과 객체 조합
+    let mut output = Vec::with_capacity(len);
+    for (i, item) in arr.iter().enumerate() {
+        match item {
+            Value::Object(map) => {
+                let mut new_map = IndexMap::new();
+                for (j, se) in exprs.iter().enumerate() {
+                    let key = se
+                        .alias
+                        .clone()
+                        .unwrap_or_else(|| expr_default_key(&se.expr));
+                    if let Some(ref win_vals) = window_results[j] {
+                        new_map.insert(key, win_vals[i].clone());
+                    } else {
+                        // 일반 표현식: 필드가 없으면 스킵
+                        if let Expr::Field(fname) = &se.expr {
+                            if se.alias.is_none() && !map.contains_key(fname) {
+                                continue;
+                            }
+                        }
+                        let val = evaluate_expr(item, &se.expr)?;
+                        new_map.insert(key, val);
+                    }
+                }
+                output.push(Value::Object(new_map));
+            }
+            _ => output.push(item.clone()),
+        }
+    }
+
+    Ok(Value::Array(output))
+}
+
+/// 윈도우 함수를 전체 배열에 대해 평가하여 각 행의 결과값 벡터를 반환
+fn evaluate_window_func(
+    arr: &[Value],
+    func: &WindowFunc,
+    spec: &WindowSpec,
+) -> Result<Vec<Value>, DkitError> {
+    let len = arr.len();
+
+    // 파티션별 인덱스 그룹 생성
+    let partitions = build_partitions(arr, &spec.partition_by);
+
+    // 각 파티션 내에서 ORDER BY로 정렬된 인덱스 계산
+    let sorted_partitions: Vec<Vec<usize>> = partitions
+        .iter()
+        .map(|indices| sort_partition(arr, indices, &spec.order_by))
+        .collect();
+
+    let mut results = vec![Value::Null; len];
+
+    for sorted_indices in &sorted_partitions {
+        match func {
+            WindowFunc::RowNumber => {
+                for (rank, &idx) in sorted_indices.iter().enumerate() {
+                    results[idx] = Value::Integer((rank + 1) as i64);
+                }
+            }
+            WindowFunc::Rank => {
+                compute_rank(arr, sorted_indices, &spec.order_by, false, &mut results);
+            }
+            WindowFunc::DenseRank => {
+                compute_rank(arr, sorted_indices, &spec.order_by, true, &mut results);
+            }
+            WindowFunc::Lag { expr, offset } => {
+                for (pos, &idx) in sorted_indices.iter().enumerate() {
+                    if pos >= *offset {
+                        let prev_idx = sorted_indices[pos - offset];
+                        results[idx] = evaluate_expr(&arr[prev_idx], expr)?;
+                    }
+                    // else remains Null
+                }
+            }
+            WindowFunc::Lead { expr, offset } => {
+                for (pos, &idx) in sorted_indices.iter().enumerate() {
+                    if pos + offset < sorted_indices.len() {
+                        let next_idx = sorted_indices[pos + offset];
+                        results[idx] = evaluate_expr(&arr[next_idx], expr)?;
+                    }
+                    // else remains Null
+                }
+            }
+            WindowFunc::FirstValue { expr } => {
+                if !sorted_indices.is_empty() {
+                    let first_idx = sorted_indices[0];
+                    let first_val = evaluate_expr(&arr[first_idx], expr)?;
+                    for &idx in sorted_indices {
+                        results[idx] = first_val.clone();
+                    }
+                }
+            }
+            WindowFunc::LastValue { expr } => {
+                if !sorted_indices.is_empty() {
+                    let last_idx = sorted_indices[sorted_indices.len() - 1];
+                    let last_val = evaluate_expr(&arr[last_idx], expr)?;
+                    for &idx in sorted_indices {
+                        results[idx] = last_val.clone();
+                    }
+                }
+            }
+            WindowFunc::Aggregate { func: agg, expr } => {
+                compute_window_aggregate(arr, sorted_indices, agg, expr, &mut results)?;
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// 파티션 구축: PARTITION BY 필드 값 기준으로 행 인덱스를 그룹화
+fn build_partitions(arr: &[Value], partition_by: &[String]) -> Vec<Vec<usize>> {
+    if partition_by.is_empty() {
+        // 파티션 없음: 전체 배열이 하나의 파티션
+        return vec![(0..arr.len()).collect()];
+    }
+
+    let mut groups: Vec<(Vec<Value>, Vec<usize>)> = Vec::new();
+
+    for (i, item) in arr.iter().enumerate() {
+        let key: Vec<Value> = partition_by
+            .iter()
+            .map(|f| {
+                if let Value::Object(map) = item {
+                    map.get(f).cloned().unwrap_or(Value::Null)
+                } else {
+                    Value::Null
+                }
+            })
+            .collect();
+
+        if let Some(group) = groups.iter_mut().find(|(k, _)| *k == key) {
+            group.1.push(i);
+        } else {
+            groups.push((key, vec![i]));
+        }
+    }
+
+    groups.into_iter().map(|(_, indices)| indices).collect()
+}
+
+/// 파티션 내 행들을 ORDER BY 기준으로 정렬
+fn sort_partition(
+    arr: &[Value],
+    indices: &[usize],
+    order_by: &[crate::query::parser::WindowOrderBy],
+) -> Vec<usize> {
+    let mut sorted = indices.to_vec();
+    if order_by.is_empty() {
+        return sorted;
+    }
+    sorted.sort_by(|&a, &b| {
+        for ob in order_by {
+            let va = extract_sort_key(&arr[a], &ob.field);
+            let vb = extract_sort_key(&arr[b], &ob.field);
+            let cmp = compare_sort_keys(&va, &vb);
+            let cmp = if ob.descending { cmp.reverse() } else { cmp };
+            if cmp != std::cmp::Ordering::Equal {
+                return cmp;
+            }
+        }
+        std::cmp::Ordering::Equal
+    });
+    sorted
+}
+
+/// RANK / DENSE_RANK 계산
+fn compute_rank(
+    arr: &[Value],
+    sorted_indices: &[usize],
+    order_by: &[crate::query::parser::WindowOrderBy],
+    dense: bool,
+    results: &mut [Value],
+) {
+    if sorted_indices.is_empty() {
+        return;
+    }
+
+    let get_order_values = |idx: usize| -> Vec<Option<Value>> {
+        order_by
+            .iter()
+            .map(|ob| extract_sort_key(&arr[idx], &ob.field))
+            .collect()
+    };
+
+    let mut current_rank: i64 = 1;
+    let mut prev_values = get_order_values(sorted_indices[0]);
+    results[sorted_indices[0]] = Value::Integer(1);
+
+    for (pos, &idx) in sorted_indices.iter().enumerate().skip(1) {
+        let current_values = get_order_values(idx);
+        if current_values == prev_values {
+            // 동점: 같은 순위
+            results[idx] = Value::Integer(current_rank);
+        } else {
+            // 새 순위
+            if dense {
+                current_rank += 1;
+            } else {
+                current_rank = (pos + 1) as i64;
+            }
+            results[idx] = Value::Integer(current_rank);
+            prev_values = current_values;
+        }
+    }
+}
+
+/// 윈도우 집계 함수 (running aggregate over the entire partition)
+fn compute_window_aggregate(
+    arr: &[Value],
+    sorted_indices: &[usize],
+    agg: &AggregateFunc,
+    expr: &Expr,
+    results: &mut [Value],
+) -> Result<(), DkitError> {
+    // 전체 파티션 집계를 계산하여 모든 행에 할당
+    let mut values = Vec::with_capacity(sorted_indices.len());
+    for &idx in sorted_indices {
+        values.push(evaluate_expr(&arr[idx], expr)?);
+    }
+
+    let agg_result = match agg {
+        AggregateFunc::Count => {
+            let count = values.iter().filter(|v| !matches!(v, Value::Null)).count();
+            Value::Integer(count as i64)
+        }
+        AggregateFunc::Sum => {
+            let mut sum_int: i64 = 0;
+            let mut sum_float: f64 = 0.0;
+            let mut has_float = false;
+            for v in &values {
+                match v {
+                    Value::Integer(n) => {
+                        sum_int += n;
+                        sum_float += *n as f64;
+                    }
+                    Value::Float(f) => {
+                        sum_float += f;
+                        has_float = true;
+                    }
+                    _ => {}
+                }
+            }
+            if has_float {
+                Value::Float(sum_float)
+            } else {
+                Value::Integer(sum_int)
+            }
+        }
+        AggregateFunc::Avg => {
+            let mut sum: f64 = 0.0;
+            let mut count = 0;
+            for v in &values {
+                match v {
+                    Value::Integer(n) => {
+                        sum += *n as f64;
+                        count += 1;
+                    }
+                    Value::Float(f) => {
+                        sum += f;
+                        count += 1;
+                    }
+                    _ => {}
+                }
+            }
+            if count > 0 {
+                Value::Float(sum / count as f64)
+            } else {
+                Value::Null
+            }
+        }
+        AggregateFunc::Min => {
+            let mut min_val = Value::Null;
+            for v in &values {
+                if matches!(v, Value::Null) {
+                    continue;
+                }
+                if matches!(min_val, Value::Null)
+                    || compare_value_ordering(v, &min_val) == std::cmp::Ordering::Less
+                {
+                    min_val = v.clone();
+                }
+            }
+            min_val
+        }
+        AggregateFunc::Max => {
+            let mut max_val = Value::Null;
+            for v in &values {
+                if matches!(v, Value::Null) {
+                    continue;
+                }
+                if matches!(max_val, Value::Null)
+                    || compare_value_ordering(v, &max_val) == std::cmp::Ordering::Greater
+                {
+                    max_val = v.clone();
+                }
+            }
+            max_val
+        }
+        _ => {
+            return Err(DkitError::QueryError(format!(
+                "unsupported window aggregate function: {:?}",
+                agg
+            )));
+        }
+    };
+
+    for &idx in sorted_indices {
+        results[idx] = agg_result.clone();
+    }
+
+    Ok(())
 }
 
 /// 오브젝트에서 지정된 필드만 추출
@@ -3954,5 +4293,404 @@ mod tests {
             assert!(obj.contains_key("stddev_score"));
             assert!(obj.contains_key("mode_score"));
         }
+    }
+
+    // --- 윈도우 함수 평가 테스트 ---
+
+    fn sample_window_data() -> Value {
+        Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Alice".to_string()));
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                m.insert("score".to_string(), Value::Integer(90));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Bob".to_string()));
+                m.insert("dept".to_string(), Value::String("B".to_string()));
+                m.insert("score".to_string(), Value::Integer(80));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Charlie".to_string()));
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                m.insert("score".to_string(), Value::Integer(85));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Dave".to_string()));
+                m.insert("dept".to_string(), Value::String("B".to_string()));
+                m.insert("score".to_string(), Value::Integer(95));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("name".to_string(), Value::String("Eve".to_string()));
+                m.insert("dept".to_string(), Value::String("A".to_string()));
+                m.insert("score".to_string(), Value::Integer(85));
+                Value::Object(m)
+            },
+        ])
+    }
+
+    #[test]
+    fn test_window_row_number() {
+        let data = sample_window_data();
+        let query = parse_query(".[] | select name, row_number() over (order by score desc) as rn")
+            .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        // Score order desc: Dave(95), Alice(90), Charlie(85), Eve(85), Bob(80)
+        // row_number for each original position:
+        let get_rn = |name: &str| -> i64 {
+            arr.iter()
+                .find(|o| {
+                    o.as_object().unwrap().get("name") == Some(&Value::String(name.to_string()))
+                })
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("rn")
+                .unwrap()
+                .as_i64()
+                .unwrap()
+        };
+        assert_eq!(get_rn("Dave"), 1);
+        assert_eq!(get_rn("Alice"), 2);
+        // Charlie and Eve both have 85, row_number assigns sequentially
+        let charlie_rn = get_rn("Charlie");
+        let eve_rn = get_rn("Eve");
+        assert!(charlie_rn == 3 || charlie_rn == 4);
+        assert!(eve_rn == 3 || eve_rn == 4);
+        assert_ne!(charlie_rn, eve_rn);
+        assert_eq!(get_rn("Bob"), 5);
+    }
+
+    #[test]
+    fn test_window_rank() {
+        let data = sample_window_data();
+        let query =
+            parse_query(".[] | select name, rank() over (order by score desc) as r").unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        let get_r = |name: &str| -> i64 {
+            arr.iter()
+                .find(|o| {
+                    o.as_object().unwrap().get("name") == Some(&Value::String(name.to_string()))
+                })
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("r")
+                .unwrap()
+                .as_i64()
+                .unwrap()
+        };
+        assert_eq!(get_r("Dave"), 1);
+        assert_eq!(get_r("Alice"), 2);
+        // Charlie and Eve both 85 → same rank 3
+        assert_eq!(get_r("Charlie"), 3);
+        assert_eq!(get_r("Eve"), 3);
+        // Bob gets rank 5 (not 4) because rank skips
+        assert_eq!(get_r("Bob"), 5);
+    }
+
+    #[test]
+    fn test_window_dense_rank() {
+        let data = sample_window_data();
+        let query = parse_query(".[] | select name, dense_rank() over (order by score desc) as dr")
+            .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        let get_dr = |name: &str| -> i64 {
+            arr.iter()
+                .find(|o| {
+                    o.as_object().unwrap().get("name") == Some(&Value::String(name.to_string()))
+                })
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("dr")
+                .unwrap()
+                .as_i64()
+                .unwrap()
+        };
+        assert_eq!(get_dr("Dave"), 1);
+        assert_eq!(get_dr("Alice"), 2);
+        assert_eq!(get_dr("Charlie"), 3);
+        assert_eq!(get_dr("Eve"), 3);
+        // Bob gets dense_rank 4 (not 5)
+        assert_eq!(get_dr("Bob"), 4);
+    }
+
+    #[test]
+    fn test_window_partition_by_row_number() {
+        let data = sample_window_data();
+        let query = parse_query(
+            ".[] | select name, dept, row_number() over (partition by dept order by score desc) as dept_rn",
+        )
+        .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        let get_rn = |name: &str| -> i64 {
+            arr.iter()
+                .find(|o| {
+                    o.as_object().unwrap().get("name") == Some(&Value::String(name.to_string()))
+                })
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("dept_rn")
+                .unwrap()
+                .as_i64()
+                .unwrap()
+        };
+        // Dept A: Alice(90)=1, Charlie(85)=2, Eve(85)=3
+        assert_eq!(get_rn("Alice"), 1);
+        let charlie_rn = get_rn("Charlie");
+        let eve_rn = get_rn("Eve");
+        assert!(charlie_rn == 2 || charlie_rn == 3);
+        assert!(eve_rn == 2 || eve_rn == 3);
+        // Dept B: Dave(95)=1, Bob(80)=2
+        assert_eq!(get_rn("Dave"), 1);
+        assert_eq!(get_rn("Bob"), 2);
+    }
+
+    #[test]
+    fn test_window_lag() {
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("date".to_string(), Value::Integer(1));
+                m.insert("value".to_string(), Value::Integer(100));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("date".to_string(), Value::Integer(2));
+                m.insert("value".to_string(), Value::Integer(200));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("date".to_string(), Value::Integer(3));
+                m.insert("value".to_string(), Value::Integer(300));
+                Value::Object(m)
+            },
+        ]);
+        let query =
+            parse_query(".[] | select date, value, lag(value) over (order by date) as prev_value")
+                .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // date=1 → prev_value=Null
+        assert_eq!(
+            arr[0].as_object().unwrap().get("prev_value"),
+            Some(&Value::Null)
+        );
+        // date=2 → prev_value=100
+        assert_eq!(
+            arr[1].as_object().unwrap().get("prev_value"),
+            Some(&Value::Integer(100))
+        );
+        // date=3 → prev_value=200
+        assert_eq!(
+            arr[2].as_object().unwrap().get("prev_value"),
+            Some(&Value::Integer(200))
+        );
+    }
+
+    #[test]
+    fn test_window_lead() {
+        let data = Value::Array(vec![
+            {
+                let mut m = IndexMap::new();
+                m.insert("date".to_string(), Value::Integer(1));
+                m.insert("value".to_string(), Value::Integer(100));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("date".to_string(), Value::Integer(2));
+                m.insert("value".to_string(), Value::Integer(200));
+                Value::Object(m)
+            },
+            {
+                let mut m = IndexMap::new();
+                m.insert("date".to_string(), Value::Integer(3));
+                m.insert("value".to_string(), Value::Integer(300));
+                Value::Object(m)
+            },
+        ]);
+        let query =
+            parse_query(".[] | select date, value, lead(value) over (order by date) as next_value")
+                .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // date=1 → next_value=200
+        assert_eq!(
+            arr[0].as_object().unwrap().get("next_value"),
+            Some(&Value::Integer(200))
+        );
+        // date=2 → next_value=300
+        assert_eq!(
+            arr[1].as_object().unwrap().get("next_value"),
+            Some(&Value::Integer(300))
+        );
+        // date=3 → next_value=Null
+        assert_eq!(
+            arr[2].as_object().unwrap().get("next_value"),
+            Some(&Value::Null)
+        );
+    }
+
+    #[test]
+    fn test_window_first_last_value() {
+        let data = sample_window_data();
+        let query = parse_query(
+            ".[] | select name, first_value(name) over (partition by dept order by score desc) as top, last_value(name) over (partition by dept order by score desc) as bottom",
+        )
+        .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // Dept A: sorted by score desc → Alice(90), then Charlie/Eve(85)
+        let alice = arr
+            .iter()
+            .find(|o| {
+                o.as_object().unwrap().get("name") == Some(&Value::String("Alice".to_string()))
+            })
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert_eq!(alice.get("top"), Some(&Value::String("Alice".to_string())));
+        // Dept B: Dave(95), Bob(80) → first=Dave, last=Bob
+        let bob = arr
+            .iter()
+            .find(|o| o.as_object().unwrap().get("name") == Some(&Value::String("Bob".to_string())))
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert_eq!(bob.get("top"), Some(&Value::String("Dave".to_string())));
+        assert_eq!(bob.get("bottom"), Some(&Value::String("Bob".to_string())));
+    }
+
+    #[test]
+    fn test_window_aggregate_sum() {
+        let data = sample_window_data();
+        let query = parse_query(
+            ".[] | select name, dept, sum(score) over (partition by dept) as dept_total",
+        )
+        .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // Dept A: 90+85+85=260, Dept B: 80+95=175
+        let alice = arr
+            .iter()
+            .find(|o| {
+                o.as_object().unwrap().get("name") == Some(&Value::String("Alice".to_string()))
+            })
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert_eq!(alice.get("dept_total"), Some(&Value::Integer(260)));
+
+        let bob = arr
+            .iter()
+            .find(|o| o.as_object().unwrap().get("name") == Some(&Value::String("Bob".to_string())))
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert_eq!(bob.get("dept_total"), Some(&Value::Integer(175)));
+    }
+
+    #[test]
+    fn test_window_aggregate_avg() {
+        let data = sample_window_data();
+        let query =
+            parse_query(".[] | select name, avg(score) over (partition by dept) as dept_avg")
+                .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // Dept A avg: (90+85+85)/3 ≈ 86.666...
+        let alice = arr
+            .iter()
+            .find(|o| {
+                o.as_object().unwrap().get("name") == Some(&Value::String("Alice".to_string()))
+            })
+            .unwrap()
+            .as_object()
+            .unwrap();
+        if let Value::Float(avg) = alice.get("dept_avg").unwrap() {
+            assert!((avg - 260.0 / 3.0).abs() < 0.001);
+        } else {
+            panic!("expected Float");
+        }
+    }
+
+    #[test]
+    fn test_window_aggregate_count() {
+        let data = sample_window_data();
+        let query =
+            parse_query(".[] | select name, count(score) over (partition by dept) as dept_count")
+                .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // Dept A: 3, Dept B: 2
+        let alice = arr
+            .iter()
+            .find(|o| {
+                o.as_object().unwrap().get("name") == Some(&Value::String("Alice".to_string()))
+            })
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert_eq!(alice.get("dept_count"), Some(&Value::Integer(3)));
+    }
+
+    #[test]
+    fn test_window_aggregate_min_max() {
+        let data = sample_window_data();
+        let query = parse_query(
+            ".[] | select name, min(score) over (partition by dept) as dept_min, max(score) over (partition by dept) as dept_max",
+        )
+        .unwrap();
+        let path_result = crate::query::evaluator::evaluate_path(&data, &query.path).unwrap();
+        let result = apply_operations(path_result, &query.operations).unwrap();
+        let arr = result.as_array().unwrap();
+        // Dept A: min=85, max=90
+        let alice = arr
+            .iter()
+            .find(|o| {
+                o.as_object().unwrap().get("name") == Some(&Value::String("Alice".to_string()))
+            })
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert_eq!(alice.get("dept_min"), Some(&Value::Integer(85)));
+        assert_eq!(alice.get("dept_max"), Some(&Value::Integer(90)));
+        // Dept B: min=80, max=95
+        let bob = arr
+            .iter()
+            .find(|o| o.as_object().unwrap().get("name") == Some(&Value::String("Bob".to_string())))
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert_eq!(bob.get("dept_min"), Some(&Value::Integer(80)));
+        assert_eq!(bob.get("dept_max"), Some(&Value::Integer(95)));
     }
 }

--- a/dkit-core/src/query/functions.rs
+++ b/dkit-core/src/query/functions.rs
@@ -1,6 +1,6 @@
 use crate::error::DkitError;
 use crate::query::filter::evaluate_condition;
-use crate::query::parser::{ArithmeticOp, Expr, LiteralValue};
+use crate::query::parser::{ArithmeticOp, Expr, LiteralValue, WindowFunc};
 use crate::value::Value;
 
 /// 표현식을 주어진 레코드(행)에 대해 평가하여 Value를 반환
@@ -46,6 +46,9 @@ pub fn evaluate_expr(row: &Value, expr: &Expr) -> Result<Value, DkitError> {
                 None => Ok(Value::Null),
             }
         }
+        Expr::Window { .. } => Err(DkitError::QueryError(
+            "window functions can only be used in select with array input".to_string(),
+        )),
     }
 }
 
@@ -156,6 +159,26 @@ pub fn expr_default_key(expr: &Expr) -> String {
                 "case".to_string()
             }
         }
+        Expr::Window { func, .. } => match func {
+            WindowFunc::RowNumber => "row_number".to_string(),
+            WindowFunc::Rank => "rank".to_string(),
+            WindowFunc::DenseRank => "dense_rank".to_string(),
+            WindowFunc::Lag { expr, .. } => format!("lag_{}", expr_default_key(expr)),
+            WindowFunc::Lead { expr, .. } => format!("lead_{}", expr_default_key(expr)),
+            WindowFunc::FirstValue { expr } => format!("first_value_{}", expr_default_key(expr)),
+            WindowFunc::LastValue { expr } => format!("last_value_{}", expr_default_key(expr)),
+            WindowFunc::Aggregate { func: agg, expr } => {
+                let name = match agg {
+                    crate::query::parser::AggregateFunc::Count => "count",
+                    crate::query::parser::AggregateFunc::Sum => "sum",
+                    crate::query::parser::AggregateFunc::Avg => "avg",
+                    crate::query::parser::AggregateFunc::Min => "min",
+                    crate::query::parser::AggregateFunc::Max => "max",
+                    _ => "agg",
+                };
+                format!("{}_{}", name, expr_default_key(expr))
+            }
+        },
     }
 }
 

--- a/dkit-core/src/query/parser.rs
+++ b/dkit-core/src/query/parser.rs
@@ -224,6 +224,49 @@ pub enum Expr {
         branches: Vec<(Condition, Expr)>,
         default: Option<Box<Expr>>,
     },
+    /// 윈도우 함수: `func(...) over (partition by ... order by ...)`
+    Window { func: WindowFunc, over: WindowSpec },
+}
+
+/// 윈도우 함수 종류
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum WindowFunc {
+    /// `row_number()` — 행 번호 (1부터 시작)
+    RowNumber,
+    /// `rank()` — 순위 (동점 시 같은 순위, 다음 순위 건너뜀)
+    Rank,
+    /// `dense_rank()` — 순위 (동점 시 같은 순위, 다음 순위 연속)
+    DenseRank,
+    /// `lag(expr, offset)` — 이전 행 값 참조
+    Lag { expr: Box<Expr>, offset: usize },
+    /// `lead(expr, offset)` — 다음 행 값 참조
+    Lead { expr: Box<Expr>, offset: usize },
+    /// `first_value(expr)` — 윈도우 내 첫 번째 값
+    FirstValue { expr: Box<Expr> },
+    /// `last_value(expr)` — 윈도우 내 마지막 값
+    LastValue { expr: Box<Expr> },
+    /// 윈도우 집계: `sum(expr) over (...)`
+    Aggregate {
+        func: AggregateFunc,
+        expr: Box<Expr>,
+    },
+}
+
+/// 윈도우 스펙: `OVER (PARTITION BY ... ORDER BY ...)`
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowSpec {
+    /// `PARTITION BY field1, field2`
+    pub partition_by: Vec<String>,
+    /// `ORDER BY field [ASC|DESC]`
+    pub order_by: Vec<WindowOrderBy>,
+}
+
+/// 윈도우 ORDER BY 절의 개별 항목
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowOrderBy {
+    pub field: String,
+    pub descending: bool,
 }
 
 /// SELECT 절의 컬럼 표현식
@@ -944,7 +987,20 @@ impl Parser {
                             self.pos
                         )));
                     }
-                    Ok(Expr::FuncCall { name, args })
+                    // Check for window function: `func(...) over (...)`
+                    let saved_over = self.pos;
+                    self.skip_whitespace();
+                    if self.try_consume_keyword("over") {
+                        let window_func = self.parse_window_func(&name, args)?;
+                        let over = self.parse_window_spec()?;
+                        Ok(Expr::Window {
+                            func: window_func,
+                            over,
+                        })
+                    } else {
+                        self.pos = saved_over;
+                        Ok(Expr::FuncCall { name, args })
+                    }
                 } else {
                     Ok(Expr::Field(name))
                 }
@@ -958,6 +1014,212 @@ impl Parser {
                 self.pos
             ))),
         }
+    }
+
+    /// 함수 이름과 인자로부터 WindowFunc를 결정
+    fn parse_window_func(&self, name: &str, args: Vec<Expr>) -> Result<WindowFunc, DkitError> {
+        match name {
+            "row_number" => {
+                if !args.is_empty() {
+                    return Err(DkitError::QueryError(
+                        "row_number() takes no arguments".to_string(),
+                    ));
+                }
+                Ok(WindowFunc::RowNumber)
+            }
+            "rank" => {
+                if !args.is_empty() {
+                    return Err(DkitError::QueryError(
+                        "rank() takes no arguments".to_string(),
+                    ));
+                }
+                Ok(WindowFunc::Rank)
+            }
+            "dense_rank" => {
+                if !args.is_empty() {
+                    return Err(DkitError::QueryError(
+                        "dense_rank() takes no arguments".to_string(),
+                    ));
+                }
+                Ok(WindowFunc::DenseRank)
+            }
+            "lag" => {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(DkitError::QueryError(
+                        "lag() requires 1 or 2 arguments: lag(expr[, offset])".to_string(),
+                    ));
+                }
+                let expr = Box::new(args[0].clone());
+                let offset = if args.len() == 2 {
+                    match &args[1] {
+                        Expr::Literal(LiteralValue::Integer(n)) if *n >= 0 => *n as usize,
+                        _ => {
+                            return Err(DkitError::QueryError(
+                                "lag() offset must be a non-negative integer literal".to_string(),
+                            ))
+                        }
+                    }
+                } else {
+                    1
+                };
+                Ok(WindowFunc::Lag { expr, offset })
+            }
+            "lead" => {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(DkitError::QueryError(
+                        "lead() requires 1 or 2 arguments: lead(expr[, offset])".to_string(),
+                    ));
+                }
+                let expr = Box::new(args[0].clone());
+                let offset = if args.len() == 2 {
+                    match &args[1] {
+                        Expr::Literal(LiteralValue::Integer(n)) if *n >= 0 => *n as usize,
+                        _ => {
+                            return Err(DkitError::QueryError(
+                                "lead() offset must be a non-negative integer literal".to_string(),
+                            ))
+                        }
+                    }
+                } else {
+                    1
+                };
+                Ok(WindowFunc::Lead { expr, offset })
+            }
+            "first_value" => {
+                if args.len() != 1 {
+                    return Err(DkitError::QueryError(
+                        "first_value() requires exactly 1 argument".to_string(),
+                    ));
+                }
+                Ok(WindowFunc::FirstValue {
+                    expr: Box::new(args[0].clone()),
+                })
+            }
+            "last_value" => {
+                if args.len() != 1 {
+                    return Err(DkitError::QueryError(
+                        "last_value() requires exactly 1 argument".to_string(),
+                    ));
+                }
+                Ok(WindowFunc::LastValue {
+                    expr: Box::new(args[0].clone()),
+                })
+            }
+            // Window aggregate functions: sum, avg, count, min, max
+            "sum" | "avg" | "count" | "min" | "max" => {
+                let agg_func = match name {
+                    "sum" => AggregateFunc::Sum,
+                    "avg" => AggregateFunc::Avg,
+                    "count" => AggregateFunc::Count,
+                    "min" => AggregateFunc::Min,
+                    "max" => AggregateFunc::Max,
+                    _ => unreachable!(),
+                };
+                let expr = if args.len() == 1 {
+                    Box::new(args[0].clone())
+                } else if args.is_empty() && name == "count" {
+                    Box::new(Expr::Literal(LiteralValue::Null))
+                } else {
+                    return Err(DkitError::QueryError(format!(
+                        "{}() over requires exactly 1 argument",
+                        name
+                    )));
+                };
+                Ok(WindowFunc::Aggregate {
+                    func: agg_func,
+                    expr,
+                })
+            }
+            _ => Err(DkitError::QueryError(format!(
+                "unknown window function: {}",
+                name
+            ))),
+        }
+    }
+
+    /// `OVER (PARTITION BY ... ORDER BY ...)` 절 파싱
+    fn parse_window_spec(&mut self) -> Result<WindowSpec, DkitError> {
+        self.skip_whitespace();
+        if !self.consume_char('(') {
+            return Err(DkitError::QueryError(format!(
+                "expected '(' after 'over' at position {}",
+                self.pos
+            )));
+        }
+        self.skip_whitespace();
+
+        let mut partition_by = Vec::new();
+        let mut order_by = Vec::new();
+
+        // Parse optional PARTITION BY
+        if self.try_consume_keyword("partition") {
+            self.skip_whitespace();
+            if !self.try_consume_keyword("by") {
+                return Err(DkitError::QueryError(format!(
+                    "expected 'by' after 'partition' at position {}",
+                    self.pos
+                )));
+            }
+            self.skip_whitespace();
+            partition_by = self.parse_identifier_list()?;
+            self.skip_whitespace();
+        }
+
+        // Parse optional ORDER BY
+        if self.try_consume_keyword("order") {
+            self.skip_whitespace();
+            if !self.try_consume_keyword("by") {
+                return Err(DkitError::QueryError(format!(
+                    "expected 'by' after 'order' at position {}",
+                    self.pos
+                )));
+            }
+            self.skip_whitespace();
+            order_by = self.parse_window_order_by_list()?;
+            self.skip_whitespace();
+        }
+
+        if !self.consume_char(')') {
+            return Err(DkitError::QueryError(format!(
+                "expected ')' to close window spec at position {}",
+                self.pos
+            )));
+        }
+
+        Ok(WindowSpec {
+            partition_by,
+            order_by,
+        })
+    }
+
+    /// ORDER BY 절의 컬럼 목록 파싱: `field [ASC|DESC] (, field [ASC|DESC])*`
+    fn parse_window_order_by_list(&mut self) -> Result<Vec<WindowOrderBy>, DkitError> {
+        let mut items = Vec::new();
+        let field = self.parse_identifier()?;
+        self.skip_whitespace();
+        let descending = self.try_consume_keyword("desc");
+        if !descending {
+            self.try_consume_keyword("asc");
+        }
+        items.push(WindowOrderBy { field, descending });
+
+        loop {
+            self.skip_whitespace();
+            if self.consume_char(',') {
+                self.skip_whitespace();
+                let field = self.parse_identifier()?;
+                self.skip_whitespace();
+                let descending = self.try_consume_keyword("desc");
+                if !descending {
+                    self.try_consume_keyword("asc");
+                }
+                items.push(WindowOrderBy { field, descending });
+            } else {
+                break;
+            }
+        }
+
+        Ok(items)
     }
 
     /// `if(condition, then_expr, else_expr)` 파싱
@@ -3003,6 +3265,206 @@ mod tests {
             assert!(matches!(aggregates[2].func, AggregateFunc::Stddev));
         } else {
             panic!("expected GroupBy operation");
+        }
+    }
+
+    // --- 윈도우 함수 파싱 테스트 ---
+
+    #[test]
+    fn test_parse_row_number_over() {
+        let q =
+            parse_query(".[] | select row_number() over (order by score desc) as rank").unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            assert_eq!(exprs.len(), 1);
+            assert_eq!(exprs[0].alias, Some("rank".to_string()));
+            if let Expr::Window { func, over } = &exprs[0].expr {
+                assert!(matches!(func, WindowFunc::RowNumber));
+                assert!(over.partition_by.is_empty());
+                assert_eq!(over.order_by.len(), 1);
+                assert_eq!(over.order_by[0].field, "score");
+                assert!(over.order_by[0].descending);
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_rank_with_partition() {
+        let q = parse_query(
+            ".[] | select name, rank() over (partition by dept order by score desc) as dept_rank",
+        )
+        .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            assert_eq!(exprs.len(), 2);
+            if let Expr::Window { func, over } = &exprs[1].expr {
+                assert!(matches!(func, WindowFunc::Rank));
+                assert_eq!(over.partition_by, vec!["dept"]);
+                assert_eq!(over.order_by[0].field, "score");
+                assert!(over.order_by[0].descending);
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_dense_rank() {
+        let q = parse_query(".[] | select dense_rank() over (order by score) as drank").unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { func, over } = &exprs[0].expr {
+                assert!(matches!(func, WindowFunc::DenseRank));
+                assert!(!over.order_by[0].descending);
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_lag_default_offset() {
+        let q = parse_query(".[] | select lag(value) over (order by date) as prev_value").unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { func, .. } = &exprs[0].expr {
+                if let WindowFunc::Lag { expr, offset } = func {
+                    assert!(matches!(expr.as_ref(), Expr::Field(f) if f == "value"));
+                    assert_eq!(*offset, 1);
+                } else {
+                    panic!("expected Lag");
+                }
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_lead_with_offset() {
+        let q =
+            parse_query(".[] | select lead(value, 2) over (order by date) as next2_value").unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { func, .. } = &exprs[0].expr {
+                if let WindowFunc::Lead { offset, .. } = func {
+                    assert_eq!(*offset, 2);
+                } else {
+                    panic!("expected Lead");
+                }
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_first_value() {
+        let q =
+            parse_query(".[] | select first_value(name) over (order by score desc) as top_name")
+                .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { func, .. } = &exprs[0].expr {
+                assert!(matches!(func, WindowFunc::FirstValue { .. }));
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_last_value() {
+        let q = parse_query(".[] | select last_value(name) over (order by score) as last_name")
+            .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { func, .. } = &exprs[0].expr {
+                assert!(matches!(func, WindowFunc::LastValue { .. }));
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_window_aggregate_sum() {
+        let q =
+            parse_query(".[] | select sum(amount) over (order by date) as running_total").unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { func, .. } = &exprs[0].expr {
+                assert!(matches!(
+                    func,
+                    WindowFunc::Aggregate {
+                        func: AggregateFunc::Sum,
+                        ..
+                    }
+                ));
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_window_empty_over() {
+        let q = parse_query(".[] | select row_number() over () as rn").unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { func, over } = &exprs[0].expr {
+                assert!(matches!(func, WindowFunc::RowNumber));
+                assert!(over.partition_by.is_empty());
+                assert!(over.order_by.is_empty());
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_window_partition_only() {
+        let q = parse_query(".[] | select count(score) over (partition by dept) as dept_count")
+            .unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { over, .. } = &exprs[0].expr {
+                assert_eq!(over.partition_by, vec!["dept"]);
+                assert!(over.order_by.is_empty());
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
+        }
+    }
+
+    #[test]
+    fn test_parse_window_multiple_order_by() {
+        let q =
+            parse_query(".[] | select rank() over (order by dept asc, score desc) as r").unwrap();
+        if let Operation::Select(exprs) = &q.operations[0] {
+            if let Expr::Window { over, .. } = &exprs[0].expr {
+                assert_eq!(over.order_by.len(), 2);
+                assert_eq!(over.order_by[0].field, "dept");
+                assert!(!over.order_by[0].descending);
+                assert_eq!(over.order_by[1].field, "score");
+                assert!(over.order_by[1].descending);
+            } else {
+                panic!("expected Window expression");
+            }
+        } else {
+            panic!("expected Select operation");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add window function support to the query engine with `OVER (PARTITION BY ... ORDER BY ...)` clause
- Supported functions: `row_number()`, `rank()`, `dense_rank()`, `lag()`, `lead()`, `first_value()`, `last_value()`, and aggregate window functions (`sum/avg/count/min/max(...) OVER (...)`)
- Add 22 new unit tests covering parsing and evaluation of all window functions

## Test plan
- [x] `cargo test` — 751 tests pass (22 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

Closes #219

https://claude.ai/code/session_011nDcunF9nhRzu65wUeCGMu