### PR TITLE
chore: bump version to v1.5.1 for repo migration release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-04-10
+
+### Changed
+
+- **Repository migration**: All URLs updated from `syangkkim/dkit` to `syang0531/dkit` — Cargo.toml metadata, README, CHANGELOG, CI workflows, Homebrew Formula, install script, and documentation links.
+
 ## [1.5.0] - 2026-03-27
 
 ### Added
@@ -218,19 +224,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI pipeline**: GitHub Actions workflow with test (Linux/macOS/Windows), clippy, and rustfmt checks.
 - **Test suite**: Integration tests covering all conversion paths, query operations, table view, fixture data, edge cases (unicode, empty input, quoted CSV fields).
 
-[Unreleased]: https://github.com/syangkkim/dkit/compare/v1.5.0...HEAD
-[1.5.0]: https://github.com/syangkkim/dkit/compare/v1.4.0...v1.5.0
-[1.4.0]: https://github.com/syangkkim/dkit/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/syangkkim/dkit/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/syangkkim/dkit/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/syangkkim/dkit/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/syangkkim/dkit/compare/v0.9.0...v1.0.0
-[0.9.0]: https://github.com/syangkkim/dkit/releases/tag/v0.9.0
-[0.8.0]: https://github.com/syangkkim/dkit/releases/tag/v0.8.0
-[0.7.0]: https://github.com/syangkkim/dkit/releases/tag/v0.7.0
-[0.6.0]: https://github.com/syangkkim/dkit/releases/tag/v0.6.0
-[0.5.0]: https://github.com/syangkkim/dkit/releases/tag/v0.5.0
-[0.4.0]: https://github.com/syangkkim/dkit/releases/tag/v0.4.0
-[0.3.0]: https://github.com/syangkkim/dkit/releases/tag/v0.3.0
-[0.2.0]: https://github.com/syangkkim/dkit/releases/tag/v0.2.0
-[0.1.0]: https://github.com/syangkkim/dkit/releases/tag/v0.1.0
+[Unreleased]: https://github.com/syang0531/dkit/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/syang0531/dkit/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/syang0531/dkit/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/syang0531/dkit/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/syang0531/dkit/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/syang0531/dkit/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/syang0531/dkit/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/syang0531/dkit/compare/v0.9.0...v1.0.0
+[0.9.0]: https://github.com/syang0531/dkit/releases/tag/v0.9.0
+[0.8.0]: https://github.com/syang0531/dkit/releases/tag/v0.8.0
+[0.7.0]: https://github.com/syang0531/dkit/releases/tag/v0.7.0
+[0.6.0]: https://github.com/syang0531/dkit/releases/tag/v0.6.0
+[0.5.0]: https://github.com/syang0531/dkit/releases/tag/v0.5.0
+[0.4.0]: https://github.com/syang0531/dkit/releases/tag/v0.4.0
+[0.3.0]: https://github.com/syang0531/dkit/releases/tag/v0.3.0
+[0.2.0]: https://github.com/syang0531/dkit/releases/tag/v0.2.0
+[0.1.0]: https://github.com/syang0531/dkit/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "dkit"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "dkit-core"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "arrow",

--- a/dkit-cli/Cargo.toml
+++ b/dkit-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkit"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "A unified CLI to convert, query, and explore data across formats"
@@ -31,7 +31,7 @@ template = ["dkit-core/template"]
 all = ["xml", "msgpack", "excel", "sqlite", "parquet", "hcl", "plist", "template"]
 
 [dependencies]
-dkit-core = { version = "1.5.0", path = "../dkit-core" }
+dkit-core = { version = "1.5.1", path = "../dkit-core" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 serde = { version = "1", features = ["derive"] }

--- a/dkit-core/Cargo.toml
+++ b/dkit-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkit-core"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "Core library for dkit — data format conversion and querying engine"


### PR DESCRIPTION
## Summary
- `dkit-core`, `dkit-cli` 버전을 `1.5.0` → `1.5.1`로 bump
- CHANGELOG에 `[1.5.1] - 2026-04-10` 섹션 추가 (저장소 URL 마이그레이션 내역)
- `Cargo.lock` 자동 갱신

> **Note**: PR #269 (URL 마이그레이션)이 먼저 merge된 후 이 PR을 merge해야 합니다.

## Test plan
- [x] `cargo build` 성공 확인
- [ ] `cargo test` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)