### PR TITLE
chore: update all URLs for repo migration to syang0531

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,4 +37,4 @@ jobs:
           alert-threshold: "150%"
           comment-on-alert: true
           fail-on-alert: false
-          alert-comment-cc-users: "@syangkkim"
+          alert-comment-cc-users: "@syang0531"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,19 +218,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI pipeline**: GitHub Actions workflow with test (Linux/macOS/Windows), clippy, and rustfmt checks.
 - **Test suite**: Integration tests covering all conversion paths, query operations, table view, fixture data, edge cases (unicode, empty input, quoted CSV fields).
 
-[Unreleased]: https://github.com/syangkkim/dkit/compare/v1.5.0...HEAD
-[1.5.0]: https://github.com/syangkkim/dkit/compare/v1.4.0...v1.5.0
-[1.4.0]: https://github.com/syangkkim/dkit/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/syangkkim/dkit/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/syangkkim/dkit/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/syangkkim/dkit/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/syangkkim/dkit/compare/v0.9.0...v1.0.0
-[0.9.0]: https://github.com/syangkkim/dkit/releases/tag/v0.9.0
-[0.8.0]: https://github.com/syangkkim/dkit/releases/tag/v0.8.0
-[0.7.0]: https://github.com/syangkkim/dkit/releases/tag/v0.7.0
-[0.6.0]: https://github.com/syangkkim/dkit/releases/tag/v0.6.0
-[0.5.0]: https://github.com/syangkkim/dkit/releases/tag/v0.5.0
-[0.4.0]: https://github.com/syangkkim/dkit/releases/tag/v0.4.0
-[0.3.0]: https://github.com/syangkkim/dkit/releases/tag/v0.3.0
-[0.2.0]: https://github.com/syangkkim/dkit/releases/tag/v0.2.0
-[0.1.0]: https://github.com/syangkkim/dkit/releases/tag/v0.1.0
+[Unreleased]: https://github.com/syang0531/dkit/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/syang0531/dkit/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/syang0531/dkit/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/syang0531/dkit/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/syang0531/dkit/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/syang0531/dkit/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/syang0531/dkit/compare/v0.9.0...v1.0.0
+[0.9.0]: https://github.com/syang0531/dkit/releases/tag/v0.9.0
+[0.8.0]: https://github.com/syang0531/dkit/releases/tag/v0.8.0
+[0.7.0]: https://github.com/syang0531/dkit/releases/tag/v0.7.0
+[0.6.0]: https://github.com/syang0531/dkit/releases/tag/v0.6.0
+[0.5.0]: https://github.com/syang0531/dkit/releases/tag/v0.5.0
+[0.4.0]: https://github.com/syang0531/dkit/releases/tag/v0.4.0
+[0.3.0]: https://github.com/syang0531/dkit/releases/tag/v0.3.0
+[0.2.0]: https://github.com/syang0531/dkit/releases/tag/v0.2.0
+[0.1.0]: https://github.com/syang0531/dkit/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ JSON, CSV, YAML, TOML 간 양방향 변환 + 통합 쿼리 + 테이블 출력.
 모든 기획, 계획, 진행, 상태 관리는 **GitHub Issues**에서 관리한다.
 저장소 내부 문서로 태스크를 관리하지 않는다.
 
