### PR TITLE
chore: v1.5.0 릴리스 준비

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-03-27
+
+### Added
+
+- **`--template` flag for custom text output**: Tera-based template rendering for `convert` subcommand — `dkit convert data.json -f template --template '{{name}} <{{email}}>'`. Supports inline templates (`--template`), file-based templates (`--template-file`), and built-in helpers (`upper`, `lower`, `default`). Feature flag: `template`. (#217)
+- **`join` subcommand**: Cross-file key-based data joining — `dkit join users.json orders.json --on user_id -f table`. Supports `inner`, `left`, `right`, and `full` join types with `--on key` or `--on left_key=right_key` syntax. Works across different data formats. (#218)
+- **Window functions in query**: `row_number()`, `rank()`, `dense_rank()`, `lag()`, `lead()`, `first_value()`, `last_value()`, and window aggregates (`sum/avg/count/min/max(...) OVER (...)`) with `PARTITION BY` and `ORDER BY` support. (#219)
+- **`profile` subcommand**: Data profiling and quality analysis — `dkit profile data.csv`. Shows field types, null ratios, unique counts, top values, numeric statistics, string length analysis, and pattern detection. Supports `--output-format json` and `--detailed` mode. (#220)
+
+### Testing & Docs
+
+- **Comprehensive v1.5.0 integration tests**: End-to-end tests for `--template`, `join`, window functions, and `profile`. README and docs updated. (#221)
+
 ## [1.4.0] - 2026-03-27
 
 ### Added
@@ -205,7 +218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI pipeline**: GitHub Actions workflow with test (Linux/macOS/Windows), clippy, and rustfmt checks.
 - **Test suite**: Integration tests covering all conversion paths, query operations, table view, fixture data, edge cases (unicode, empty input, quoted CSV fields).
 
-[Unreleased]: https://github.com/syangkkim/dkit/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/syangkkim/dkit/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/syangkkim/dkit/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/syangkkim/dkit/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/syangkkim/dkit/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/syangkkim/dkit/compare/v1.1.0...v1.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "dkit"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "dkit-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkit"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "A unified CLI to convert, query, and explore data across formats"
@@ -31,7 +31,7 @@ template = ["dkit-core/template"]
 all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist", "template"]
 
 [dependencies]
-dkit-core = { version = "1.4.0", path = "../dkit-core" }
+dkit-core = { version = "1.5.0", path = "../dkit-core" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 serde = { version = "1", features = ["derive"] }

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkit-core"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "Core library for dkit — data format conversion and querying engine"


### PR DESCRIPTION
## Summary
- `Cargo.toml` 버전 범프: `1.4.0` → `1.5.0` (dkit-core, dkit-cli)
- CHANGELOG.md에 v1.5.0 릴리스 노트 추가 (template, join, window functions, profile)
- `cargo fmt`, `cargo clippy`, `cargo test` 전체 통과 확인

## Test plan
- [x] `cargo fmt -- --check` 통과
- [x] `cargo clippy --all-features -- -D warnings` 통과
- [x] `cargo test --all-features` 전체 통과 (0 failed)
- [x] feature flag 확인 (template, join 등 `all` feature에 포함)

Closes #222

https://claude.ai/code/session_01AoY3eddUQpcvo7ubs2uent