-- **Issues**: https://github.com/syangkkim/dkit/issues
+- **Issues**: https://github.com/syang0531/dkit/issues
 
 ### How to Work on Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to dkit! This guide will help you ge
 ### Setting Up the Development Environment
 
 ```bash
-git clone https://github.com/syangkkim/dkit.git
+git clone https://github.com/syang0531/dkit.git
 cd dkit
 cargo build
 cargo test
@@ -46,7 +46,7 @@ See [docs/architecture.md](docs/architecture.md) for a detailed overview.
 
 ### 1. Find or Create an Issue
 
-- Check [open issues](https://github.com/syangkkim/dkit/issues) for tasks to work on.
+- Check [open issues](https://github.com/syang0531/dkit/issues) for tasks to work on.
 - For new features or bugs, open an issue first to discuss the approach.
 
 ### 2. Create a Branch
@@ -143,4 +143,4 @@ Benchmark results are saved to `target/criterion/` with HTML reports.
 
 ## Questions?
 
-Open an issue on [GitHub](https://github.com/syangkkim/dkit/issues) for any questions about contributing.
+Open an issue on [GitHub](https://github.com/syang0531/dkit/issues) for any questions about contributing.

--- a/Formula/dkit.rb
+++ b/Formula/dkit.rb
@@ -1,24 +1,24 @@
 class Dkit < Formula
   desc "Swiss army knife for data format conversion and querying"
-  homepage "https://github.com/syangkkim/dkit"
+  homepage "https://github.com/syang0531/dkit"
   license "MIT"
   version "0.9.0"
 
   on_macos do
     on_intel do
-      url "https://github.com/syangkkim/dkit/releases/download/v#{version}/dkit-v#{version}-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/syang0531/dkit/releases/download/v#{version}/dkit-v#{version}-x86_64-apple-darwin.tar.gz"
       # sha256 will be updated on release
     end
 
     on_arm do
-      url "https://github.com/syangkkim/dkit/releases/download/v#{version}/dkit-v#{version}-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/syang0531/dkit/releases/download/v#{version}/dkit-v#{version}-aarch64-apple-darwin.tar.gz"
       # sha256 will be updated on release
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/syangkkim/dkit/releases/download/v#{version}/dkit-v#{version}-x86_64-unknown-linux-musl.tar.gz"
+      url "https://github.com/syang0531/dkit/releases/download/v#{version}/dkit-v#{version}-x86_64-unknown-linux-musl.tar.gz"
       # sha256 will be updated on release
     end
   end

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 syangkkim
+Copyright (c) 2026 syang0531
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ cargo install dkit
 ### From source
 
 ```bash
-git clone https://github.com/syangkkim/dkit.git
+git clone https://github.com/syang0531/dkit.git
 cd dkit
 cargo install --path dkit-cli
 ```
 
 ### Pre-built binaries
 
-Download from [GitHub Releases](https://github.com/syangkkim/dkit/releases).
+Download from [GitHub Releases](https://github.com/syang0531/dkit/releases).
 
 ### With cargo-binstall
 

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 rust-version = "1.75.0"
 description = "A unified CLI to convert, query, and explore data across formats"
 license = "MIT"
-repository = "https://github.com/syangkkim/dkit"
-homepage = "https://github.com/syangkkim/dkit"
+repository = "https://github.com/syang0531/dkit"
+homepage = "https://github.com/syang0531/dkit"
 keywords = ["cli", "data-format", "converter", "query", "json"]
 categories = ["command-line-utilities", "encoding"]
 

--- a/dkit-cli/README.md
+++ b/dkit-cli/README.md
@@ -26,11 +26,11 @@ cargo install dkit
 cargo binstall dkit
 
 # From source
-git clone https://github.com/syangkkim/dkit.git
+git clone https://github.com/syang0531/dkit.git
 cd dkit && cargo install --path dkit-cli
 ```
 
-Pre-built binaries are available on [GitHub Releases](https://github.com/syangkkim/dkit/releases).
+Pre-built binaries are available on [GitHub Releases](https://github.com/syang0531/dkit/releases).
 
 ## Quick Start
 
@@ -70,8 +70,8 @@ dkit diff config_dev.yaml config_prod.yaml
 
 ## Documentation
 
-See the [full README](https://github.com/syangkkim/dkit) for detailed usage, query syntax, and more.
+See the [full README](https://github.com/syang0531/dkit) for detailed usage, query syntax, and more.
 
 ## License
 
-[MIT](https://github.com/syangkkim/dkit/blob/main/LICENSE)
+[MIT](https://github.com/syang0531/dkit/blob/main/LICENSE)

--- a/dkit-cli/src/config.rs
+++ b/dkit-cli/src/config.rs
@@ -149,7 +149,7 @@ pub fn load_config() -> ConfigSource {
 /// Generate a default config file content.
 pub fn default_config_content() -> String {
     r#"# dkit configuration file
-# See: https://github.com/syangkkim/dkit
+# See: https://github.com/syang0531/dkit
 
 # Default output format (json, csv, yaml, toml, xml, md, html, table)
 # default_format = "json"

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 rust-version = "1.75.0"
 description = "Core library for dkit — data format conversion and querying engine"
 license = "MIT"
-repository = "https://github.com/syangkkim/dkit"
-homepage = "https://github.com/syangkkim/dkit"
+repository = "https://github.com/syang0531/dkit"
+homepage = "https://github.com/syang0531/dkit"
 keywords = ["data-format", "converter", "query", "serialization", "json"]
 categories = ["encoding", "parser-implementations"]
 

--- a/dkit-core/README.md
+++ b/dkit-core/README.md
@@ -57,10 +57,10 @@ CsvFormat::write(&mut output, &value, &Default::default())?;
 
 ## Documentation
 
-- [API Reference](https://github.com/syangkkim/dkit/blob/main/docs/api-reference.md)
-- [Technical Spec](https://github.com/syangkkim/dkit/blob/main/docs/technical-spec.md)
-- [Query Syntax](https://github.com/syangkkim/dkit/blob/main/docs/query-syntax.md)
+- [API Reference](https://github.com/syang0531/dkit/blob/main/docs/api-reference.md)
+- [Technical Spec](https://github.com/syang0531/dkit/blob/main/docs/technical-spec.md)
+- [Query Syntax](https://github.com/syang0531/dkit/blob/main/docs/query-syntax.md)
 
 ## License
 
-[MIT](https://github.com/syangkkim/dkit/blob/main/LICENSE)
+[MIT](https://github.com/syang0531/dkit/blob/main/LICENSE)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # dkit Roadmap
 
-> v0.4.0 ~ v1.0.0 로드맵. 세부 이슈는 [GitHub Issues](https://github.com/syangkkim/dkit/issues)에서 관리.
+> v0.4.0 ~ v1.0.0 로드맵. 세부 이슈는 [GitHub Issues](https://github.com/syang0531/dkit/issues)에서 관리.
 
 ## 버전 요약
 

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # dkit installer script
-# Usage: curl -sSL https://raw.githubusercontent.com/syangkkim/dkit/main/install.sh | sh
+# Usage: curl -sSL https://raw.githubusercontent.com/syang0531/dkit/main/install.sh | sh
 
 set -eu
 
-REPO="syangkkim/dkit"
+REPO="syang0531/dkit"
 BINARY_NAME="dkit"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 


### PR DESCRIPTION
## Summary
- 저장소를 `syangkkim/dkit` → `syang0531/dkit`로 이전함에 따라 모든 URL 참조를 갱신
- Cargo.toml 메타데이터, README, CHANGELOG, CI 워크플로우, Homebrew Formula, install script 등 14개 파일 반영

## Changed files
- `dkit-cli/Cargo.toml`, `dkit-core/Cargo.toml` — repository, homepage
- `README.md`, `dkit-cli/README.md`, `dkit-core/README.md` — clone/release/docs 링크
- `CONTRIBUTING.md` — clone URL, issues 링크
- `CHANGELOG.md` — 비교/릴리스 링크 16개
- `CLAUDE.md`, `docs/roadmap.md` — issues 링크
- `.github/workflows/benchmark.yml` — alert CC 유저
- `install.sh` — REPO 변수, raw URL
- `Formula/dkit.rb` — homepage, download URL
- `dkit-cli/src/config.rs` — 주석 내 URL
- `LICENSE` — copyright holder

## Test plan
- [x] `grep -r syangkkim .` 결과 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)